### PR TITLE
Add `@CheckReturnValue` (JSR-305) annotation to certain key methods

### DIFF
--- a/core/src/main/java/org/truth0/AbstractVerb.java
+++ b/core/src/main/java/org/truth0/AbstractVerb.java
@@ -1,10 +1,12 @@
 package org.truth0;
 
+import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtIncompatible;
+
 import org.truth0.subjects.Subject;
 import org.truth0.subjects.SubjectFactory;
 
-import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.GwtIncompatible;
+import javax.annotation.CheckReturnValue;
 
 @GwtCompatible
 public class AbstractVerb {
@@ -41,6 +43,7 @@ public class AbstractVerb {
    * @param factory a SubjectFactory<S, T> implementation
    * @returns A custom verb for the type returned by the SubjectFactory
    */
+	@CheckReturnValue
   public <S extends Subject<S,T>, T, SF extends SubjectFactory<S, T>>
       DelegatedVerb<S, T> about(SF factory) {
       return new DelegatedVerb<S, T>(getFailureStrategy(), factory);

--- a/core/src/main/java/org/truth0/IteratingVerb.java
+++ b/core/src/main/java/org/truth0/IteratingVerb.java
@@ -4,15 +4,19 @@ import com.google.common.annotations.GwtIncompatible;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Type;
-import java.util.concurrent.ExecutionException;
+
 import org.truth0.codegen.CompilingClassLoader;
 import org.truth0.codegen.CompilingClassLoader.CompilerException;
 import org.truth0.codegen.IteratingWrapperClassBuilder;
 import org.truth0.subjects.Subject;
 import org.truth0.subjects.SubjectFactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Type;
+import java.util.concurrent.ExecutionException;
+
+import javax.annotation.CheckReturnValue;
 /**
  * A verb that iterates over data and applies the predicate iteratively
  */
@@ -35,6 +39,7 @@ public class IteratingVerb<T> extends AbstractVerb {
     this.data = data;
   }
 
+  @CheckReturnValue
   public <S extends Subject<S,T>, SF extends SubjectFactory<S, T>> S thatEach(SF factory) {
     return wrap(getFailureStrategy(), factory, data);
   }

--- a/core/src/main/java/org/truth0/TestVerb.java
+++ b/core/src/main/java/org/truth0/TestVerb.java
@@ -35,6 +35,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.CheckReturnValue;
+
 @GwtCompatible
 public class TestVerb extends AbstractVerb {
   public TestVerb(FailureStrategy failureStrategy) {
@@ -45,44 +47,59 @@ public class TestVerb extends AbstractVerb {
     return new DefaultSubject(getFailureStrategy(), target);
   }
 
+  @CheckReturnValue
   @GwtIncompatible("ClassSubject.java")
   public ClassSubject that(Class<?> target) {
     return new ClassSubject(getFailureStrategy(), target);
   }
 
+  @CheckReturnValue
   public IntegerSubject that(Long target) {
     return new IntegerSubject(getFailureStrategy(), target);
   }
 
+  @CheckReturnValue
   public IntegerSubject that(Integer target) {
     return new IntegerSubject(getFailureStrategy(), target);
   }
 
+  @CheckReturnValue
   public BooleanSubject that(Boolean target) {
     return new BooleanSubject(getFailureStrategy(), target);
   }
 
+  @CheckReturnValue
   public StringSubject that(String target) {
     return new StringSubject(getFailureStrategy(), target);
   }
 
-  public <T, C extends Iterable<T>> IterableSubject<? extends IterableSubject<?, T, C>, T, C> that(Iterable<T> target) {
+  @CheckReturnValue
+  public <T, C extends Iterable<T>> IterableSubject<? extends IterableSubject<?, T, C>, T, C>
+      that(Iterable<T> target) {
     return IterableSubject.create(getFailureStrategy(), target);
   }
 
-  public <T, C extends Collection<T>> CollectionSubject<? extends CollectionSubject<?, T, C>, T, C> that(Collection<T> target) {
+  @CheckReturnValue
+  public <T, C extends Collection<T>> CollectionSubject<? extends CollectionSubject<?, T, C>, T, C>
+      that(Collection<T> target) {
     return CollectionSubject.create(getFailureStrategy(), target);
   }
 
-  public <T, C extends List<T>> ListSubject<? extends ListSubject<?, T, C>, T, C> that(List<T> target) {
+  @CheckReturnValue
+  public <T, C extends List<T>> ListSubject<? extends ListSubject<?, T, C>, T, C>
+      that(List<T> target) {
     return ListSubject.create(getFailureStrategy(), target);
   }
 
-  public <T, C extends List<T>> ListSubject<? extends ListSubject<?, T, C>, T, C> that(T[] target) {
+  @CheckReturnValue
+  public <T, C extends List<T>> ListSubject<? extends ListSubject<?, T, C>, T, C>
+      that(T[] target) {
     return that(Arrays.asList(target));
   }
 
-  public <K, V, M extends Map<K, V>> MapSubject<? extends MapSubject<?, K, V, M>, K, V, M> that(Map<K, V> target) {
+  @CheckReturnValue
+  public <K, V, M extends Map<K, V>> MapSubject<? extends MapSubject<?, K, V, M>, K, V, M>
+      that(Map<K, V> target) {
     return MapSubject.create(getFailureStrategy(), target);
   }
 

--- a/core/src/main/java/org/truth0/subjects/CollectionSubject.java
+++ b/core/src/main/java/org/truth0/subjects/CollectionSubject.java
@@ -28,6 +28,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 
+import javax.annotation.CheckReturnValue;
+
 @GwtCompatible
 public class CollectionSubject<S extends CollectionSubject<S, T, C>, T, C extends Collection<T>> extends IterableSubject<S, T, C> {
 
@@ -51,6 +53,7 @@ public class CollectionSubject<S extends CollectionSubject<S, T, C>, T, C extend
     }
   }
 
+  @CheckReturnValue
   public Has<T, C> has() {
     return new Has<T, C>() {
       @Override public void item(T item) {


### PR DESCRIPTION
Add `@CheckReturnValue` (JSR-305) annotation to certain key methods, since these methods being called without further calling their fluent chain would result in falsely-passing tests.

This will result in Error-Prone or any other static analysis system flagging as an error any usage of `ASSERT.that(foo);`  This is especially important for the erroneous use of booleans such as `ASSERT.that(a == b);`
