### PR TITLE
Remove Useless parentheses

### DIFF
--- a/core/src/main/java/com/google/common/truth/AbstractVerb.java
+++ b/core/src/main/java/com/google/common/truth/AbstractVerb.java
@@ -29,7 +29,7 @@ public abstract class AbstractVerb<T extends AbstractVerb<T>> {
   }
 
   protected FailureStrategy getFailureStrategy() {
-    return (hasFailureMessage())
+    return hasFailureMessage()
         ? new MessagePrependingFailureStrategy(failureStrategy, this)
         : failureStrategy;
   }

--- a/core/src/main/java/com/google/common/truth/IterableSubject.java
+++ b/core/src/main/java/com/google/common/truth/IterableSubject.java
@@ -376,7 +376,7 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
         verb,
         expected,
         failVerb,
-        ((actual == null) ? "null reference" : actual),
+        (actual == null) ? "null reference" : actual,
         suffix);
   }
 

--- a/core/src/main/java/com/google/common/truth/Platform.java
+++ b/core/src/main/java/com/google/common/truth/Platform.java
@@ -118,7 +118,7 @@ public final class Platform {
   }
 
   private static String stripIfPrefixed(String string, String prefix) {
-    return (string.startsWith(prefix)) ? string.substring(prefix.length()) : string;
+    return string.startsWith(prefix) ? string.substring(prefix.length()) : string;
   }
 
   private static String stripIfInPackage(String type, String packagePrefix) {

--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -333,7 +333,7 @@ public class Subject<S extends Subject<S, T>, T> {
             verb,
             expected,
             failVerb,
-            ((actual == null) ? "null reference" : actual));
+            (actual == null) ? "null reference" : actual);
     failureStrategy.fail(message);
   }
 
@@ -349,7 +349,7 @@ public class Subject<S extends Subject<S, T>, T> {
     String message =
         format(
             "Not true that <%s> %s <%s>",
-            ((actual == null) ? "null reference" : actual),
+            (actual == null) ? "null reference" : actual,
             verb,
             expected);
     failureStrategy.fail(message);

--- a/core/src/main/java/com/google/common/truth/TestVerb.java
+++ b/core/src/main/java/com/google/common/truth/TestVerb.java
@@ -205,7 +205,7 @@ public class TestVerb extends AbstractVerb<TestVerb> {
 
   @Override
   protected boolean hasFailureMessage() {
-    return (format != null);
+    return format != null;
   }
 
   static int countPlaceholders(@Nullable String template) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck Useless parentheses around expressions should be removed to prevent any misunderstanding

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/coding_rules#q=squid:UselessParenthesesCheck


Please let me know if you have any questions.

Zeeshan