### PR TITLE
Set up preemptive Java8 testing to catch accidental incompatibilities.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk:
+  - oraclejdk8
   - oraclejdk7
   - openjdk7
 #  - openjdk6

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -10,6 +10,7 @@
   <artifactId>truth</artifactId>
   <properties>
     <gwt.version>2.5.1</gwt.version>
+    <javadoc.param></javadoc.param>
   </properties>
   <dependencies>
     <dependency>
@@ -80,6 +81,9 @@
             <id>attach-docs</id>
             <phase>post-integration-test</phase>
             <goals><goal>jar</goal></goals>
+            <configuration>
+                <additionalparam>${javadoc.param}</additionalparam>
+            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -190,5 +194,16 @@
         </configuration>        
       </plugin>
     </plugins>
-  </reporting>  
+  </reporting>
+  <profiles>
+  <profile>
+    <id>java8</id>
+    <activation>
+      <jdk>[1.8,1.8)</jdk>
+    </activation>
+    <properties>
+      <javadoc.param>-Xdoclint:none</javadoc.param>
+    </properties>
+  </profile>
+</profiles>
 </project>

--- a/core/src/main/java/org/truth0/gwtemul/org/truth0/subjects/StringSubject.java
+++ b/core/src/main/java/org/truth0/gwtemul/org/truth0/subjects/StringSubject.java
@@ -19,8 +19,6 @@ package org.truth0.subjects;
 
 import org.truth0.FailureStrategy;
 
-import java.util.regex.Pattern;
-
 /**
  * Propositions for String subjects
  *


### PR DESCRIPTION
Also, tune down the doclint which runs by default.  
