### PR TITLE
Fix handling of multiple proposition arguments when using thatEach()

### DIFF
--- a/core/src/main/java/com/google/common/truth/codegen/IteratingWrapperClassBuilder.java
+++ b/core/src/main/java/com/google/common/truth/codegen/IteratingWrapperClassBuilder.java
@@ -165,7 +165,7 @@ public class IteratingWrapperClassBuilder {
     StringBuilder builder = new StringBuilder();
     for (int i = 0; i < length; i++) {
       if (i > 0) builder.append(", ");
-      builder.append("arg").append(0);
+      builder.append("arg").append(i);
     }
     return builder;
   }

--- a/core/src/test/java/com/google/common/truth/IterationOverSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/IterationOverSubjectTest.java
@@ -18,7 +18,11 @@ package com.google.common.truth;
 import static com.google.common.truth.IntegerSubject.INTEGER;
 import static com.google.common.truth.LongSubject.LONG;
 import static com.google.common.truth.StringSubject.STRING;
+import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assert_;
+
+import com.google.common.truth.delegation.Foo;
+import com.google.common.truth.delegation.FooSubject;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -71,6 +75,17 @@ public class IterationOverSubjectTest {
       if (e.getMessage().startsWith("Expected assertion to fail")) {
         throw e;
       }
+    }
+  }
+
+  @Test public void collectionPropositionWithMultipleArguments() {
+    Iterable<Foo> data = iterable(new Foo(2 + 3), new Foo(2 + 4));
+    assert_().in(data).thatEach(FooSubject.FOO).matchesEither(new Foo(5), new Foo(6));
+    try {
+      assert_().in(data).thatEach(FooSubject.FOO).matchesEither(new Foo(6), new Foo(7));
+      assert_().fail("Expected assertion to fail on element 1.");
+    } catch (AssertionError e) {
+      assertThat(e.getMessage()).contains("Not true that <Foo(5)> matches one of <Foo(6)> <Foo(7)>");
     }
   }
 

--- a/core/src/test/java/com/google/common/truth/delegation/Foo.java
+++ b/core/src/test/java/com/google/common/truth/delegation/Foo.java
@@ -29,4 +29,8 @@ public class Foo {
     this.value = value;
   }
 
+  @Override
+  public String toString() {
+    return "Foo(" + value + ")";
+  }
 }

--- a/core/src/test/java/com/google/common/truth/delegation/FooSubject.java
+++ b/core/src/test/java/com/google/common/truth/delegation/FooSubject.java
@@ -39,8 +39,13 @@ public class FooSubject extends Subject<FooSubject, Foo> {
 
   public void matches(Foo object) {
     if (getSubject().value != object.value) {
-      fail("matches", getSubject(), object);
+      fail("matches", object);
     }
   }
 
+  public void matchesEither(Foo object1, Foo object2) {
+    if (getSubject().value != object1.value && getSubject().value != object2.value) {
+      fail("matches one of", object1, object2);
+    }
+  }
 }


### PR DESCRIPTION
Fixes #144: proposition arguments used in

    assert_().in(...).thatEach(SF).proposition(arg1, arg2)

should be forward as-is to the original subject, instead of passing
arg1 multiple times.
