### PR TITLE
use correct only 1.8 range for java8 profile

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -204,7 +204,7 @@
   <profile>
     <id>java8</id>
     <activation>
-      <jdk>[1.8,1.8)</jdk>
+      <jdk>[1.8,)</jdk>
     </activation>
     <properties>
       <javadoc.param>-Xdoclint:none</javadoc.param>


### PR DESCRIPTION
This existing range breaks Intellij
![screen shot 2014-09-03 at 2 23 01 pm](https://cloud.githubusercontent.com/assets/4166092/4141688/89006222-33b0-11e4-8c84-1b8969e9b5d8.png)

The provided range syntax conforms to maven range syntax http://maven.apache.org/enforcer/enforcer-rules/versionRanges.html
