### PR TITLE
Add StringSubject.isEqualToIgnoreCase

### DIFF
--- a/core/src/main/java/com/google/common/truth/StringSubject.java
+++ b/core/src/main/java/com/google/common/truth/StringSubject.java
@@ -72,6 +72,15 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
     }
   }
 
+  public void isEqualToIgnoreCase(CharSequence expected) {
+    checkNotNull(expected);
+    if (getSubject() == null) {
+      failWithRawMessage("Not true that null reference is case insensitive equal to <%s>", quote(expected));
+    } else if (!getSubject().equalsIgnoreCase(expected.toString())) {
+      fail("is equal to ignoring case", quote(expected));
+    }
+  }
+
   /**
    * @deprecated Use {@link #isEqualTo} instead. String comparison is consistent with equality.
    */

--- a/core/src/test/java/com/google/common/truth/SubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/SubjectTest.java
@@ -341,6 +341,19 @@ public class SubjectTest {
     }
   }
 
+  @Test public void isEqualToIgnoreCase() {
+    assertThat("aB").isEqualToIgnoreCase("Ab");
+  }
+
+  @Test public void isEqualToIgnoreCaseFailure() {
+    try {
+      assertThat("a").isEqualToIgnoreCase("b");
+      fail("Should have thrown.");
+    } catch (AssertionError e) {
+      assertThat(e).hasMessage("Not true that <\"a\"> is equal to ignoring case <\"b\">");
+    }
+  }
+
   @Test public void isEqualToFailureWithDifferentTypesAndSameToString() {
     Object a = "true";
     Object b = true;


### PR DESCRIPTION
Sometimes you have to test for string equality while not caring about case sensitivity e.g. when you work with data coming from a case insensitive source (like MySQL with some collation). Includes unit tests.

CLA will follow.
