### PR TITLE
Methods named equals should override Object.equals(Object)

### DIFF
--- a/core/src/main/java/com/google/common/truth/DoubleSubject.java
+++ b/core/src/main/java/com/google/common/truth/DoubleSubject.java
@@ -101,7 +101,7 @@ public final class DoubleSubject extends ComparableSubject<DoubleSubject, Double
             actual, "actual value cannot be null. tolerance=%s expected=%s", tolerance, expected);
         checkTolerance(tolerance);
 
-        if (!MathUtil.equals(actual, expected, tolerance)) {
+        if (!MathUtil.isEquals(actual, expected, tolerance)) {
           failWithRawMessage(
               "%s and <%s> should have been finite values within <%s> of each other",
               getDisplaySubject(),

--- a/core/src/main/java/com/google/common/truth/FloatSubject.java
+++ b/core/src/main/java/com/google/common/truth/FloatSubject.java
@@ -101,7 +101,7 @@ public final class FloatSubject extends ComparableSubject<FloatSubject, Float> {
             actual, "actual value cannot be null. tolerance=%s expected=%s", tolerance, expected);
         checkTolerance(tolerance);
 
-        if (!MathUtil.equals(actual, expected, tolerance)) {
+        if (!MathUtil.isEquals(actual, expected, tolerance)) {
           failWithRawMessage(
               "%s and <%s> should have been finite values within <%s> of each other",
               getDisplaySubject(),

--- a/core/src/main/java/com/google/common/truth/MathUtil.java
+++ b/core/src/main/java/com/google/common/truth/MathUtil.java
@@ -29,7 +29,7 @@ public final class MathUtil {
    * each other. Note that both this method and {@link #notEquals} returns false if either {@code
    * left} or {@code right} is infinite or NaN.
    */
-  public static boolean equals(double left, double right, double tolerance) {
+  public static boolean isEquals(double left, double right, double tolerance) {
     return Math.abs(left - right) <= Math.abs(tolerance);
   }
 
@@ -38,8 +38,8 @@ public final class MathUtil {
    * each other. Note that both this method and {@link #notEquals} returns false if either {@code
    * left} or {@code right} is infinite or NaN.
    */
-  public static boolean equals(float left, float right, float tolerance) {
-    return equals((double) left, (double) right, (double) tolerance);
+  public static boolean isEquals(float left, float right, float tolerance) {
+    return isEquals((double) left, (double) right, (double) tolerance);
   }
 
   /**

--- a/core/src/main/java/com/google/common/truth/PrimitiveDoubleArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveDoubleArraySubject.java
@@ -97,7 +97,7 @@ public class PrimitiveDoubleArraySubject
       }
       List<Integer> unequalIndices = new ArrayList<Integer>();
       for (int i = 0; i < expectedArray.length; i++) {
-        if (!MathUtil.equals(actual[i], expectedArray[i], tolerance)) {
+        if (!MathUtil.isEquals(actual[i], expectedArray[i], tolerance)) {
           unequalIndices.add(i);
         }
       }
@@ -151,7 +151,7 @@ public class PrimitiveDoubleArraySubject
       }
       List<Integer> unequalIndices = new ArrayList<Integer>();
       for (int i = 0; i < expected.length; i++) {
-        if (!MathUtil.equals(actual[i], expected[i], tolerance)) {
+        if (!MathUtil.isEquals(actual[i], expected[i], tolerance)) {
           unequalIndices.add(i);
         }
       }
@@ -242,7 +242,7 @@ public class PrimitiveDoubleArraySubject
           // if expected is longer than actual, we can skip the excess values: this case is covered
           // by the length check below
           if (expectedCount < actual.length
-              && !MathUtil.equals(actual[expectedCount], expectedValue.doubleValue(), tolerance)) {
+              && !MathUtil.isEquals(actual[expectedCount], expectedValue.doubleValue(), tolerance)) {
             mismatches.add(expectedCount);
           }
           expectedCount++;

--- a/core/src/main/java/com/google/common/truth/PrimitiveFloatArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveFloatArraySubject.java
@@ -97,7 +97,7 @@ public class PrimitiveFloatArraySubject
       }
       List<Integer> unequalIndices = new ArrayList<Integer>();
       for (int i = 0; i < expectedArray.length; i++) {
-        if (!MathUtil.equals(actual[i], expectedArray[i], tolerance)) {
+        if (!MathUtil.isEquals(actual[i], expectedArray[i], tolerance)) {
           unequalIndices.add(i);
         }
       }
@@ -151,7 +151,7 @@ public class PrimitiveFloatArraySubject
       }
       List<Integer> unequalIndices = new ArrayList<Integer>();
       for (int i = 0; i < expected.length; i++) {
-        if (!MathUtil.equals(actual[i], expected[i], tolerance)) {
+        if (!MathUtil.isEquals(actual[i], expected[i], tolerance)) {
           unequalIndices.add(i);
         }
       }
@@ -242,7 +242,7 @@ public class PrimitiveFloatArraySubject
           // if expected is longer than actual, we can skip the excess values: this case is covered
           // by the length check below
           if (expectedCount < actual.length
-              && !MathUtil.equals(actual[expectedCount], expectedValue.floatValue(), tolerance)) {
+              && !MathUtil.isEquals(actual[expectedCount], expectedValue.floatValue(), tolerance)) {
             mismatches.add(expectedCount);
           }
           expectedCount++;

--- a/core/src/test/java/com/google/common/truth/MathUtilTest.java
+++ b/core/src/test/java/com/google/common/truth/MathUtilTest.java
@@ -32,33 +32,33 @@ import org.junit.runners.JUnit4;
 public class MathUtilTest {
   @Test
   public void floatEquals() {
-    assertThat(MathUtil.equals(1.3f, 1.3f, 0.00000000000001f)).isTrue();
-    assertThat(MathUtil.equals(1.3f, 1.3f, 0.0f)).isTrue();
-    assertThat(MathUtil.equals(0.0f, 1.0f + 2.0f - 3.0f, 0.00000000000000000000000000000001f))
+    assertThat(MathUtil.isEquals(1.3f, 1.3f, 0.00000000000001f)).isTrue();
+    assertThat(MathUtil.isEquals(1.3f, 1.3f, 0.0f)).isTrue();
+    assertThat(MathUtil.isEquals(0.0f, 1.0f + 2.0f - 3.0f, 0.00000000000000000000000000000001f))
         .isTrue();
-    assertThat(MathUtil.equals(1.3f, 1.303f, 0.004f)).isTrue();
-    assertThat(MathUtil.equals(1.3f, 1.303f, 0.002f)).isFalse();
-    assertThat(MathUtil.equals(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY, 0.01f)).isFalse();
-    assertThat(MathUtil.equals(Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, 0.01f)).isFalse();
-    assertThat(MathUtil.equals(Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY, 0.01f)).isFalse();
-    assertThat(MathUtil.equals(Float.NaN, Float.NaN, 0.01f)).isFalse();
+    assertThat(MathUtil.isEquals(1.3f, 1.303f, 0.004f)).isTrue();
+    assertThat(MathUtil.isEquals(1.3f, 1.303f, 0.002f)).isFalse();
+    assertThat(MathUtil.isEquals(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY, 0.01f)).isFalse();
+    assertThat(MathUtil.isEquals(Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, 0.01f)).isFalse();
+    assertThat(MathUtil.isEquals(Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY, 0.01f)).isFalse();
+    assertThat(MathUtil.isEquals(Float.NaN, Float.NaN, 0.01f)).isFalse();
   }
 
   @Test
   public void doubleEquals() {
-    assertThat(MathUtil.equals(1.3d, 1.3d, 0.00000000000001d)).isTrue();
-    assertThat(MathUtil.equals(1.3d, 1.3d, 0.0d)).isTrue();
-    assertThat(MathUtil.equals(0.0d, 1.0d + 2.0d - 3.0d, 0.00000000000000000000000000000001d))
+    assertThat(MathUtil.isEquals(1.3d, 1.3d, 0.00000000000001d)).isTrue();
+    assertThat(MathUtil.isEquals(1.3d, 1.3d, 0.0d)).isTrue();
+    assertThat(MathUtil.isEquals(0.0d, 1.0d + 2.0d - 3.0d, 0.00000000000000000000000000000001d))
         .isTrue();
-    assertThat(MathUtil.equals(1.3d, 1.303d, 0.004d)).isTrue();
-    assertThat(MathUtil.equals(1.3d, 1.303d, 0.002d)).isFalse();
-    assertThat(MathUtil.equals(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, 0.01d))
+    assertThat(MathUtil.isEquals(1.3d, 1.303d, 0.004d)).isTrue();
+    assertThat(MathUtil.isEquals(1.3d, 1.303d, 0.002d)).isFalse();
+    assertThat(MathUtil.isEquals(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, 0.01d))
         .isFalse();
-    assertThat(MathUtil.equals(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, 0.01d))
+    assertThat(MathUtil.isEquals(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, 0.01d))
         .isFalse();
-    assertThat(MathUtil.equals(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, 0.01d))
+    assertThat(MathUtil.isEquals(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, 0.01d))
         .isFalse();
-    assertThat(MathUtil.equals(Double.NaN, Double.NaN, 0.01d)).isFalse();
+    assertThat(MathUtil.isEquals(Double.NaN, Double.NaN, 0.01d)).isFalse();
   }
 
   @Test
@@ -97,8 +97,8 @@ public class MathUtilTest {
 
   @Test
   public void equalsDifferentTypes() {
-    assertThat(MathUtil.equals(1.3d, 1.3f, 0.00000000000001d)).isFalse();
-    assertThat(MathUtil.equals(1.3f, 1.3d, 0.00000000000001f)).isFalse();
+    assertThat(MathUtil.isEquals(1.3d, 1.3f, 0.00000000000001d)).isFalse();
+    assertThat(MathUtil.isEquals(1.3f, 1.3d, 0.00000000000001f)).isFalse();
   }
 
   // TODO(cgruber): More complicated ways to break float/double casting to make sure.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1201 Methods named equals should override Object.equals(Object)

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1201

Please let me know if you have any questions.

Zeeshan