### PR TITLE
Re-work the failure message storage so that it is not stored in the Verb

### DIFF
--- a/core/src/main/java/com/google/common/truth/StringUtil.java
+++ b/core/src/main/java/com/google/common/truth/StringUtil.java
@@ -70,6 +70,10 @@ final class StringUtil {
       builder.append(args[i++]);
       templateStart = placeholderStart + 2;
     }
+    if (template.indexOf("%s", templateStart) >= 0) {
+      throw new IllegalStateException(
+          "Too many parameters for " + args.length + " argument: \"" + template + "\"");
+    }
     builder.append(template.substring(templateStart));
 
     // if we run out of placeholders, append the extra args in square braces
@@ -84,5 +88,21 @@ final class StringUtil {
     }
 
     return builder.toString();
+  }
+
+  /**
+   * Returns the number of {@code %s} placeholders in the template.
+   */
+  static int countOfPlaceholders(@Nullable String template) {
+    template = String.valueOf(template); // null -> "null"
+    int templateStart = 0;
+    int count = 0;
+    int placeholderStart = template.indexOf("%s", templateStart);
+    while (placeholderStart != -1) {
+      templateStart = placeholderStart + 2;
+      count++;
+      placeholderStart = template.indexOf("%s", templateStart);
+    }
+    return count;
   }
 }

--- a/core/src/test/java/com/google/common/truth/AbstractVerbTest.java
+++ b/core/src/test/java/com/google/common/truth/AbstractVerbTest.java
@@ -17,9 +17,6 @@ package com.google.common.truth;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.truth.AbstractVerb;
-import com.google.common.truth.FailureStrategy;
-
 import org.junit.Test;
 import org.junit.experimental.theories.DataPoints;
 import org.junit.experimental.theories.Theories;
@@ -27,8 +24,6 @@ import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
 
 import java.util.concurrent.atomic.AtomicReference;
-
-import javax.annotation.CheckReturnValue;
 
 /**
  * Tests for AbstractVerbs.
@@ -47,24 +42,19 @@ public class AbstractVerbTest {
         }
       };
 
-  private static final AbstractVerb<?> CAPTURE_FAILURE =
-      new AbstractVerb(FAILURE_STRATEGY) {
-        @Override
-        @CheckReturnValue
-        public AbstractVerb<?> withFailureMessage(String failureMessage) {
-          throw new UnsupportedOperationException();
-        }
+  private static final AbstractVerb<?> CAPTURE_FAILURE = new TestVerb(FAILURE_STRATEGY);
 
-        @Override
-        protected String getFailureMessage() {
-          return null;
-        }
+  static class TestVerb extends AbstractVerb<TestVerb> {
+    private TestVerb(FailureStrategy fs) {
+      super(fs);
+    }
 
-        @Override
-        protected boolean hasFailureMessage() {
-          return false;
-        }
-      };
+    @Override
+    public TestVerb withFailureMessage(String format, Object ... args) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
   @DataPoints public static String[] strings = new String[] {"a", "b"};
 
   @Test

--- a/core/src/test/java/com/google/common/truth/CustomFailureMessageTest.java
+++ b/core/src/test/java/com/google/common/truth/CustomFailureMessageTest.java
@@ -35,13 +35,6 @@ import org.junit.runners.JUnit4;
 public class CustomFailureMessageTest {
 
   @Test
-  public void hasFailureMessage() {
-    assertThat(assertWithMessage(null).hasFailureMessage()).isFalse();
-    assertThat(assertWithMessage("foo").hasFailureMessage()).isTrue();
-    assertThat(assertWithMessage("foo %s", "foo").hasFailureMessage()).isTrue();
-  }
-
-  @Test
   public void assertWithMessageIsPrepended() {
     try {
       assertWithMessage("Invalid month").that(13).isIn(Range.closed(1, 12));

--- a/core/src/test/java/com/google/common/truth/PrimitiveDoubleArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveDoubleArraySubjectTest.java
@@ -21,8 +21,6 @@ import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
 import static java.lang.Math.nextAfter;
 
-import com.google.common.truth.PrimitiveDoubleArraySubject;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/core/src/test/java/com/google/common/truth/PrimitiveFloatArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveFloatArraySubjectTest.java
@@ -21,8 +21,6 @@ import static java.lang.Float.NaN;
 import static java.lang.Float.POSITIVE_INFINITY;
 import static java.lang.Math.nextAfter;
 
-import com.google.common.truth.PrimitiveFloatArraySubject;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/core/src/test/java/com/google/common/truth/StringUtilTest.java
+++ b/core/src/test/java/com/google/common/truth/StringUtilTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2011 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.common.truth;
+
+import static com.google.common.truth.StringUtil.countOfPlaceholders;
+import static com.google.common.truth.StringUtil.format;
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.Assert.fail;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for String Subjects.
+ *
+ * @author David Saff
+ * @author Christian Gruber (cgruber@israfil.net)
+ */
+@RunWith(JUnit4.class)
+public class StringUtilTest {
+  @Test
+  public void nullTemplate() {
+    assertThat(format(null)).isEqualTo("null");
+  }
+
+  @Test
+  public void noArgs() {
+    assertThat(format("foo")).isEqualTo("foo");
+  }
+
+  @Test
+  public void simpleReplacement() {
+    assertThat(format("%s", "foo")).isEqualTo("foo");
+  }
+
+  @Test
+  public void simpleNonStringReplacement() {
+    assertThat(format("%s", 1L)).isEqualTo("1");
+  }
+
+  @Test
+  public void multipleReplacement() {
+    assertThat(format("%s: %s", 1L, true)).isEqualTo("1: true");
+  }
+
+  @Test
+  public void tooManyArguments() {
+    assertThat(format("%s", 1L, true)).isEqualTo("1 [true]");
+  }
+
+  @Test
+  public void tooManyPlaceholders() {
+    try {
+    assertThat(format("%s: %s", true)).isEqualTo("1 [true]");
+    fail("Expected to throw");
+    } catch (IllegalStateException expected) {
+      assertThat(expected).hasMessage("Too many parameters for 1 argument: \"%s: %s\"");
+    }
+  }
+
+  @Test
+  public void placeholderCountNull() {
+    assertThat(countOfPlaceholders(null)).isEqualTo(0);
+  }
+
+
+  @Test
+  public void placeholderCountNone() {
+    assertThat(countOfPlaceholders("foo")).isEqualTo(0);
+  }
+
+  @Test
+  public void placeholderCountOne() {
+    assertThat(countOfPlaceholders("foo%sfoo")).isEqualTo(1);
+  }
+
+  @Test
+  public void placeholderCountMany() {
+    assertThat(countOfPlaceholders("foo%sfoo%s%s%s 3s%s")).isEqualTo(5);
+  }
+
+}

--- a/core/src/test/java/com/google/common/truth/SubjectCheckTest.java
+++ b/core/src/test/java/com/google/common/truth/SubjectCheckTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2015 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.common.truth;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for String Subjects.
+ *
+ * @author David Saff
+ * @author Christian Gruber (cgruber@israfil.net)
+ */
+@RunWith(JUnit4.class)
+public class SubjectCheckTest {
+
+  private static class MySubject extends Subject<MySubject, String> {
+    private MySubject(FailureStrategy failureStrategy, String subject) {
+      super(failureStrategy, subject);
+    }
+
+    public void isPropagatingMessage() {
+      check().that("foo").isEqualTo("bar");
+    }
+  }
+
+  @Test
+  public void checkPreservesOverriddenMessage() {
+    try{
+      assertWithMessage("blah").about(new SubjectFactory<MySubject, String>() {
+        @Override
+        public MySubject getSubject(FailureStrategy fs, String that) {
+          return new MySubject(fs, that);
+        }
+      }).that("").isPropagatingMessage();
+    } catch (AssertionError expected) {
+      assertThat(expected.getMessage()).startsWith("blah: ");
+    }
+  }
+
+  @Test
+  public void throwOnDoubleCallToWithFailureMessage() {
+    try{
+      assertWithMessage("blah").withFailureMessage("foo");
+    } catch (IllegalStateException expected) {
+      assertThat(expected)
+          .hasMessage("Overriding failure message has already been set for this call-chain.");
+    }
+  }
+}


### PR DESCRIPTION
Previously it was stored in AbstractVerb, and accessed by a delegating failure message which stored the TestVerb.  There's no real reason to keep a TestVerb around when we already have a new instance of FailureStrategy which delegates, so this change moves the storage of the overriding failure message to the delegating FailureStrategy instance.

This fixes issue #199 where check() doesn't preserve the failure message, because it doesn't have proper access to the original verb.

While in the area added proper tests for StringUtil, and make it properly throw when there are too many placeholders.
