### PR TITLE
Disambiguate message when consolidating multiple copies of an item

### DIFF
--- a/core/src/main/java/org/truth0/subjects/SubjectUtils.java
+++ b/core/src/main/java/org/truth0/subjects/SubjectUtils.java
@@ -67,7 +67,7 @@ final class SubjectUtils {
     int n = 0;
     for (T item : itemSet) {
       int count = countOf(item, items);
-      params[n++] = (count > 1) ? count + " copies of " + item : item;
+      params[n++] = (count > 1) ? item + " [" + count + " copies]" : item;
     }
     return Arrays.asList(params);
   }

--- a/core/src/test/java/org/truth0/subjects/CollectionTest.java
+++ b/core/src/test/java/org/truth0/subjects/CollectionTest.java
@@ -110,7 +110,7 @@ public class CollectionTest {
       ASSERT.that(e.getMessage()).contains("Not true that");
       ASSERT.that(e.getMessage()).contains("has all of");
       ASSERT.that(e.getMessage()).contains("is missing");
-      ASSERT.that(e.getMessage()).contains("2 copies of 2, 4");
+      ASSERT.that(e.getMessage()).contains("2 [2 copies], 4");
     }
   }
 
@@ -125,7 +125,7 @@ public class CollectionTest {
     } catch (AssertionError e) {
       ASSERT.that(e.getMessage()).contains("Not true that");
       ASSERT.that(e.getMessage()).contains("is missing");
-      ASSERT.that(e.getMessage()).contains("3 copies of 4");
+      ASSERT.that(e.getMessage()).contains("4 [3 copies]");
     }
   }
 
@@ -212,7 +212,7 @@ public class CollectionTest {
       ASSERT.that(e.getMessage()).contains("Not true that");
       ASSERT.that(e.getMessage()).contains("has exactly");
       ASSERT.that(e.getMessage()).contains("is missing");
-      ASSERT.that(e.getMessage()).contains("2 copies of 2");
+      ASSERT.that(e.getMessage()).contains("2 [2 copies]");
     }
   }
 
@@ -224,7 +224,7 @@ public class CollectionTest {
       ASSERT.that(e.getMessage()).contains("Not true that");
       ASSERT.that(e.getMessage()).contains("has exactly");
       ASSERT.that(e.getMessage()).contains("is missing");
-      ASSERT.that(e.getMessage()).contains("2 copies of 2, 4");
+      ASSERT.that(e.getMessage()).contains("2 [2 copies], 4");
     }
   }
 
@@ -236,7 +236,7 @@ public class CollectionTest {
       ASSERT.that(e.getMessage()).contains("Not true that");
       ASSERT.that(e.getMessage()).contains("has exactly");
       ASSERT.that(e.getMessage()).contains("has unexpected items");
-      ASSERT.that(e.getMessage()).contains("2 copies of 2");
+      ASSERT.that(e.getMessage()).contains("2 [2 copies]");
     }
   }
 
@@ -251,7 +251,7 @@ public class CollectionTest {
     } catch (AssertionError e) {
       ASSERT.that(e.getMessage()).contains("Not true that");
       ASSERT.that(e.getMessage()).contains("is missing");
-      ASSERT.that(e.getMessage()).contains("3 copies of 4");
+      ASSERT.that(e.getMessage()).contains("4 [3 copies]");
     }
   }
 


### PR DESCRIPTION
This is a response to a comment @hagbard brought up in truth0/truth#56 about how "2 copies of 2, 4" is somewhat ambiguous, so I've rewritten it to "2 [2 copies], 4".
