### PR TITLE
Add assertThat() short-cut methods on Truth

### DIFF
--- a/core/src/main/java/com/google/common/truth/Truth.java
+++ b/core/src/main/java/com/google/common/truth/Truth.java
@@ -15,6 +15,15 @@
  */
 package com.google.common.truth;
 
+import com.google.common.base.Optional;
+import com.google.gwt.core.shared.GwtIncompatible;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.CheckReturnValue;
+
 
 /**
  * Truth - a proposition framework for tests, supporting JUnit style
@@ -58,5 +67,105 @@ public class Truth {
 
   /* @deprecated prefer {@link com.google.common.truth.Truth#assert_()}. */
   public static TestVerb assert_() { return ASSERT; }
+
+  private static FailureStrategy getFailureStrategy() {
+    return THROW_ASSERTION_ERROR;
+  }
+
+  @CheckReturnValue
+  public static Subject<DefaultSubject, Object> assertThat(Object target) {
+    return new DefaultSubject(getFailureStrategy(), target);
+  }
+
+  @CheckReturnValue
+  @GwtIncompatible("ClassSubject.java")
+  public static ClassSubject assertThat(Class<?> target) {
+    return new ClassSubject(getFailureStrategy(), target);
+  }
+
+  @CheckReturnValue
+  public static IntegerSubject assertThat(Long target) {
+    return new IntegerSubject(getFailureStrategy(), target);
+  }
+
+  @CheckReturnValue
+  public static IntegerSubject assertThat(Integer target) {
+    return new IntegerSubject(getFailureStrategy(), target);
+  }
+
+  @CheckReturnValue
+  public static BooleanSubject assertThat(Boolean target) {
+    return new BooleanSubject(getFailureStrategy(), target);
+  }
+
+  @CheckReturnValue
+  public static StringSubject assertThat(String target) {
+    return new StringSubject(getFailureStrategy(), target);
+  }
+
+  @CheckReturnValue
+  public static <T, C extends Iterable<T>> IterableSubject<? extends IterableSubject<?, T, C>, T, C>
+      assertThat(Iterable<T> target) {
+    return IterableSubject.create(getFailureStrategy(), target);
+  }
+
+  @CheckReturnValue
+  public static <T, C extends Collection<T>>
+      CollectionSubject<? extends CollectionSubject<?, T, C>, T, C>
+      assertThat(Collection<T> target) {
+    return CollectionSubject.create(getFailureStrategy(), target);
+  }
+
+  @CheckReturnValue
+  public static <T, C extends List<T>> ListSubject<? extends ListSubject<?, T, C>, T, C>
+      assertThat(List<T> target) {
+    return ListSubject.create(getFailureStrategy(), target);
+  }
+
+  @CheckReturnValue
+  public static <T> ObjectArraySubject<T> assertThat(T[] target) {
+    return new ObjectArraySubject<T>(getFailureStrategy(), target);
+  }
+
+  @CheckReturnValue
+  public static PrimitiveBooleanArraySubject assertThat(boolean[] target) {
+    return new PrimitiveBooleanArraySubject(getFailureStrategy(), target);
+  }
+
+  @CheckReturnValue
+  public static PrimitiveIntArraySubject assertThat(int[] target) {
+    return new PrimitiveIntArraySubject(getFailureStrategy(), target);
+  }
+
+  @CheckReturnValue
+  public static PrimitiveLongArraySubject assertThat(long[] target) {
+    return new PrimitiveLongArraySubject(getFailureStrategy(), target);
+  }
+
+  @CheckReturnValue
+  public static PrimitiveCharArraySubject assertThat(char[] target) {
+    return new PrimitiveCharArraySubject(getFailureStrategy(), target);
+  }
+
+  @CheckReturnValue
+  public static PrimitiveFloatArraySubject assertThat(float[] target) {
+    return new PrimitiveFloatArraySubject(getFailureStrategy(), target);
+  }
+
+  @CheckReturnValue
+  public static PrimitiveDoubleArraySubject assertThat(double[] target) {
+    return new PrimitiveDoubleArraySubject(getFailureStrategy(), target);
+  }
+
+  @CheckReturnValue
+  public static <T> OptionalSubject<T> assertThat(Optional<T> target) {
+    return new OptionalSubject<T>(getFailureStrategy(), target);
+  }
+
+  @CheckReturnValue
+  public static <K, V, M extends Map<K, V>> MapSubject<? extends MapSubject<?, K, V, M>, K, V, M>
+      assertThat(Map<K, V> target) {
+    return MapSubject.create(getFailureStrategy(), target);
+  }
 
 }

--- a/core/src/test/java/com/google/common/truth/TruthAssertThatTest.java
+++ b/core/src/test/java/com/google/common/truth/TruthAssertThatTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2014 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.common.truth;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assert_;
+import static java.util.Arrays.asList;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Ordering;
+import com.google.common.reflect.TypeToken;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+/**
+ * Tests for the FEST-alike assertThat() entry point.
+ *
+ * @author Christian Gruber (cgruber@israfil.net)
+ */
+@RunWith(JUnit4.class)
+public class TruthAssertThatTest {
+  private final static Function<Method, TypeToken<?>> METHOD_TO_RETURN_TYPE_TOKEN =
+      new Function<Method, TypeToken<?>>() {
+        @Override public TypeToken<?> apply(Method input) {
+          return TypeToken.of(Iterables.getOnlyElement(asList(input.getParameterTypes())));
+        }
+      };
+
+  @Test public void staticAssertThatMethodsMatchTestVerbInstanceMethods() {
+    ImmutableSortedSet<TypeToken<?>> verbTypes =
+        FluentIterable.from(asList(TestVerb.class.getMethods())).filter(new Predicate<Method>() {
+          @Override public boolean apply(Method input) {
+            return input.getName().equals("that");
+          }
+        }).transform(METHOD_TO_RETURN_TYPE_TOKEN).toSortedSet(Ordering.usingToString());
+    ImmutableSortedSet<TypeToken<?>> truthTypes =
+        FluentIterable.from(asList(Truth.class.getMethods())).filter(new Predicate<Method>() {
+          @Override public boolean apply(Method input) {
+            return input.getName().equals("assertThat")
+                && Modifier.isStatic(input.getModifiers());
+          }
+        }).transform(METHOD_TO_RETURN_TYPE_TOKEN).toSortedSet(Ordering.usingToString());
+
+    assert_().that(verbTypes).isNotEmpty();
+    assert_().that(truthTypes).isNotEmpty();
+    assert_().that(truthTypes).has().exactlyAs(verbTypes);
+  }
+
+  @Test public void festAlike() {
+    assertThat("foo").contains("fo");
+    assertThat(false).isFalse();
+  }
+}


### PR DESCRIPTION
Add `assertThat()` short-cut methods on `Truth`, and implement a test to ensure that no `TestVerb.test()` methods are added without a companion `Truth.assertThat()` method accompanying it.

Note: Internally, the Google core libraries team engaged in discussions on our internal java mailing lists, and it was determined that many people found `ASSERT.that()` disruptive and shouty, and since `assert()` is a non-starter (java keyword), a less disruptive option of `assert_()` was chosen.  However, this resulted in some code that looked like this:

``` java
assertTrue("We're all about junit", someCondition);
assert_().that(fooCollection).has().allOf("a", "b", "c");
assertEquals("a", someString);
```

This was seen as disruptive to the reader.  This commit provides a Hamcrest/FEST-like alias for assertions against the test verb (that is, short-circuiting failure strategy).  It results in code looking like this:

``` java
assertTrue("We're all about junit", someCondition);
assertThat(fooCollection).has().allOf("a", "b", "c");
assertEquals("a", someString);
```

This style introduces a conflict with statically importing hamcrest or FEST assertions, but `Truth.assert_().that()` will remain available (as will `TruthJUnit.assume().that()`).  Users can set project policies around what style they prefer as appropriate for their organization or context.
