### PR TITLE
Alternative approach to GWT-JDK8 compatibility.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>truth</artifactId>
   <properties>
     <javadoc.param></javadoc.param>
-    <gwt.version>2.7.0</gwt.version>
+    <gwt.version>2.6.1</gwt.version>
   </properties>
   <dependencies>
     <dependency>
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>1.0-rc1</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -94,7 +94,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.4</version>
         <executions>
           <execution>
             <phase>post-integration-test</phase>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -123,11 +123,11 @@
                 <include>**/*.gwt.xml</include>
               </includes>
               <excludes>
-                <exclude>org/truth0/codegen/**</exclude>
-                <exclude>org/truth0/subjects/ClassSubject.java</exclude>
-                <exclude>org/truth0/util/ReflectionUtil.java</exclude>
-                <exclude>org/truth0/IteratingVerb.java</exclude>
-                <exclude>org/truth0/Expect.java</exclude>
+                <exclude>com/google/common/truth/ClassSubject.java</exclude>
+                <exclude>com/google/common/truth/Expect.java</exclude>
+                <exclude>com/google/common/truth/IteratingVerb.java</exclude>
+                <exclude>com/google/common/truth/ReflectionUtil.java</exclude>
+                <exclude>com/google/common/truth/codegen/**</exclude>
               </excludes>
             </configuration>
           </execution>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -152,6 +152,7 @@
             <configuration>
               <mode>htmlunit</mode>
               <productionMode>true</productionMode>
+              <sourceLevel>1.7</sourceLevel>
               <userAgents>gecko1_8</userAgents>
               <includes>**/*GwtTest.java</includes>
             </configuration>

--- a/core/src/main/java/com/google/common/truth/ClassSubject.java
+++ b/core/src/main/java/com/google/common/truth/ClassSubject.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.GwtIncompatible;
  *
  * @author Kurt Alfred Kluever
  */
+@GwtIncompatible("reflection")
 public class ClassSubject extends Subject<ClassSubject, Class<?>> {
   ClassSubject(FailureStrategy failureStrategy, Class<?> o) {
     super(failureStrategy, o);
@@ -34,7 +35,6 @@ public class ClassSubject extends Subject<ClassSubject, Class<?>> {
    * @deprecated Use either {@code assertThat(instance).isInstanceOf(clazz)} or {code
    *     assertThat(clazzA).isAssignableTo(clazzB)} instead.
    */
-  @GwtIncompatible("isAssignableFrom")
   @Deprecated
   public void isAssignableFrom(Class<?> clazz) {
     if (!getSubject().isAssignableFrom(clazz)) {
@@ -46,7 +46,6 @@ public class ClassSubject extends Subject<ClassSubject, Class<?>> {
    * Fails if this class or interface is not the same as or a subclass or subinterface of,
    * the given class or interface.
    */
-  @GwtIncompatible("isAssignableFrom")
   public void isAssignableTo(Class<?> clazz) {
     if (!clazz.isAssignableFrom(getSubject())) {
       fail("is assignable to", clazz);
@@ -54,7 +53,6 @@ public class ClassSubject extends Subject<ClassSubject, Class<?>> {
   }
 
   // TODO(user): Create an alternative implementation using JSNI.
-  @GwtIncompatible("Reflection")
   public void declaresField(String fieldName) {
     if (getSubject() == null) {
       failureStrategy.fail("Cannot determine a field name from a null class.");

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,41 @@
           </execution>
         </executions>
       </plugin>
+
+      <!-- Work around slow group resolution, similar to https://github.com/sonatype/plexus-io/commit/da38b3d0966b44d5a980b71038dff593fde2b815 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-io</artifactId>
+            <version>2.0.9</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-io</artifactId>
+            <version>2.0.9</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-io</artifactId>
+            <version>2.0.9</version>
+          </dependency>
+        </dependencies>
+      </plugin>
     </plugins>
   </build>
   <developers>


### PR DESCRIPTION
Plus some assorted fixes that don't necessarily have to be part of the same pull request.

After this pull request, I can run `mvn clean install` for Truth (under both JDK7 and JDK8).