### PR TITLE
Make AbstractArraySubject compatible with SubjectFactory

### DIFF
--- a/core/src/main/java/com/google/common/truth/AbstractArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/AbstractArraySubject.java
@@ -25,7 +25,7 @@ import java.util.List;
  * @author Christian Gruber (cgruber@israfil.net)
  */
 public abstract class AbstractArraySubject<S extends AbstractArraySubject<S, T>, T>
-    extends Subject<AbstractArraySubject<S, T>, T> {
+    extends Subject<S, T> {
 
   AbstractArraySubject(FailureStrategy failureStrategy, T subject) {
     super(failureStrategy, subject);

--- a/core/src/test/java/com/google/common/truth/AbstractArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/AbstractArraySubjectTest.java
@@ -16,6 +16,7 @@
 package com.google.common.truth;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assert_;
 
 import com.google.common.truth.AbstractArraySubject;
 import com.google.common.truth.FailureStrategy;
@@ -40,6 +41,19 @@ public class AbstractArraySubjectTest {
     String[] strings = { "Foo", "Bar" };
     TestableStringArraySubject subject = new TestableStringArraySubject(failureStrategy, strings);
     assertThat(subject.getDisplaySubject()).isEqualTo("<(String[]) [Foo, Bar]>");
+  }
+
+  @Test public void canBeUsedInSubjectFactories() {
+    // This will fail to compile if the super-type of AbstractArraySubject
+    // is incompatible with the generic bounds of SubjectFactory.
+    class TestSubjectFactory extends SubjectFactory<TestableStringArraySubject, String[]> {
+      @Override public TestableStringArraySubject getSubject(FailureStrategy fs, String[] that) {
+        return new TestableStringArraySubject(fs, that);
+      }
+    }
+
+    String[] strings = { "foo", "bar" };
+    assert_().about(new TestSubjectFactory()).that(strings).hasLength(2);
   }
 
   class TestableStringArraySubject


### PR DESCRIPTION
Change the supertype of `AbstractArraySubject<S, T>` to `Subject<S, T>`.
This enables deriving classes to the be used with `SubjectFactory`.

The old supertype (`Subject<AbstractArraySubject<S>, T>`) was not
compatible; for example, attempting to instantiate a
`SubjectFactory<PrimitiveIntArraySubject, int[]>` would be a
compile-time error due to SubjectFactory's generic constraints.

I'm not thrilled with the accompanying test; it's not clear to me how
(or whether) compile-time facts should be verified in a test suite. I'd love
to hear thoughts or ideas about that, if anyone has them.
