### PR TITLE
Code Improvements: remove dead stores, local var shadow issue, Utility classes private constructor

### DIFF
--- a/core/src/main/java/com/google/common/truth/ObjectArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/ObjectArraySubject.java
@@ -175,11 +175,10 @@ public class ObjectArraySubject<T> extends AbstractArraySubject<ObjectArraySubje
   @Nullable
   private String checkArrayEqualsRecursive(
       Object expectedArray, Object actualArray, String lastIndex) {
-    String index = "";
     int actualLength = Platform.getArrayLength(actualArray);
     int expectedLength = Platform.getArrayLength(expectedArray);
     for (int i = 0; i < actualLength || i < expectedLength; i++) {
-      index = lastIndex + "[" + i + "]";
+      String index = lastIndex + "[" + i + "]";
       if (i < expectedLength && i < actualLength) {
         Object expected = Platform.getFromArray(expectedArray, i);
         Object actual = Platform.getFromArray(actualArray, i);

--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -103,18 +103,18 @@ public class Subject<S extends Subject<S, T>, T> {
 
   private void doEqualCheck(
       @Nullable Object rawSubject, @Nullable Object rawOther, boolean expectEqual) {
-    Object subject;
+    Object localSubject;
     Object other;
     if (isIntegralBoxedPrimitive(rawSubject) && isIntegralBoxedPrimitive(rawOther)) {
-      subject = integralValue(rawSubject);
+      localSubject = integralValue(rawSubject);
       other = integralValue(rawOther);
     } else {
-      subject = rawSubject;
+      localSubject = rawSubject;
       other = rawOther;
     }
-    if (Objects.equal(subject, other) != expectEqual) {
+    if (Objects.equal(localSubject, other) != expectEqual) {
       failComparingToStrings(
-          expectEqual ? "is equal to" : "is not equal to", subject, other, rawOther, expectEqual);
+          expectEqual ? "is equal to" : "is not equal to", localSubject, other, rawOther, expectEqual);
     }
   }
 
@@ -361,8 +361,8 @@ public class Subject<S extends Subject<S, T>, T> {
    * @param verb the proposition being asserted
    */
   protected void failWithoutSubject(String verb) {
-    String subject = this.customName == null ? "the subject" : "\"" + customName + "\"";
-    failureStrategy.fail(format("Not true that %s %s", subject, verb));
+    String strSubject = this.customName == null ? "the subject" : "\"" + customName + "\"";
+    failureStrategy.fail(format("Not true that %s %s", strSubject, verb));
   }
 
   /**

--- a/core/src/main/java/com/google/common/truth/SubjectUtils.java
+++ b/core/src/main/java/com/google/common/truth/SubjectUtils.java
@@ -27,6 +27,10 @@ import java.util.List;
  * @author Christian Gruber
  */
 final class SubjectUtils {
+	
+  private SubjectUtils(){
+	throw new AssertionError("Must not instantiate this class");
+  }
 
   static <T> List<T> accumulate(T first, T second, T... rest) {
     // rest should never be deliberately null, so assume that the caller passed null

--- a/core/src/main/java/com/google/common/truth/Truth.java
+++ b/core/src/main/java/com/google/common/truth/Truth.java
@@ -69,6 +69,11 @@ import javax.annotation.Nullable;
  */
 @CheckReturnValue
 public final class Truth {
+
+  private Truth(){
+	throw new AssertionError("Must not instantiate this class");
+  }
+
   public static final FailureStrategy THROW_ASSERTION_ERROR =
       new FailureStrategy() {
         @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1854 dead stores should be removed,
squid:S1118 Utility classes should not have public constructors, 
squid:HiddenFieldCheck Local variable should not shadow class fields

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1854
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118
https://dev.eclipse.org/sonar/coding_rules#q=squid:HiddenFieldCheck

Please let me know if you have any questions.

Zeeshan
