### PR TITLE
Un-deprecate org.truth0.Truth (temporarily)

### DIFF
--- a/core/src/main/java/com/google/common/truth/Truth.java
+++ b/core/src/main/java/com/google/common/truth/Truth.java
@@ -54,7 +54,7 @@ public class Truth {
         }
       };
 
-  private static final TestVerb ASSERT = new TestVerb(THROW_ASSERTION_ERROR);
+  public static final TestVerb ASSERT = new TestVerb(THROW_ASSERTION_ERROR);
 
   public static TestVerb assert_() { return ASSERT; }
 

--- a/core/src/main/java/com/google/common/truth/TruthJUnit.java
+++ b/core/src/main/java/com/google/common/truth/TruthJUnit.java
@@ -66,11 +66,12 @@ public class TruthJUnit {
       };
 
   @GwtIncompatible("JUnit4")
-  private static final TestVerb ASSUME = new TestVerb(THROW_ASSUMPTION_ERROR);
+  public static final TestVerb ASSUME = new TestVerb(THROW_ASSUMPTION_ERROR);
 
   @GwtIncompatible("JUnit4")
   public static final TestVerb assume() { return ASSUME; }
 
+  @SuppressWarnings("serial") // Super serial.
   @GwtIncompatible("JUnit4")
   private static class ThrowableAssumptionViolatedException extends AssumptionViolatedException {
     public ThrowableAssumptionViolatedException(String message, Throwable throwable) {
@@ -78,6 +79,6 @@ public class TruthJUnit {
       if (throwable != null) initCause(throwable);
     }
   }
-  
+
   private TruthJUnit() {}
 }

--- a/core/src/main/java/org/truth0/Truth.java
+++ b/core/src/main/java/org/truth0/Truth.java
@@ -21,26 +21,28 @@ import com.google.common.truth.TruthJUnit;
 import com.google.gwt.core.shared.GwtIncompatible;
 
 /**
- * @deprecated please use {@link com.google.common.truth.Truth#assert_()} and
+ * deprecated please use {@link com.google.common.truth.Truth#assert_()} and
  *     {@link TruthJUnit#assume()} to access these capabilities.
  */
-@Deprecated
+//Deprecated
 public class Truth {
+  /** @deprecated prefer {@link com.google.common.truth.Truth#THROW_ASSERTION_ERROR}. */
   @Deprecated
   public static final FailureStrategy THROW_ASSERTION_ERROR =
           com.google.common.truth.Truth.THROW_ASSERTION_ERROR;
 
+  /** @deprecated prefer {@link com.google.common.truth.TruthJUnit#THROW_ASSUMPTION_ERROR}. */
   @Deprecated
   @GwtIncompatible("JUnit4")
   public static final FailureStrategy THROW_ASSUMPTION_ERROR =
           com.google.common.truth.TruthJUnit.THROW_ASSUMPTION_ERROR;
 
-  // TODO(cgruber): @deprecated prefer {@link com.google.common.truth.Truth#assert_()}. */
-  // TODO(cgruber): @Deprecated
+  // TODO(cgruber): deprecated prefer {@link com.google.common.truth.Truth#assert_()}. */
+  //Deprecated
   public static final TestVerb ASSERT = com.google.common.truth.Truth.assert_();
 
-  // TODO(cgruber): @deprecated prefer {@link com.google.common.truth.TruthJUnit#assume()}. */
-  // TODO(cgruber): @Deprecated
+  // TODO(cgruber): deprecated prefer {@link com.google.common.truth.TruthJUnit#assume()}. */
+  //Deprecated
   @GwtIncompatible("JUnit4")
   public static final TestVerb ASSUME = com.google.common.truth.TruthJUnit.assume();
 }


### PR DESCRIPTION
Un-deprecate org.truth0.Truth (temporarily, to not warnings-spam people during migration, and make public the equivalent c.g.common.truth.Truth.CONSTANTS for easier migration.
