### PR TITLE
Fix named() for array-types.

### DIFF
--- a/core/src/main/java/org/truth0/subjects/AbstractArraySubject.java
+++ b/core/src/main/java/org/truth0/subjects/AbstractArraySubject.java
@@ -10,11 +10,14 @@ import java.util.List;
  *
  * @author Christian Gruber (cgruber@israfil.net)
  */
-public abstract class AbstractArraySubject<T> extends Subject<AbstractArraySubject<T>, T> {
+public abstract class AbstractArraySubject<S extends AbstractArraySubject<S, T>, T>
+    extends Subject<AbstractArraySubject<S, T>, T> {
 
   public AbstractArraySubject(FailureStrategy failureStrategy, T subject) {
     super(failureStrategy, subject);
   }
+
+  @Override public S named(String name) { return (S)super.named(name); }
 
   protected abstract String underlyingType();
 

--- a/core/src/main/java/org/truth0/subjects/ObjectArraySubject.java
+++ b/core/src/main/java/org/truth0/subjects/ObjectArraySubject.java
@@ -18,9 +18,8 @@ package org.truth0.subjects;
 
 import com.google.common.annotations.GwtCompatible;
 
-import org.truth0.util.Platform;
-
 import org.truth0.FailureStrategy;
+import org.truth0.util.Platform;
 
 import java.util.Arrays;
 import java.util.List;
@@ -31,7 +30,7 @@ import java.util.List;
  * @author Christian Gruber (cgruber@israfil.net)
  */
 @GwtCompatible
-public class ObjectArraySubject<T> extends AbstractArraySubject<T[]> {
+public class ObjectArraySubject<T> extends AbstractArraySubject<ObjectArraySubject<T>, T[]> {
 
   private final String typeName;
 

--- a/core/src/main/java/org/truth0/subjects/PrimitiveBooleanArraySubject.java
+++ b/core/src/main/java/org/truth0/subjects/PrimitiveBooleanArraySubject.java
@@ -30,7 +30,8 @@ import java.util.List;
  * @author Christian Gruber (cgruber@israfil.net)
  */
 @GwtCompatible
-public class PrimitiveBooleanArraySubject extends AbstractArraySubject<boolean[]> {
+public class PrimitiveBooleanArraySubject
+    extends AbstractArraySubject<PrimitiveBooleanArraySubject, boolean[]> {
   public PrimitiveBooleanArraySubject(FailureStrategy failureStrategy, boolean[] o) {
     super(failureStrategy, o);
   }

--- a/core/src/main/java/org/truth0/subjects/PrimitiveCharArraySubject.java
+++ b/core/src/main/java/org/truth0/subjects/PrimitiveCharArraySubject.java
@@ -30,7 +30,8 @@ import java.util.List;
  * @author Christian Gruber (cgruber@israfil.net)
  */
 @GwtCompatible
-public class PrimitiveCharArraySubject extends AbstractArraySubject<char[]> {
+public class PrimitiveCharArraySubject
+    extends AbstractArraySubject<PrimitiveCharArraySubject, char[]> {
   public PrimitiveCharArraySubject(FailureStrategy failureStrategy, char[] o) {
     super(failureStrategy, o);
   }

--- a/core/src/main/java/org/truth0/subjects/PrimitiveDoubleArraySubject.java
+++ b/core/src/main/java/org/truth0/subjects/PrimitiveDoubleArraySubject.java
@@ -35,7 +35,8 @@ import java.util.List;
  * @author Christian Gruber (cgruber@israfil.net)
  */
 @GwtCompatible
-public class PrimitiveDoubleArraySubject extends AbstractArraySubject<double[]> {
+public class PrimitiveDoubleArraySubject
+    extends AbstractArraySubject<PrimitiveDoubleArraySubject, double[]> {
   public PrimitiveDoubleArraySubject(FailureStrategy failureStrategy, double[] o) {
     super(failureStrategy, o);
   }

--- a/core/src/main/java/org/truth0/subjects/PrimitiveFloatArraySubject.java
+++ b/core/src/main/java/org/truth0/subjects/PrimitiveFloatArraySubject.java
@@ -35,7 +35,8 @@ import java.util.List;
  * @author Christian Gruber (cgruber@israfil.net)
  */
 @GwtCompatible
-public class PrimitiveFloatArraySubject extends AbstractArraySubject<float[]> {
+public class PrimitiveFloatArraySubject
+    extends AbstractArraySubject<PrimitiveFloatArraySubject, float[]> {
   public PrimitiveFloatArraySubject(FailureStrategy failureStrategy, float[] o) {
     super(failureStrategy, o);
   }
@@ -109,7 +110,7 @@ public class PrimitiveFloatArraySubject extends AbstractArraySubject<float[]> {
     try {
       float[] expected = (float[]) expectedArray;
       if (actual == expected) {
-        failWithRawMessage("%s unexpectedly equal to %s.",
+        failWithRawMessage("%s unexpectedly equal to %s",
             getDisplaySubject(),  Floats.asList(expected));
       }
       if (expected.length != actual.length) {
@@ -123,7 +124,7 @@ public class PrimitiveFloatArraySubject extends AbstractArraySubject<float[]> {
         }
       }
       if (unequalIndices.isEmpty()) {
-        failWithRawMessage("%s unexpectedly equal to %s.",
+        failWithRawMessage("%s unexpectedly equal to %s",
             getDisplaySubject(),  Floats.asList(expected));
       }
     } catch (ClassCastException ignored) {} // Unequal since they are of different types.
@@ -137,5 +138,4 @@ public class PrimitiveFloatArraySubject extends AbstractArraySubject<float[]> {
   private ListSubject<?, Float, List<Float>> asList() {
     return ListSubject.create(failureStrategy, listRepresentation());
   }
-
 }

--- a/core/src/main/java/org/truth0/subjects/PrimitiveIntArraySubject.java
+++ b/core/src/main/java/org/truth0/subjects/PrimitiveIntArraySubject.java
@@ -30,7 +30,9 @@ import java.util.List;
  * @author Christian Gruber (cgruber@israfil.net)
  */
 @GwtCompatible
-public class PrimitiveIntArraySubject extends AbstractArraySubject<int[]> {
+public class PrimitiveIntArraySubject
+    extends AbstractArraySubject<PrimitiveIntArraySubject, int[]> {
+
   public PrimitiveIntArraySubject(FailureStrategy failureStrategy, int[] o) {
     super(failureStrategy, o);
   }

--- a/core/src/main/java/org/truth0/subjects/PrimitiveLongArraySubject.java
+++ b/core/src/main/java/org/truth0/subjects/PrimitiveLongArraySubject.java
@@ -30,7 +30,8 @@ import java.util.List;
  * @author Christian Gruber (cgruber@israfil.net)
  */
 @GwtCompatible
-public class PrimitiveLongArraySubject extends AbstractArraySubject<long[]> {
+public class PrimitiveLongArraySubject
+    extends AbstractArraySubject<PrimitiveLongArraySubject, long[]> {
   public PrimitiveLongArraySubject(FailureStrategy failureStrategy, long[] o) {
     super(failureStrategy, o);
   }

--- a/core/src/main/java/org/truth0/subjects/StringSubject.java
+++ b/core/src/main/java/org/truth0/subjects/StringSubject.java
@@ -82,7 +82,7 @@ public class StringSubject extends Subject<StringSubject, String> {
 
   public void contains(String string) {
     if (string == null) {
-      throw new IllegalArgumentException("Cannot test that a string contains a null reference.");
+      throw new IllegalArgumentException("Cannot test that a string contains a null reference");
     }
     if (getSubject() == null) {
       failWithRawMessage("Not true that null reference contains <%s>", quote(string));
@@ -94,7 +94,7 @@ public class StringSubject extends Subject<StringSubject, String> {
   public void doesNotContain(String string) {
     if (string == null) {
       throw new IllegalArgumentException(
-              "Cannot test that a string does not contain a null reference.");
+              "Cannot test that a string does not contain a null reference");
     }
     if (getSubject() == null) {
       failWithRawMessage("Not true that null reference contains <%s>", quote(string));
@@ -105,7 +105,7 @@ public class StringSubject extends Subject<StringSubject, String> {
 
   public void startsWith(String string) {
     if (string == null) {
-      throw new IllegalArgumentException("Cannot test that a string starts with a null reference.");
+      throw new IllegalArgumentException("Cannot test that a string starts with a null reference");
     }
     if (getSubject() == null) {
       failWithRawMessage("Not true that null reference starts with <%s>", quote(string));
@@ -116,7 +116,7 @@ public class StringSubject extends Subject<StringSubject, String> {
 
   public void endsWith(String string) {
     if (string == null) {
-      throw new IllegalArgumentException("Cannot test that a string ends with a null reference.");
+      throw new IllegalArgumentException("Cannot test that a string ends with a null reference");
     }
     if (getSubject() == null) {
       failWithRawMessage("Not true that null reference ends with <%s>", quote(string));

--- a/core/src/test/java/org/truth0/RelabeledSubjectsTest.java
+++ b/core/src/test/java/org/truth0/RelabeledSubjectsTest.java
@@ -66,5 +66,14 @@ public class RelabeledSubjectsTest {
     }
   }
 
-
+  @Test public void relabelledPrimitiveFloatArrays() {
+    float[] expected = { 1.3f, 1.0f };
+    float[] actual = { 1.3f, 1.0f };
+    try {
+      ASSERT.that(actual).named("crazy list").isNotEqualTo(expected, 0.0000001f);
+      fail("Should have thrown");
+    } catch (AssertionError error) {
+      ASSERT.that(error.getMessage()).is("\"crazy list\" unexpectedly equal to [1.3, 1.0]");
+    }
+  }
 }

--- a/core/src/test/java/org/truth0/gwt/Inventory.java
+++ b/core/src/test/java/org/truth0/gwt/Inventory.java
@@ -37,7 +37,7 @@ public class Inventory {
   Truth ae;
 
   // Subject
-  AbstractArraySubject<?> a;
+  AbstractArraySubject<?, ?> a;
   BooleanSubject b;
   ClassSubject c;
   DefaultSubject e;

--- a/core/src/test/java/org/truth0/subjects/AbstractArraySubjectTest.java
+++ b/core/src/test/java/org/truth0/subjects/AbstractArraySubjectTest.java
@@ -40,7 +40,8 @@ public class AbstractArraySubjectTest {
     ASSERT.that(subject.getDisplaySubject()).isEqualTo("<(String[]) [Foo, Bar]>");
   }
 
-  class TestableStringArraySubject extends AbstractArraySubject<String[]> {
+  class TestableStringArraySubject
+      extends AbstractArraySubject<TestableStringArraySubject, String[]> {
     public TestableStringArraySubject(FailureStrategy failureStrategy, String[] subject) {
       super(failureStrategy, subject);
     }

--- a/core/src/test/java/org/truth0/subjects/PrimitiveFloatArraySubjectTest.java
+++ b/core/src/test/java/org/truth0/subjects/PrimitiveFloatArraySubjectTest.java
@@ -47,7 +47,8 @@ public class PrimitiveFloatArraySubjectTest {
       ASSERT.that(array(2.2f, 3.3f)).isEqualTo(array(3.3f, 2.2f), DEFAULT_TOLERANCE);
       throw new Error("Expected to throw.");
     } catch (AssertionError e) {
-      ASSERT.that(e.getMessage()).is("Not true that <(float[]) [2.2, 3.3]> is equal to <[3.3, 2.2]>");
+      ASSERT.that(e.getMessage())
+          .isEqualTo("Not true that <(float[]) [2.2, 3.3]> is equal to <[3.3, 2.2]>");
     }
   }
 
@@ -87,7 +88,7 @@ public class PrimitiveFloatArraySubjectTest {
       throw new Error("Expected to throw.");
     } catch (AssertionError e) {
       ASSERT.that(e.getMessage())
-          .is("<(float[]) [2.2, 3.3]> unexpectedly equal to [2.2, 3.3].");
+          .is("<(float[]) [2.2, 3.3]> unexpectedly equal to [2.2, 3.3]");
     }
   }
 
@@ -98,7 +99,7 @@ public class PrimitiveFloatArraySubjectTest {
       throw new Error("Expected to throw.");
     } catch (AssertionError e) {
       ASSERT.that(e.getMessage())
-          .is("<(float[]) [2.2, 3.3]> unexpectedly equal to [2.2, 3.3].");
+          .is("<(float[]) [2.2, 3.3]> unexpectedly equal to [2.2, 3.3]");
     }
   }
 


### PR DESCRIPTION
The simplified generics that were originally used (but weren't used for, say, collections) caused the concrete type to be ignored and the abstract parent type returned from named().

In short, I had to restructure AbstractArraySubject so that implementers pass themselves as a type parameter, which filters back up to "S extends Subject".  This lets methods in Subject that return S actually return the concrete subtype.  AbstractArraySubject was short-circuiting this by interposing a concrete type instead of propagating the type variable. 
