### PR TITLE
Remove and() from the API.

### DIFF
--- a/core/src/main/java/org/truth0/codegen/IteratingWrapperClassBuilder.java
+++ b/core/src/main/java/org/truth0/codegen/IteratingWrapperClassBuilder.java
@@ -83,7 +83,6 @@ public class IteratingWrapperClassBuilder {
       "      %6$s subject = (%6$s)subjectFactory.getSubject(failureStrategy, item);%n" +
       "      subject.%3$s(%7$s);%n" +
       "    }%n" +
-      "    return nextChain();%n" +
       "  }%n";
 
 

--- a/core/src/main/java/org/truth0/gwtemul/org/truth0/subjects/Subject.java
+++ b/core/src/main/java/org/truth0/gwtemul/org/truth0/subjects/Subject.java
@@ -29,29 +29,13 @@ import org.truth0.TestVerb;
 public class Subject<S extends Subject<S,T>,T> {
   protected final FailureStrategy failureStrategy;
   private final T subject;
-  private final And<S> chain;
 
   public Subject(FailureStrategy failureStrategy, T subject) {
     this.failureStrategy = failureStrategy;
     this.subject = subject;
-
-    this.chain = new And<S>(){
-      @SuppressWarnings("unchecked")
-      @Override public S and() {
-        return (S)Subject.this;
-      }
-    };
   }
 
-  /**
-   * A method which wraps the current Subject concrete
-   * subtype in a chaining "And" object.
-   */
-  protected final And<S> nextChain() {
-    return chain;
-  }
-
-  public And<S> is(T other) {
+  public void is(T other) {
 
     if (getSubject() == null) {
       if(other != null) {
@@ -62,24 +46,21 @@ public class Subject<S extends Subject<S,T>,T> {
         fail("is", other);
       }
     }
-    return nextChain();
   }
 
-  public And<S> isNull() {
+  public void isNull() {
     if (getSubject() != null) {
       failWithoutSubject("is null");
     }
-    return nextChain();
   }
 
-  public And<S> isNotNull() {
+  public void isNotNull() {
     if (getSubject() == null) {
       failWithoutSubject("is not null");
     }
-    return nextChain();
   }
 
-  public And<S> isEqualTo(Object other) {
+  public void isEqualTo(Object other) {
     if (getSubject() == null) {
       if(other != null) {
         fail("is equal to", other);
@@ -89,10 +70,9 @@ public class Subject<S extends Subject<S,T>,T> {
         fail("is equal to", other);
       }
     }
-    return nextChain();
   }
 
-  public And<S> isNotEqualTo(Object other) {
+  public void isNotEqualTo(Object other) {
     if (getSubject() == null) {
       if(other == null) {
         fail("is not equal to", (Object)null);
@@ -102,7 +82,6 @@ public class Subject<S extends Subject<S,T>,T> {
         fail("is not equal to", other);
       }
     }
-    return nextChain();
   }
 
   protected T getSubject() {
@@ -133,15 +112,4 @@ public class Subject<S extends Subject<S,T>,T> {
     failureStrategy.fail(message.toString());
   }
 
-  /**
-   * A convenience class to allow for chaining in the fluent API
-   * style, such that subjects can make propositions in series.
-   * i.e. ASSERT.that(blah).isNotNull().and().contains(b).and().isNotEmpty();
-   */
-  public static interface And<C> {
-    /**
-     * Returns the next object in the chain of anded objects.
-     */
-    C and();
-  }
 }

--- a/core/src/main/java/org/truth0/subjects/CollectionSubject.java
+++ b/core/src/main/java/org/truth0/subjects/CollectionSubject.java
@@ -46,36 +46,33 @@ public class CollectionSubject<S extends CollectionSubject<S, T, C>, T, C extend
   /**
    * Attests that a Collection contains the provided object or fails.
    */
-  @Override public And<S> contains(Object item) {
+  @Override public void contains(Object item) {
     if (!getSubject().contains(item)) {
       fail("contains", item);
     }
-    return nextChain();
   }
 
   /**
    * Attests that a Collection is empty or fails.
    */
-  @Override public And<S> isEmpty() {
+  @Override public void isEmpty() {
     if (!getSubject().isEmpty()) {
       fail("is empty");
     }
-    return nextChain();
   }
 
   /**
    * Attests that a Collection contains at least one of the provided
    * objects or fails.
    */
-  public And<S> containsAnyOf(Object first, Object second, Object ... rest) {
+  public void containsAnyOf(Object first, Object second, Object ... rest) {
     Collection<?> collection = getSubject();
     for (Object item : accumulate(first, second, rest)) {
       if (collection.contains(item)) {
-        return nextChain();
+        return;
       }
     }
     fail("contains", accumulate(first, second, rest));
-    return nextChain();
   }
 
 
@@ -104,7 +101,7 @@ public class CollectionSubject<S extends CollectionSubject<S, T, C>, T, C extend
 
     final List<?> expectedItems = accumulate(first, second, rest);
     return new Ordered<S>() {
-      @Override public And<S> inOrder() {
+      @Override public void inOrder() {
         Iterator<T> actualItems = getSubject().iterator();
         for (Object expected : expectedItems) {
           if (!actualItems.hasNext()) {
@@ -121,10 +118,6 @@ public class CollectionSubject<S extends CollectionSubject<S, T, C>, T, C extend
         if (actualItems.hasNext()) {
           fail("iterates through", expectedItems);
         }
-        return nextChain();
-      }
-      @Override public S and() {
-        return nextChain().and();
       }
     };
   }

--- a/core/src/main/java/org/truth0/subjects/IntegerSubject.java
+++ b/core/src/main/java/org/truth0/subjects/IntegerSubject.java
@@ -45,12 +45,11 @@ public class IntegerSubject extends Subject<IntegerSubject, Long> {
    * @throws IllegalArgumentException
    *           if the lower bound is greater than the upper.
    */
-  public And<IntegerSubject> isInclusivelyInRange(long lower, long upper) {
+  public void isInclusivelyInRange(long lower, long upper) {
     ensureOrderedBoundaries(lower, upper);
     if (!(lower <= getSubject() && getSubject() <= upper)) {
       fail("is inclusively in range", lower, upper);
     }
-    return nextChain();
   }
 
   /**
@@ -60,12 +59,11 @@ public class IntegerSubject extends Subject<IntegerSubject, Long> {
    * @throws IllegalArgumentException
    *           if the lower bound is greater than the upper.
    */
-  public And<IntegerSubject> isBetween(long lower, long upper) {
+  public void isBetween(long lower, long upper) {
     ensureOrderedBoundaries(lower, upper);
     if (!(lower < getSubject() && getSubject() < upper)) {
       fail("is in between", lower, upper);
     }
-    return nextChain();
   }
 
   /**
@@ -80,11 +78,11 @@ public class IntegerSubject extends Subject<IntegerSubject, Long> {
     }
   }
 
-  public And<IntegerSubject> isEqualTo(Integer other) {
-    return isEqualTo((other == null) ? null : Long.valueOf(other.longValue()));
+  public void isEqualTo(Integer other) {
+    isEqualTo((other == null) ? null : Long.valueOf(other.longValue()));
   }
 
-  public And<IntegerSubject> isEqualTo(Long other) {
+  public void isEqualTo(Long other) {
     if (getSubject() == null) {
       if(other != null) {
         fail("is equal to", other);
@@ -94,14 +92,13 @@ public class IntegerSubject extends Subject<IntegerSubject, Long> {
         fail("is equal to", other);
       }
     }
-    return nextChain();
   }
 
-  public And<IntegerSubject> isNotEqualTo(Integer other) {
-    return isNotEqualTo((other == null) ? null : Long.valueOf(other.longValue()));
+  public void isNotEqualTo(Integer other) {
+    isNotEqualTo((other == null) ? null : Long.valueOf(other.longValue()));
   }
 
-  public And<IntegerSubject> isNotEqualTo(Long other) {
+  public void isNotEqualTo(Long other) {
     if (getSubject() == null) {
       if(other == null) {
         fail("is not equal to", (Object)null);
@@ -111,19 +108,18 @@ public class IntegerSubject extends Subject<IntegerSubject, Long> {
         fail("is not equal to", other);
       }
     }
-    return nextChain();
   }
 
-  public And<IntegerSubject> is(int other) {
-    return super.is((long)other);
+  public void is(int other) {
+    super.is((long)other);
   }
 
-  public And<IntegerSubject> is(short other) {
-    return super.is((long)other);
+  public void is(short other) {
+    super.is((long)other);
   }
 
-  public And<IntegerSubject> is(byte other) {
-    return super.is((long)other);
+  public void is(byte other) {
+    super.is((long)other);
   }
 
 

--- a/core/src/main/java/org/truth0/subjects/IterableSubject.java
+++ b/core/src/main/java/org/truth0/subjects/IterableSubject.java
@@ -43,10 +43,10 @@ public class IterableSubject<S extends IterableSubject<S, T, C>, T, C extends It
    * @deprecated - please pass your iterable into a collection first.
    */
   @Deprecated
-  public And<S> contains(Object item) {
+  public void contains(Object item) {
     for (Object t : getSubject()) {
       if (item == t || item != null && item.equals(t)) {
-        return nextChain();
+        return;
       }
     }
     fail("contains", item);
@@ -56,21 +56,19 @@ public class IterableSubject<S extends IterableSubject<S, T, C>, T, C extends It
   /**
    * Attests that the subject holds no more objects, or fails.
    */
-  public And<S> isEmpty() {
+  public void isEmpty() {
     if (getSubject().iterator().hasNext()) {
       fail("is empty");
     }
-    return nextChain();
   }
 
   /**
    * Attests that the subject holds one or more objects, or fails
    */
-  public And<S> isNotEmpty() {
+  public void isNotEmpty() {
     if (!getSubject().iterator().hasNext()) {
       fail("is not empty");
     }
-    return nextChain();
   }
 
   /**
@@ -78,7 +76,7 @@ public class IterableSubject<S extends IterableSubject<S, T, C>, T, C extends It
    * Collections and other things which contain items but may not have guaranteed
    * iteration order, this method should be overridden.
    */
-  public And<S> iteratesOverSequence(Object... expectedItems) {
+  public void iteratesOverSequence(Object... expectedItems) {
     Iterator<T> actualItems = getSubject().iterator();
     for (Object expected : expectedItems) {
       if (!actualItems.hasNext()) {
@@ -95,6 +93,5 @@ public class IterableSubject<S extends IterableSubject<S, T, C>, T, C extends It
     if (actualItems.hasNext()) {
       fail("iterates through", Arrays.asList(expectedItems));
     }
-    return nextChain();
   }
 }

--- a/core/src/main/java/org/truth0/subjects/ListSubject.java
+++ b/core/src/main/java/org/truth0/subjects/ListSubject.java
@@ -39,9 +39,9 @@ public class ListSubject<S extends ListSubject<S, T, C>, T, C extends List<T>>
   /**
    * Attests that a List contains the specified sequence.
    */
-  public And<S> containsSequence(List<?> sequence) {
+  public void containsSequence(List<?> sequence) {
     if (sequence.isEmpty()) {
-      return nextChain();
+      return;
     }
     List<?> list = getSubject();
     while (true) {
@@ -54,12 +54,11 @@ public class ListSubject<S extends ListSubject<S, T, C>, T, C extends List<T>>
         break;    // Not enough room left
       }
       if (sequence.equals(list.subList(first, last))) {
-        return nextChain();
+        return;
       }
       list = list.subList(first + 1, list.size());
     }
     fail("contains sequence", sequence);
-    return nextChain();
   }
 
   /**
@@ -69,8 +68,8 @@ public class ListSubject<S extends ListSubject<S, T, C>, T, C extends List<T>>
    * @throws ClassCastException if any pair of elements is not mutually Comparable.
    * @throws NullPointerException if any element is null.
    */
-  public And<S> isOrdered() {
-    return pairwiseCheck(new PairwiseChecker<T>() {
+  public void isOrdered() {
+    pairwiseCheck(new PairwiseChecker<T>() {
       @SuppressWarnings("unchecked")
       @Override public void check(T prev, T next) {
         if (((Comparable<T>) prev).compareTo(next) >= 0) {
@@ -87,8 +86,8 @@ public class ListSubject<S extends ListSubject<S, T, C>, T, C extends List<T>>
    * @throws ClassCastException if any pair of elements is not mutually Comparable.
    * @throws NullPointerException if any element is null.
    */
-  public And<S> isPartiallyOrdered() {
-    return pairwiseCheck(new PairwiseChecker<T>() {
+  public void isPartiallyOrdered() {
+    pairwiseCheck(new PairwiseChecker<T>() {
       @SuppressWarnings("unchecked")
       @Override public void check(T prev, T next) {
         if (((Comparable<T>) prev).compareTo(next) > 0) {
@@ -105,8 +104,8 @@ public class ListSubject<S extends ListSubject<S, T, C>, T, C extends List<T>>
    * @throws ClassCastException if any pair of elements is not mutually Comparable.
    * @throws NullPointerException if any element is null.
    */
-  public And<S> isOrdered(final Comparator<T> comparator) {
-    return pairwiseCheck(new PairwiseChecker<T>() {
+  public void isOrdered(final Comparator<T> comparator) {
+    pairwiseCheck(new PairwiseChecker<T>() {
       @Override public void check(T prev, T next) {
         if (comparator.compare(prev, next) >= 0) {
           fail("is strictly ordered", prev, next);
@@ -122,8 +121,8 @@ public class ListSubject<S extends ListSubject<S, T, C>, T, C extends List<T>>
    * @throws ClassCastException if any pair of elements is not mutually Comparable.
    * @throws NullPointerException if any element is null.
    */
-  public And<S> isPartiallyOrdered(final Comparator<T> comparator) {
-    return pairwiseCheck(new PairwiseChecker<T>() {
+  public void isPartiallyOrdered(final Comparator<T> comparator) {
+    pairwiseCheck(new PairwiseChecker<T>() {
       @Override public void check(T prev, T next) {
         if (comparator.compare(prev, next) > 0) {
           fail("is partially ordered", prev, next);
@@ -132,7 +131,7 @@ public class ListSubject<S extends ListSubject<S, T, C>, T, C extends List<T>>
     });
   }
 
-  private And<S> pairwiseCheck(PairwiseChecker<T> checker) {
+  private void pairwiseCheck(PairwiseChecker<T> checker) {
     List<T> list = getSubject();
     if (list.size() > 1) {
       T prev = list.get(0);
@@ -142,7 +141,6 @@ public class ListSubject<S extends ListSubject<S, T, C>, T, C extends List<T>>
         prev = next;
       }
     }
-    return nextChain();
   }
 
   private interface PairwiseChecker<T> {

--- a/core/src/main/java/org/truth0/subjects/Ordered.java
+++ b/core/src/main/java/org/truth0/subjects/Ordered.java
@@ -1,15 +1,26 @@
+/*
+ * Copyright (c) 2011 Christian Gruber
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.truth0.subjects;
 
-import org.truth0.subjects.Subject.And;
-
-public interface Ordered<Q> extends And<Q> {
+public interface Ordered<Q> {
 
   /**
    * An additional assertion, implemented by some containment subjects
    * which allows for a further constraint of orderedness.
    */
-  And<Q> inOrder();
+  void inOrder();
 
 }
-
-

--- a/core/src/main/java/org/truth0/subjects/StringSubject.java
+++ b/core/src/main/java/org/truth0/subjects/StringSubject.java
@@ -32,7 +32,7 @@ public class StringSubject extends Subject<StringSubject, String> {
     super(failureStrategy, string);
   }
 
-  public And<StringSubject> contains(String string) {
+  public void contains(String string) {
     if (getSubject() == null) {
       if (string != null) {
         fail("contains", string);
@@ -40,10 +40,9 @@ public class StringSubject extends Subject<StringSubject, String> {
     } else if (!getSubject().contains(string)) {
       fail("contains", string);
     }
-    return nextChain();
   }
 
-  public And<StringSubject> startsWith(String string) {
+  public void startsWith(String string) {
     if (getSubject() == null) {
       if (string != null) {
         fail("starts with", string);
@@ -51,10 +50,9 @@ public class StringSubject extends Subject<StringSubject, String> {
     } else if (!getSubject().startsWith(string)) {
       fail("starts with", string);
     }
-    return nextChain();
   }
 
-  public And<StringSubject> endsWith(String string) {
+  public void endsWith(String string) {
     if (getSubject() == null) {
       if (string != null) {
         fail("ends with", string);
@@ -62,7 +60,6 @@ public class StringSubject extends Subject<StringSubject, String> {
     } else if (!getSubject().endsWith(string)) {
       fail("ends with", string);
     }
-    return nextChain();
   }
 
   public static final SubjectFactory<StringSubject, String> STRING =

--- a/core/src/main/java/org/truth0/subjects/Subject.java
+++ b/core/src/main/java/org/truth0/subjects/Subject.java
@@ -37,29 +37,13 @@ import com.google.common.annotations.GwtIncompatible;
 public class Subject<S extends Subject<S,T>,T> {
   protected final FailureStrategy failureStrategy;
   private final T subject;
-  private final And<S> chain;
 
   public Subject(FailureStrategy failureStrategy, T subject) {
     this.failureStrategy = failureStrategy;
     this.subject = subject;
-
-    this.chain = new And<S>(){
-      @SuppressWarnings("unchecked")
-      @Override public S and() {
-        return (S)Subject.this;
-      }
-    };
   }
 
-  /**
-   * A method which wraps the current Subject concrete
-   * subtype in a chaining "And" object.
-   */
-  protected final And<S> nextChain() {
-    return chain;
-  }
-
-  public And<S> is(T other) {
+  public void is(T other) {
 
     if (getSubject() == null) {
       if(other != null) {
@@ -70,24 +54,21 @@ public class Subject<S extends Subject<S,T>,T> {
         fail("is", other);
       }
     }
-    return nextChain();
   }
 
-  public And<S> isNull() {
+  public void isNull() {
     if (getSubject() != null) {
       failWithoutSubject("is null");
     }
-    return nextChain();
   }
 
-  public And<S> isNotNull() {
+  public void isNotNull() {
     if (getSubject() == null) {
       failWithoutSubject("is not null");
     }
-    return nextChain();
   }
 
-  public And<S> isEqualTo(Object other) {
+  public void isEqualTo(Object other) {
     if (getSubject() == null) {
       if(other != null) {
         fail("is equal to", other);
@@ -97,10 +78,9 @@ public class Subject<S extends Subject<S,T>,T> {
         fail("is equal to", other);
       }
     }
-    return nextChain();
   }
 
-  public And<S> isNotEqualTo(Object other) {
+  public void isNotEqualTo(Object other) {
     if (getSubject() == null) {
       if(other == null) {
         fail("is not equal to", (Object)null);
@@ -110,23 +90,20 @@ public class Subject<S extends Subject<S,T>,T> {
         fail("is not equal to", other);
       }
     }
-    return nextChain();
   }
 
   @GwtIncompatible("Class.isInstance")
-  public And<S> isA(Class<?> clazz) {
+  public void isA(Class<?> clazz) {
     if (!clazz.isInstance(getSubject())) {
       fail("is a", clazz.getName());
     }
-    return nextChain();
   }
 
   @GwtIncompatible("Class.isInstance")
-  public And<S> isNotA(Class<?> clazz) {
+  public void isNotA(Class<?> clazz) {
     if (clazz.isInstance(getSubject())) {
       fail("is not a", clazz.getName());
     }
-    return nextChain();
   }
 
   protected T getSubject() {
@@ -221,15 +198,4 @@ public class Subject<S extends Subject<S,T>,T> {
     void withValue(Object value);
   }
 
-  /**
-   * A convenience class to allow for chaining in the fluent API
-   * style, such that subjects can make propositions in series.
-   * i.e. ASSERT.that(blah).isNotNull().and().contains(b).and().isNotEmpty();
-   */
-  public static interface And<C> {
-    /**
-     * Returns the next object in the chain of anded objects.
-     */
-    C and();
-  }
 }

--- a/core/src/main/java/org/truth0/subjects/SubjectFactory.java
+++ b/core/src/main/java/org/truth0/subjects/SubjectFactory.java
@@ -36,8 +36,8 @@ public abstract class SubjectFactory<S extends Subject<S,T>, T> {
   private static final int SUBJECT_TYPE_PARAMETER = 0;
 
   @GwtIncompatible("reflection")
-  @SuppressWarnings("unchecked") // cast failure is a critical error
-  private final Class<S> type = (Class<S>)ReflectionUtil.typeParameter(getClass(), SUBJECT_TYPE_PARAMETER);
+  private final Class<S> type =
+      (Class<S>)ReflectionUtil.typeParameter(getClass(), SUBJECT_TYPE_PARAMETER);
 
   public SubjectFactory() {}
 

--- a/core/src/test/java/org/truth0/ExampleTest.java
+++ b/core/src/test/java/org/truth0/ExampleTest.java
@@ -41,10 +41,6 @@ public class ExampleTest {
     ASSERT.that(Arrays.asList(1, 2, 3)).contains(1);
   }
 
-  @Test public void listContainsWithChaining() {
-    ASSERT.that(Arrays.asList(1, 2, 3)).contains(1).and().contains(2);
-  }
-
   @Test public void equalityFail() {
     int x = 2 + 2;
     try {

--- a/core/src/test/java/org/truth0/ExpectFailureTest.java
+++ b/core/src/test/java/org/truth0/ExpectFailureTest.java
@@ -43,7 +43,7 @@ public class ExpectFailureTest {
   }
 
   @Test public void expectFailStringContains() {
-    EXPECT.that("abc").contains("x").and().contains("y").and().contains("z");
+    EXPECT.that("abc").contains("x");
   }
 
   @Test public void expectFailContainsAllOf() {

--- a/core/src/test/java/org/truth0/ExpectTest.java
+++ b/core/src/test/java/org/truth0/ExpectTest.java
@@ -58,7 +58,9 @@ public class ExpectTest {
 		thrown.expectMessage("1. Not true that <abc> contains <x>");
 		thrown.expectMessage("2. Not true that <abc> contains <y>");
 		thrown.expectMessage("3. Not true that <abc> contains <z>");
-		EXPECT.that("abc").contains("x").and().contains("y").and().contains("z");
+		EXPECT.that("abc").contains("x");
+		EXPECT.that("abc").contains("y");
+		EXPECT.that("abc").contains("z");
 	}
 
 	@Test

--- a/core/src/test/java/org/truth0/codegen/BarSubject.java
+++ b/core/src/test/java/org/truth0/codegen/BarSubject.java
@@ -38,11 +38,10 @@ public class BarSubject extends Subject<BarSubject, String> {
     super(failureStrategy, subject);
   }
 
-  public And<BarSubject> startsWith(@Nullable String prefix) {
+  public void startsWith(@Nullable String prefix) {
     if (getSubject().startsWith(prefix)) {
       fail("matches", getSubject(), prefix);
     }
-    return nextChain();
   }
 
 }

--- a/core/src/test/java/org/truth0/codegen/IteratingWrapperClassBuilderTest.java
+++ b/core/src/test/java/org/truth0/codegen/IteratingWrapperClassBuilderTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.truth0.FailureStrategy;
-import org.truth0.codegen.IteratingWrapperClassBuilder;
 import org.truth0.subjects.Subject;
 import org.truth0.subjects.SubjectFactory;
 
@@ -61,21 +60,19 @@ public class IteratingWrapperClassBuilderTest {
       "public class %1$sSubjectIteratingWrapper extends %1$sSubject {";
 
   private static final String FOO_WRAPPED_METHOD =
-      "  public org.truth0.subjects.Subject.And endsWith(java.lang.String arg0) {\n" +
+      "  public void endsWith(java.lang.String arg0) {\n" +
       "    for (java.lang.String item : data) {\n" +
       "      org.truth0.codegen.IteratingWrapperClassBuilderTest.FooSubject subject = (org.truth0.codegen.IteratingWrapperClassBuilderTest.FooSubject)subjectFactory.getSubject(failureStrategy, item);\n" +
       "      subject.endsWith(arg0);\n" +
       "    }\n" +
-      "    return nextChain();\n" +
       "  }";
 
   private static final String BAR_WRAPPED_METHOD =
-      "  public org.truth0.subjects.Subject.And startsWith(@javax.annotation.Nullable java.lang.String arg0) {\n" +
+      "  public void startsWith(@javax.annotation.Nullable java.lang.String arg0) {\n" +
       "    for (java.lang.String item : data) {\n" +
       "      org.truth0.codegen.BarSubject subject = (org.truth0.codegen.BarSubject)subjectFactory.getSubject(failureStrategy, item);\n" +
       "      subject.startsWith(arg0);\n" +
       "    }\n" +
-      "    return nextChain();\n" +
       "  }";
 
 
@@ -116,11 +113,10 @@ public class IteratingWrapperClassBuilderTest {
       super(failureStrategy, subject);
     }
 
-    public And<FooSubject> endsWith(String suffix) {
+    public void endsWith(String suffix) {
       if (getSubject().endsWith(suffix)) {
         fail("matches", getSubject(), suffix);
       }
-      return nextChain();
     }
 
   }

--- a/core/src/test/java/org/truth0/delegatetest/DelegationTest.java
+++ b/core/src/test/java/org/truth0/delegatetest/DelegationTest.java
@@ -36,8 +36,8 @@ public class DelegationTest {
       ASSERT.about(FOO).that(new Foo(5)).matches(new Foo(4));
       ASSERT.fail("Should have thrown.");
     } catch (AssertionError e) {
-      ASSERT.that(e.getMessage()).contains("Not true that")
-          .and().contains("matches");
+      ASSERT.that(e.getMessage()).contains("Not true that");
+      ASSERT.that(e.getMessage()).contains("matches");
     }
   }
 }

--- a/core/src/test/java/org/truth0/delegatetest/FooSubject.java
+++ b/core/src/test/java/org/truth0/delegatetest/FooSubject.java
@@ -38,11 +38,10 @@ public class FooSubject extends Subject<FooSubject, Foo> {
     super(failureStrategy, subject);
   }
 
-  public And<FooSubject> matches(Foo object) {
+  public void matches(Foo object) {
     if (getSubject().value != object.value) {
       fail("matches", getSubject(), object);
     }
-    return nextChain();
   }
 
 }

--- a/core/src/test/java/org/truth0/extensiontest/ExtensionTest.java
+++ b/core/src/test/java/org/truth0/extensiontest/ExtensionTest.java
@@ -16,6 +16,7 @@
  */
 package org.truth0.extensiontest;
 
+
 import static org.truth0.extensiontest.ExtendedVerb.ASSERT;
 
 import org.junit.Test;
@@ -39,8 +40,8 @@ public class ExtensionTest {
       ASSERT.that(new MyType(5)).matches(new MyType(4));
       ASSERT.fail("Should have thrown.");
     } catch (AssertionError e) {
-      ASSERT.that(e.getMessage()).contains("Not true that")
-          .and().contains("matches");
+      ASSERT.that(e.getMessage()).contains("Not true that");
+      ASSERT.that(e.getMessage()).contains("matches");
     }
   }
 

--- a/core/src/test/java/org/truth0/extensiontest/MySubject.java
+++ b/core/src/test/java/org/truth0/extensiontest/MySubject.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2011 David Saff
  * Copyright (c) 2011 Christian Gruber
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -22,7 +22,7 @@ import org.truth0.subjects.Subject;
 
 /**
  * A simple example Subject to demonstrate extension.
- * 
+ *
  * @author Christian Gruber (christianedwardgruber@gmail.com)
  */
 public class MySubject extends Subject<MySubject, MyType> {
@@ -31,11 +31,10 @@ public class MySubject extends Subject<MySubject, MyType> {
     super(failureStrategy, subject);
   }
 
-  public And<MySubject> matches(MyType object) {
+  public void matches(MyType object) {
     if (getSubject().value != object.value) {
       fail("matches", getSubject(), object);
     }
-    return nextChain();
   }
 
 }

--- a/core/src/test/java/org/truth0/subjects/CollectionTest.java
+++ b/core/src/test/java/org/truth0/subjects/CollectionTest.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.truth0.subjects.Ordered;
 
 /**
  * Tests for Collection Subjects.
@@ -41,25 +40,8 @@ public class CollectionTest {
     ASSERT.that(collection(1, 2, 3)).contains(1);
   }
 
-  @Test public void collectionContainsWithChaining() {
-    ASSERT.that(collection(1, 2, 3)).contains(1).and().contains(2);
-  }
-
   @Test public void collectionContainsWithNull() {
     ASSERT.that(collection(1, null, 3)).contains(null);
-  }
-
-  @Test public void collectionContainsWith2KindsOfChaining() {
-    Collection<Integer> foo = collection(1, 2, 3);
-    Collection<Integer> bar = foo;
-    ASSERT.that(foo).is(bar).and().contains(1).and().contains(2);
-  }
-
-  @Test public void collectionContainsFailureWithChaining() {
-    try {
-      ASSERT.that(collection(1, 2, 3)).contains(1).and().contains(5);
-      fail("Should have thrown.");
-    } catch (AssertionError e) {}
   }
 
   @Test public void collectionContainsFailure() {
@@ -105,7 +87,8 @@ public class CollectionTest {
       ASSERT.that(collection(1, 2, 3)).contains(1, 2, 4);
       fail("Should have thrown.");
     } catch (AssertionError e) {
-      ASSERT.that(e.getMessage()).contains("Not true that").and().contains("<4>");
+      ASSERT.that(e.getMessage()).contains("Not true that");
+      ASSERT.that(e.getMessage()).contains("<4>");
     }
   }
 
@@ -114,9 +97,9 @@ public class CollectionTest {
       ASSERT.that(collection(1, 2, 3)).contains(1, 2, 2, 2, 3, 4);
       fail("Should have thrown.");
     } catch (AssertionError e) {
-      ASSERT.that(e.getMessage()).contains("Not true that")
-          .and().contains("<3 copies of 2>")
-          .and().contains("<4>");
+      ASSERT.that(e.getMessage()).contains("Not true that");
+      ASSERT.that(e.getMessage()).contains("<3 copies of 2>");
+       ASSERT.that(e.getMessage()).contains("<4>");
     }
   }
 
@@ -129,8 +112,8 @@ public class CollectionTest {
       ASSERT.that(collection(1, 2)).contains(4, 4, 4);
       fail("Should have thrown.");
     } catch (AssertionError e) {
-      ASSERT.that(e.getMessage()).contains("Not true that")
-          .and().endsWith("contains <3 copies of 4>");
+      ASSERT.that(e.getMessage()).contains("Not true that");
+      ASSERT.that(e.getMessage()).endsWith("contains <3 copies of 4>");
     }
   }
 
@@ -139,8 +122,8 @@ public class CollectionTest {
       ASSERT.that(collection(1, null, 3)).contains(1, null, null, 3);
       fail("Should have thrown.");
     } catch (AssertionError e) {
-      ASSERT.that(e.getMessage()).contains("Not true that")
-          .and().contains("<2 copies of null>");
+      ASSERT.that(e.getMessage()).contains("Not true that");
+      ASSERT.that(e.getMessage()).contains("<2 copies of null>");
     }
   }
 
@@ -157,8 +140,8 @@ public class CollectionTest {
       ASSERT.that(collection(1, null, 3)).contains(null, 1, 3).inOrder();
       fail("Should have thrown.");
     } catch (AssertionError e) {
-      ASSERT.that(e.getMessage()).contains("Not true that")
-          .and().contains("iterates through");
+      ASSERT.that(e.getMessage()).contains("Not true that");
+      ASSERT.that(e.getMessage()).contains("iterates through");
     }
   }
 
@@ -201,8 +184,8 @@ public class CollectionTest {
       ordered.inOrder();
       fail("Should have thrown.");
     } catch (AssertionError e) {
-      ASSERT.that(e.getMessage()).contains("Not true that")
-          .and().contains("iterates through");
+      ASSERT.that(e.getMessage()).contains("Not true that");
+      ASSERT.that(e.getMessage()).contains("iterates through");
     }
   }
 
@@ -215,8 +198,8 @@ public class CollectionTest {
       ASSERT.that(collection(1, null, 3)).isEmpty();
       fail("Should have thrown.");
     } catch (AssertionError e) {
-      ASSERT.that(e.getMessage()).contains("Not true that")
-          .and().contains("is empty");
+      ASSERT.that(e.getMessage()).contains("Not true that");
+      ASSERT.that(e.getMessage()).contains("is empty");
     }
   }
 

--- a/core/src/test/java/org/truth0/subjects/IntegerTest.java
+++ b/core/src/test/java/org/truth0/subjects/IntegerTest.java
@@ -38,7 +38,8 @@ public class IntegerTest {
   @Rule public final Expect EXPECT = Expect.create();
 
   @Test public void simpleEquality() {
-    ASSERT.that(2 + 2).isEqualTo(4).and().isBetween(3, 5);
+    ASSERT.that(2 + 2).is(4);
+    ASSERT.that(2 + 2).isEqualTo(4);
   }
 
   @Test public void intIsInt() {

--- a/core/src/test/java/org/truth0/subjects/IterableTest.java
+++ b/core/src/test/java/org/truth0/subjects/IterableTest.java
@@ -40,19 +40,6 @@ public class IterableTest {
     ASSERT.that(iterable(1, null, 3)).contains(null);
   }
 
-  @Test public void iterableContainsWith2KindsOfChaining() {
-    Iterable<Integer> foo = iterable(1, 2, 3);
-    Iterable<Integer> bar = foo;
-    ASSERT.that(foo).is(bar).and().contains(1).and().contains(2);
-  }
-
-  @Test public void iterableContainsFailureWithChaining() {
-    try {
-      ASSERT.that(iterable(1, 2, 3)).contains(1).and().contains(5);
-      fail("Should have thrown.");
-    } catch (AssertionError e) {}
-  }
-
   @Test public void iterableContainsFailure() {
     try {
       ASSERT.that(iterable(1, 2, 3)).contains(5);
@@ -106,8 +93,8 @@ public class IterableTest {
       ASSERT.that(iterable(1, null, 3)).isEmpty();
       fail("Should have thrown.");
     } catch (AssertionError e) {
-      ASSERT.that(e.getMessage()).contains("Not true that")
-          .and().contains("is empty");
+      ASSERT.that(e.getMessage()).contains("Not true that");
+      ASSERT.that(e.getMessage()).contains("is empty");
     }
   }
 

--- a/core/src/test/java/org/truth0/subjects/ListTest.java
+++ b/core/src/test/java/org/truth0/subjects/ListTest.java
@@ -58,7 +58,8 @@ public class ListTest {
       ASSERT.that(Arrays.asList(1, 2, 3)).containsSequence(Arrays.asList(1, 2, 3, 4));
       fail("Should have thrown.");
     } catch (AssertionError e) {
-      ASSERT.that(e.getMessage()).contains("contains sequence").and().contains("[1, 2, 3, 4]");
+      ASSERT.that(e.getMessage()).contains("contains sequence");
+      ASSERT.that(e.getMessage()).contains("[1, 2, 3, 4]");
     }
   }
 
@@ -67,7 +68,8 @@ public class ListTest {
       ASSERT.that(Arrays.asList(1, 2, 2, 3)).containsSequence(Arrays.asList(1, 2, 3));
       fail("Should have thrown.");
     } catch (AssertionError e) {
-      ASSERT.that(e.getMessage()).contains("contains sequence").and().contains("[1, 2, 3]");
+      ASSERT.that(e.getMessage()).contains("contains sequence");
+      ASSERT.that(e.getMessage()).contains("[1, 2, 3]");
     }
   }
 
@@ -82,7 +84,8 @@ public class ListTest {
       ASSERT.that(Arrays.asList(1, 2, 2, 4)).isOrdered();
       fail("Should have thrown.");
     } catch (AssertionError e) {
-      ASSERT.that(e.getMessage()).contains("is strictly ordered").and().contains("<2> <2>");
+      ASSERT.that(e.getMessage()).contains("is strictly ordered");
+      ASSERT.that(e.getMessage()).contains("<2> <2>");
     }
   }
 
@@ -104,7 +107,8 @@ public class ListTest {
       ASSERT.that(Arrays.asList(1, 3, 2, 4)).isPartiallyOrdered();
       fail("Should have thrown.");
     } catch (AssertionError e) {
-      ASSERT.that(e.getMessage()).contains("is partially ordered").and().contains("<3> <2>");
+      ASSERT.that(e.getMessage()).contains("is partially ordered");
+      ASSERT.that(e.getMessage()).contains("<3> <2>");
     }
   }
 
@@ -127,7 +131,8 @@ public class ListTest {
       ASSERT.that(Arrays.asList("1", "2", "2", "10")).isOrdered(COMPARE_AS_DECIMAL);
       fail("Should have thrown.");
     } catch (AssertionError e) {
-      ASSERT.that(e.getMessage()).contains("is strictly ordered").and().contains("<2> <2>");
+      ASSERT.that(e.getMessage()).contains("is strictly ordered");
+      ASSERT.that(e.getMessage()).contains("<2> <2>");
     }
   }
 
@@ -143,7 +148,8 @@ public class ListTest {
       ASSERT.that(Arrays.asList("1", "10", "2", "20")).isPartiallyOrdered(COMPARE_AS_DECIMAL);
       fail("Should have thrown.");
     } catch (AssertionError e) {
-      ASSERT.that(e.getMessage()).contains("is partially ordered").and().contains("<10> <2>");
+      ASSERT.that(e.getMessage()).contains("is partially ordered");
+      ASSERT.that(e.getMessage()).contains("<10> <2>");
     }
   }
 

--- a/core/src/test/java/org/truth0/subjects/StringTest.java
+++ b/core/src/test/java/org/truth0/subjects/StringTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2011 David Saff
  * Copyright (c) 2011 Christian Gruber
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -25,7 +25,7 @@ import org.junit.runners.JUnit4;
 
 /**
  * Tests for String Subjects.
- * 
+ *
  * @author David Saff
  * @author Christian Gruber (cgruber@israfil.net)
  */
@@ -35,7 +35,7 @@ public class StringTest {
   @Test public void stringContains() {
     ASSERT.that("abc").contains("c");
   }
-  
+
   @Test public void stringContainsFail() {
     try {
       ASSERT.that("abc").contains("d");
@@ -45,10 +45,6 @@ public class StringTest {
       return;
     }
     fail("Should have thrown");
-  }
-
-  @Test public void chain() {
-    ASSERT.that("abc").contains("a").and().contains("b");
   }
 
   @Test public void stringEquality() {
@@ -80,7 +76,7 @@ public class StringTest {
     }
     fail("Should have thrown");
   }
-  
+
   @Test public void stringEndsWith() {
     ASSERT.that("abc").endsWith("bc");
   }
@@ -110,7 +106,7 @@ public class StringTest {
     ASSERT.that((String)null).startsWith(null);
     ASSERT.that((String)null).endsWith(null);
   }
-  
+
   @Test public void stringNullContains() {
     try {
       ASSERT.that((String)null).contains("a");


### PR DESCRIPTION
Remove And<T> and all and() and chaining from Subjects, as And<T> is a confusing API when used with iterable verbs

List<Strings> list = Arrays.asList("oofob", "oobob", "oofob")
ASSERT.in(list).thatEach(STRING).contains("oo").and().contains("ob");

This would be ambiguous as to whether the and() referred to the "that each" or the underlying collection.  While it can be reasoned about, the code, as read, is not inherently obvious, containing a linguistic ambiguity in the english fluent reading.  
