### PR TITLE
TravisCI: Cache downloaded Maven dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,6 @@ after_success:
   - bash util/generate-latest-docs.sh
   - bash util/publish-snapshot-on-commit.sh
 
+cache:
+  directories:
+    - $HOME/.m2


### PR DESCRIPTION
With container-based builds, we can use Travis' built-in caching layer to speed up test runs significantly.
This change causes `~/.m2` to be cached between builds, so only new/updated dependencies need to be downloaded during build.

This cuts test times for my fork in Travis by about a minute.
