### PR TITLE
Rename iteratesOverSequence -> iteratesAs

### DIFF
--- a/core/src/main/java/org/truth0/subjects/IterableSubject.java
+++ b/core/src/main/java/org/truth0/subjects/IterableSubject.java
@@ -64,7 +64,7 @@ public class IterableSubject<S extends IterableSubject<S, T, C>, T, C extends It
    * unexpected results.  Consider using {@link #is(T)} in such cases, or using
    * collections and iterables that provide strong order guarantees.
    */
-  public void iteratesOver(Iterable<T> expectedItems) {
+  public void iteratesAs(Iterable<T> expectedItems) {
     Iterator<T> actualItems = getSubject().iterator();
     for (Object expected : expectedItems) {
       if (!actualItems.hasNext()) {
@@ -84,11 +84,11 @@ public class IterableSubject<S extends IterableSubject<S, T, C>, T, C extends It
   }
 
   /**
-   * @deprecated use {@link #iteratesOver(T...)}
+   * @deprecated use {@link #iteratesAs(T...)}
    */
   @Deprecated
   public void iteratesOverSequence(T... expectedItems) {
-    iteratesOver(expectedItems);
+    iteratesAs(expectedItems);
   }
 
   /**
@@ -97,7 +97,7 @@ public class IterableSubject<S extends IterableSubject<S, T, C>, T, C extends It
    * a {@link Set<T>}), this method is not suitable for asserting that order.
    * Consider using {@link #is(T)}
    */
-  public void iteratesOver(T... expectedItems) {
-    iteratesOver(Arrays.asList(expectedItems));
+  public void iteratesAs(T... expectedItems) {
+    iteratesAs(Arrays.asList(expectedItems));
   }
 }

--- a/core/src/test/java/org/truth0/subjects/IterableTest.java
+++ b/core/src/test/java/org/truth0/subjects/IterableTest.java
@@ -37,11 +37,11 @@ import java.util.Arrays;
 public class IterableTest {
 
   @Test public void iteratesOver() {
-    ASSERT.that(iterable(1, 2, 3)).iteratesOver(1, 2, 3);
+    ASSERT.that(iterable(1, 2, 3)).iteratesAs(1, 2, 3);
   }
 
   @Test public void iteratesOverAsList() {
-    ASSERT.that(iterable(1, 2, 3)).iteratesOver(asList(1, 2, 3));
+    ASSERT.that(iterable(1, 2, 3)).iteratesAs(asList(1, 2, 3));
   }
 
   @Test public void iteratesOverLegacy() {
@@ -55,12 +55,12 @@ public class IterableTest {
   }
 
   @Test public void iteratesOverEmpty() {
-    ASSERT.that(iterable()).iteratesOver();
+    ASSERT.that(iterable()).iteratesAs();
   }
 
   @Test public void iteratesOverWithOrderingFailure() {
     try {
-      ASSERT.that(iterable(1, 2, 3)).iteratesOver(2, 3, 1);
+      ASSERT.that(iterable(1, 2, 3)).iteratesAs(2, 3, 1);
       fail("Should have thrown.");
     } catch (AssertionError e) {
       ASSERT.that(e.getMessage()).contains("Not true that");
@@ -69,7 +69,7 @@ public class IterableTest {
 
   @Test public void iteratesOverWithTooManyItemsFailure() {
     try {
-      ASSERT.that(iterable(1, 2, 3)).iteratesOver(1, 2, 3, 4);
+      ASSERT.that(iterable(1, 2, 3)).iteratesAs(1, 2, 3, 4);
       fail("Should have thrown.");
     } catch (AssertionError e) {
       ASSERT.that(e.getMessage()).contains("Not true that");
@@ -78,7 +78,7 @@ public class IterableTest {
 
   @Test public void iteratesOverWithTooFewItemsFailure() {
     try {
-      ASSERT.that(iterable(1, 2, 3)).iteratesOver(1, 2);
+      ASSERT.that(iterable(1, 2, 3)).iteratesAs(1, 2);
       fail("Should have thrown.");
     } catch (AssertionError e) {
       ASSERT.that(e.getMessage()).contains("Not true that");


### PR DESCRIPTION
Rename iteratesOverSequence -> iteratesAs, and add a form that takes an `Iterable<T>`, allowing

```
List<String> iterable = Arrays.asList("foo", "bar");
ASSERT.that(iterable).iteratesAs("foo", "bar");
```

which it already allows now with the older method name, but also allows

```
ASSERT.that(iterable).iteratesAs(asList("foo", "bar"));
```

since many people may need ordered collections for expected values in more complex tests.

This PR also keeps iteratesOverSequence() for compatibility but deprecates it.
