### PR TITLE
Loosen generics on IterableSubject.iteratesAs() overloads

### DIFF
--- a/core/src/main/java/org/truth0/subjects/CollectionSubject.java
+++ b/core/src/main/java/org/truth0/subjects/CollectionSubject.java
@@ -35,13 +35,13 @@ public class CollectionSubject<S extends CollectionSubject<S, T, C>, T, C extend
 
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public static <T, C extends Collection<T>> CollectionSubject<? extends CollectionSubject<?, T, C>, T, C> create(
-      FailureStrategy failureStrategy, Collection<T> list) {
-    return new CollectionSubject(failureStrategy, list);
+      FailureStrategy failureStrategy, Collection<T> collection) {
+    return new CollectionSubject(failureStrategy, collection);
   }
 
   // TODO: Arguably this should even be package private
-  protected CollectionSubject(FailureStrategy failureStrategy, C list) {
-    super(failureStrategy, list);
+  protected CollectionSubject(FailureStrategy failureStrategy, C collection) {
+    super(failureStrategy, collection);
   }
 
   /**

--- a/core/src/main/java/org/truth0/subjects/IterableSubject.java
+++ b/core/src/main/java/org/truth0/subjects/IterableSubject.java
@@ -64,7 +64,7 @@ public class IterableSubject<S extends IterableSubject<S, T, C>, T, C extends It
    * unexpected results.  Consider using {@link #is(T)} in such cases, or using
    * collections and iterables that provide strong order guarantees.
    */
-  public void iteratesAs(Iterable<T> expectedItems) {
+  public void iteratesAs(Iterable<?> expectedItems) {
     Iterator<T> actualItems = getSubject().iterator();
     for (Object expected : expectedItems) {
       if (!actualItems.hasNext()) {
@@ -87,7 +87,7 @@ public class IterableSubject<S extends IterableSubject<S, T, C>, T, C extends It
    * @deprecated use {@link #iteratesAs(T...)}
    */
   @Deprecated
-  public void iteratesOverSequence(T... expectedItems) {
+  public void iteratesOverSequence(Object... expectedItems) {
     iteratesAs(expectedItems);
   }
 
@@ -97,7 +97,7 @@ public class IterableSubject<S extends IterableSubject<S, T, C>, T, C extends It
    * a {@link Set<T>}), this method is not suitable for asserting that order.
    * Consider using {@link #is(T)}
    */
-  public void iteratesAs(T... expectedItems) {
+  public void iteratesAs(Object... expectedItems) {
     iteratesAs(Arrays.asList(expectedItems));
   }
 }

--- a/core/src/test/java/org/truth0/subjects/IterableTest.java
+++ b/core/src/test/java/org/truth0/subjects/IterableTest.java
@@ -85,6 +85,25 @@ public class IterableTest {
     }
   }
 
+  @Test public void iteratesOverWithIncompatibleItems() {
+    try {
+      ASSERT.that(iterable(1, 2, 3)).iteratesAs(1, 2, "a");
+      fail("Should have thrown.");
+    } catch (AssertionError e) {
+      ASSERT.that(e.getMessage()).contains("Not true that");
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test public void iteratesOverAsListWithIncompatibleItems() {
+    try {
+      ASSERT.that(iterable(1, 2, 3)).iteratesAs(asList(1, 2, "a"));
+      fail("Should have thrown.");
+    } catch (AssertionError e) {
+      ASSERT.that(e.getMessage()).contains("Not true that");
+    }
+  }
+
   @Test public void iterableIsEmpty() {
     ASSERT.that(iterable()).isEmpty();
   }


### PR DESCRIPTION
Loosen generics on IterableSubject.iteratesAs() overloads, to permit mixed-type objects to be passed in.  This is more in keeping with Java type erasure and the contract of equals().
