### PR TITLE
Show subject name when string comparison fails

### DIFF
--- a/core/src/main/java/org/truth0/subjects/StringSubject.java
+++ b/core/src/main/java/org/truth0/subjects/StringSubject.java
@@ -61,7 +61,7 @@ public class StringSubject extends Subject<StringSubject, String> {
             getDisplaySubject(), expected.getClass().getName(), expected);
       } else if (!getSubject().equals(expected)) {
         if (expected instanceof String) {
-          failureStrategy.failComparing("", (String) expected, getSubject());
+          failureStrategy.failComparing(getDisplaySubject(), (String) expected, getSubject());
         } else {
           failWithRawMessage("Not true that %s equal to (%s)<%s>",
               getDisplaySubject(), expected.getClass().getName(), expected);


### PR DESCRIPTION
Hi.

It's nice that subjects can be named, but it seems that when comparing strings, the display name of the subject is not used in the error message.