### PR TITLE
Fixed jar URL from Maven's Central Repository

### DIFF
--- a/index.md
+++ b/index.md
@@ -155,7 +155,7 @@ or download the jar directly from the link below and add it to
 your tests classpath
 
 {% highlight text %}
-http://search.maven.org/remotecontent?filepath=org/truth0/truth/{{site.version}}/truth-{{site.version}}.jar
+http://search.maven.org/remotecontent?filepath=com/google/truth/truth/{{site.version}}/truth-{{site.version}}.jar
 {% endhighlight %}
 
 # More Detailed Usage Information


### PR DESCRIPTION
In the index.md from the website, the URL to the jar seems to be wrong. In this minimal PR I replaced the URL with the one from http://search.maven.org/