### PR TITLE
Some improvements to release and travis tooling.

### DIFF
--- a/util/generate-latest-docs.sh
+++ b/util/generate-latest-docs.sh
@@ -1,24 +1,55 @@
-# see http://benlimmer.com/2013/12/26/automatically-publish-javadoc-to-gh-pages-with-travis-ci/ for details
+#!/bin/bash
+# A script to automatically deploy javadocs.
+#
+# This script is useful both in a travis-ci.org regular build, where it will generate
+# javadocs (aggregated) via a maven build, and deploy them to github pages. This script
+# is derived from instructions given in this blog article:
+# http://benlimmer.com/2013/12/26/automatically-publish-javadoc-to-gh-pages-with-travis-ci/
+#
+# If the RELEASE_VERSION environment variable is set, then it will perform a similar
+# action, but push to a versioned api docs folder, under the current user's credentials
+# rather than using an encrypted secret via github's GH_TOKEN mechanism.  Users who
+# use the script this way must have a .ssh key which they have declared on github.com
+# per the instructions here: https://help.github.com/articles/generating-ssh-keys/
+#
+readonly GH_PROJECT=truth
+readonly ORG=google
+readonly EXPECTED_REPO_SLUG="${ORG}/${GH_PROJECT}"
 
-if [ "$TRAVIS_REPO_SLUG" == "google/truth" ] && \
-   [ "$TRAVIS_JDK_VERSION" == "oraclejdk7" ] && \
-   [ "$TRAVIS_PULL_REQUEST" == "false" ] && \
-   [ "$TRAVIS_BRANCH" == "master" ]; then
+if [[ -n "$RELEASE_VERSION" || \
+    "$TRAVIS_REPO_SLUG" == "$EXPECTED_REPO_SLUG" && \
+    "$TRAVIS_JDK_VERSION" == "oraclejdk7" && \
+    "$TRAVIS_PULL_REQUEST" == "false" && \
+    "$TRAVIS_BRANCH" == "master" ]]; then
   echo -e "Publishing javadoc...\n"
+
+  if [ -n "$RELEASE_VERSION" ]; then
+    # Release
+    version_subdir=api/${RELEASE_VERSION}
+    github_url="git@github.com:${EXPECTED_REPO_SLUG}.git"
+    commit_message="Release $RELEASE_VERSION javadoc pushed to gh-pages."
+  else
+    # Travis
+    version_subdir=api/latest
+    github_url="https://${GH_TOKEN}@github.com/${EXPECTED_REPO_SLUG}"
+    commit_message="Lastest javadoc on successful travis build $TRAVIS_BUILD_NUMBER auto-pushed to gh-pages."
+  fi
   
   mvn javadoc:aggregate
-  TARGET="$(pwd)/target"
-
-  cd $HOME
-  git clone --quiet --branch=gh-pages https://${GH_TOKEN}@github.com/google/truth gh-pages > /dev/null
-  
+  target_dir="$(pwd)/target"
+  cd ${target_dir}
+  git clone --quiet --branch=gh-pages ${github_url} gh-pages > /dev/null
   cd gh-pages
-  git config --global user.email "travis@travis-ci.org"
-  git config --global user.name "travis-ci"
-  git rm -rf api/latest 
-  mv ${TARGET}/site/apidocs api/latest
-  git add -A -f api/latest
-  git commit -m "Lastest javadoc on successful travis build $TRAVIS_BUILD_NUMBER auto-pushed to gh-pages"
+
+  if [[ -z "$RELEASE_VERSION" ]]; then
+    git config --global user.email "travis@travis-ci.org"
+    git config --global user.name "travis-ci"
+  fi
+  api_version_dir="${target_dir}/gh-pages/${version_subdir}"
+  git rm -rf ${api_version_dir}
+  mv ${target_dir}/site/apidocs ${api_version_dir}
+  git add -A -f ${api_version_dir}
+  git commit -m "${commit_message}"
   git push -fq origin gh-pages > /dev/null
 
   echo -e "Published Javadoc to gh-pages.\n"

--- a/util/mvn-deploy.sh
+++ b/util/mvn-deploy.sh
@@ -1,21 +1,57 @@
 #!/bin/bash
-if [ $# -lt 1 ]; then
-  echo "usage $0 <ssl-key> [<param> ...]"
-  exit 1;
-fi
-key=${1}
-shift
-params=${@}
+keys="$(gpg --list-keys | grep ^pub | sed 's#/# #' | awk '{ print $3 }')"
+key_count="$(echo ${keys} | wc -w)"
 
-#validate key
-keystatus=$(gpg --list-keys | grep ${key} | awk '{print $1}')
-if [ "${keystatus}" != "pub" ]; then
-  echo "Could not find public key with label ${key}"
-  echo -n "Available keys from: "
-  gpg --list-keys | grep --invert-match '^sub'
+seen=""
+while [[ $# > 0 ]] ; do
+  param="$1"
+  case $param in
+    --signing-key)
+      # disambiguating or overriding key
+      key="$2"
+      shift
+    ;;
+    *)
+      seen="${seen} ${param}"
+    ;;
+  esac
+  shift
+done
+params=${seen}
 
+if [[ ${key_count} -lt 1 ]]; then
+  echo ""
+  echo "You are attempting to deploy a maven release without a GPG signing key."
+  echo "You need to generate a signing key in accordance with the instructions"
+  echo "found at http://blog.sonatype.com/2010/01/how-to-generate-pgp-signatures-with-maven"
   exit 1
 fi
 
-mvn ${params} clean site:jar -P sonatype-oss-release -Dgpg.keyname=${key} deploy
+# if a key is specified, use that, else use the default, unless there are many
+if [[ -n "${key}" ]]; then 
+  #validate key
+  keystatus=$(gpg --list-keys | grep ${key} | awk '{print $1}')
+  if [ "${keystatus}" != "pub" ]; then
+    echo ""
+    echo "Could not find public key with label \"${key}\""
+    echo ""
+    echo "Available keys from: "
+    gpg --list-keys | grep --invert-match '^sub'
+    exit 1
+  fi
+
+  key_param="-Dgpg.keyname=${key}"
+elif [ ${key_count} -gt 1 ]; then
+  echo ""
+  echo "You are attempting to deploy a maven release but have more than one GPG"
+  echo "signing key and did not specify which one you wish to sign with."
+  echo ""
+  echo "usage $0 [--signing-key <ssl-key>] [<maven params> ...]"
+  echo ""
+  echo -n "Available keys from: "
+  gpg --list-keys | grep --invert-match '^sub'
+  exit 1;
+fi
+
+mvn ${params} clean site:jar -P sonatype-oss-release ${key_param} deploy
 


### PR DESCRIPTION
These don't put us in a "one-script-to-release" situation, but they improve the existing scripts to suck less, and leave us in a better place to do releases.

Notably the generate-latest-docs.sh is now able to take a RELEASE_VERSION env variable and deploy javadocs to gh-pages for that release to api/${RELEASE_VERSION} (pushing whatever is in the current checked out repo contents, so use with caution, such as at a checked-out release tag). If the RELEASE_VERSION is elided, it will behave as before, pushing to gh-pages into api/latest