### PR TITLE
Assert fail

### DIFF
--- a/src/main/java/org/junit/contrib/truth/AbstractVerb.java
+++ b/src/main/java/org/junit/contrib/truth/AbstractVerb.java
@@ -15,6 +15,20 @@ public class AbstractVerb {
   protected FailureStrategy getFailureStrategy() {
     return failureStrategy;
   }
+  
+	/**
+	 * Triggers the failure strategy with an empty failure message
+	 */
+	public void fail() {
+		failureStrategy.fail("");
+	}
+
+	/**
+	 * Triggers the failure strategy with the given failure message
+	 */
+	public void fail(String message) {
+		failureStrategy.fail(message);
+	}
 
   /**
    * The recommended method of extension of Truth to new types, which is 

--- a/src/test/java/org/junit/contrib/truth/AbstractVerbTest.java
+++ b/src/test/java/org/junit/contrib/truth/AbstractVerbTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2011 David Saff
+ * Copyright (c) 2011 Christian Gruber
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.junit.contrib.truth;
+
+import static org.junit.contrib.truth.Truth.ASSERT;
+
+import org.junit.Test;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests for Boolean Subjects.
+ * 
+ * @author Christian Gruber (cgruber@israfil.net)
+ */
+@RunWith(Theories.class)
+public class AbstractVerbTest {
+	private String failureMessage = null;
+	
+	private AbstractVerb captureFailure = new AbstractVerb(new FailureStrategy() {		
+		@Override
+		public void fail(String message) {
+			failureMessage = message;
+		}
+	});
+	
+	@DataPoints public static String[] strings = new String[] {"a", "b"};
+	
+	@Test public void noArgFail() {
+		captureFailure.fail();
+		ASSERT.that(failureMessage).is("");
+	}
+	
+	@Theory public void argFail(String message) {
+		captureFailure.fail(message);
+		ASSERT.that(failureMessage).is(message);
+	}
+}


### PR DESCRIPTION
This should be uncontroversial, and is on a different, parallel branch from the other, controversial branch.

Sometimes it's useful to be able to say ASSERT.fail("I lose").
