### PR TITLE
Fix a bug when passing null in the third position of some methods.

### DIFF
--- a/core/src/main/java/org/truth0/subjects/SubjectUtils.java
+++ b/core/src/main/java/org/truth0/subjects/SubjectUtils.java
@@ -33,10 +33,17 @@ final class SubjectUtils {
     return new ArrayList<T>(Collections.singleton(only));
   }
   static <T> List<T> accumulate(T first, T second, T ... rest) {
-    List<T> items = new ArrayList<T>(rest.length + 2);
+    // rest should never be deliberately null, so assume that the caller passed null
+    // in the third position but intended it to be the third element in the array of values.
+    // Javac makes the opposite inference, so handle that here.
+    List<T> items = new ArrayList<T>(2 + ((rest == null) ? 1 : rest.length));
     items.add(first);
     items.add(second);
-    items.addAll(Arrays.asList(rest));
+    if (rest == null) {
+      items.add(null);
+    } else {
+      items.addAll(Arrays.asList(rest));
+    }
     return items;
   }
 

--- a/core/src/test/java/org/truth0/subjects/CollectionTest.java
+++ b/core/src/test/java/org/truth0/subjects/CollectionTest.java
@@ -61,6 +61,10 @@ public class CollectionTest {
     ASSERT.that(collection(1, null, 3)).has().anyOf(null, 5);
   }
 
+  @Test public void collectionHasAnyOfWithNullInThirdAndFinalPosition() {
+    ASSERT.that(collection(1, null, 3)).has().anyOf(4, 5, null);
+  }
+
   @Test public void collectionHasAnyOfFailure() {
     try {
       ASSERT.that(collection(1, 2, 3)).has().anyOf(5, 6, 0);
@@ -80,6 +84,10 @@ public class CollectionTest {
 
   @Test public void collectionHasAllOfWithNull() {
     ASSERT.that(collection(1, null, 3)).has().allOf(3, null);
+  }
+
+  @Test public void collectionHasAllOfWithNullAtThirdAndFinalPosition() {
+    ASSERT.that(collection(1, null, 3)).has().allOf(1, 3, null);
   }
 
   @Test public void collectionHasAllOfFailure() {


### PR DESCRIPTION
When passing into methods such as:

ASSERT.that(aCollection).has().anOf("this", "that", null);

javac infers that this is an Object[] and passes null to the varargs method underneath this.  Since we never will be calling:

ASSERT.that(aCollection).has().anOf("this", "that", (Object[])null);

but always mean

ASSERT.that(aCollection).has().anOf("this", "that", (T)null);

we will treat a null varargs array as a mis-fired single-element null intended to be the third item in an array of values. 
