### PR TITLE
Code Improvments: Reorder modifiers, equality for floating numbers, remove duplicate strings

### DIFF
--- a/core/src/main/java/com/google/common/truth/DoubleSubject.java
+++ b/core/src/main/java/com/google/common/truth/DoubleSubject.java
@@ -183,7 +183,7 @@ public final class DoubleSubject extends ComparableSubject<DoubleSubject, Double
         doubleToLongBits(tolerance) != NEG_ZERO_BITS,
         "tolerance (%s) cannot be negative",
         tolerance);
-    checkArgument(tolerance != Double.POSITIVE_INFINITY, "tolerance cannot be POSITIVE_INFINITY");
+    checkArgument(Double.doubleToRawLongBits(tolerance) != Double.POSITIVE_INFINITY, "tolerance cannot be POSITIVE_INFINITY");
   }
 
   /**

--- a/core/src/main/java/com/google/common/truth/Expect.java
+++ b/core/src/main/java/com/google/common/truth/Expect.java
@@ -94,7 +94,7 @@ public class Expect extends TestVerb implements TestRule {
   }
 
   @AutoValue
-  static abstract class ExpectationFailure {
+  abstract static class ExpectationFailure {
     static ExpectationFailure create(String message, Throwable cause) {
       return new AutoValue_Expect_ExpectationFailure(message, cause);
     }

--- a/core/src/main/java/com/google/common/truth/FloatSubject.java
+++ b/core/src/main/java/com/google/common/truth/FloatSubject.java
@@ -180,7 +180,7 @@ public final class FloatSubject extends ComparableSubject<FloatSubject, Float> {
     checkArgument(tolerance >= 0.0f, "tolerance (%s) cannot be negative", tolerance);
     checkArgument(
         floatToIntBits(tolerance) != NEG_ZERO_BITS, "tolerance (%s) cannot be negative", tolerance);
-    checkArgument(tolerance != Float.POSITIVE_INFINITY, "tolerance cannot be POSITIVE_INFINITY");
+    checkArgument(Float.floatToRawIntBits(tolerance) != Float.POSITIVE_INFINITY, "tolerance cannot be POSITIVE_INFINITY");
   }
 
   /**

--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -38,6 +38,8 @@ public class Subject<S extends Subject<S, T>, T> {
   protected final FailureStrategy failureStrategy;
   private final T subject;
   private String customName = null;
+  private static final String IS_AN_INSTANCE_OF = "is an instance of";
+  private static final String NOT_TRUE_THAT = "Not true that ";
 
   public Subject(FailureStrategy failureStrategy, @Nullable T subject) {
     this.failureStrategy = checkNotNull(failureStrategy);
@@ -164,12 +166,12 @@ public class Subject<S extends Subject<S, T>, T> {
     if (!Platform.isInstanceOfType(getSubject(), clazz)) {
       if (getSubject() != null) {
         failWithBadResults(
-            "is an instance of",
+        	IS_AN_INSTANCE_OF,
             clazz.getName(),
-            "is an instance of",
+            IS_AN_INSTANCE_OF,
             getSubject().getClass().getName());
       } else {
-        fail("is an instance of", clazz.getName());
+        fail(IS_AN_INSTANCE_OF, clazz.getName());
       }
     }
   }
@@ -258,7 +260,7 @@ public class Subject<S extends Subject<S, T>, T> {
    * @param verb the proposition being asserted
    */
   protected void fail(String verb) {
-    failureStrategy.fail("Not true that " + getDisplaySubject() + " " + verb);
+    failureStrategy.fail(NOT_TRUE_THAT + getDisplaySubject() + " " + verb);
   }
 
   /**
@@ -275,7 +277,7 @@ public class Subject<S extends Subject<S, T>, T> {
   private void failComparingToStrings(
       String verb, Object subject, Object other, Object displayOther, boolean compareToStrings) {
     StringBuilder message =
-        new StringBuilder("Not true that ").append(getDisplaySubject()).append(" ");
+        new StringBuilder(NOT_TRUE_THAT).append(getDisplaySubject()).append(" ");
     // If the subject and parts aren't null, and they have equal toString()'s but different
     // classes, we need to disambiguate them.
     boolean neitherNull = (other != null) && (subject != null);
@@ -308,7 +310,7 @@ public class Subject<S extends Subject<S, T>, T> {
     } else if (messageParts.length == 1) {
       fail(verb, messageParts[0]);
     } else {
-      StringBuilder message = new StringBuilder("Not true that ");
+      StringBuilder message = new StringBuilder(NOT_TRUE_THAT);
       message.append(getDisplaySubject()).append(" ").append(verb);
       for (Object part : messageParts) {
         message.append(" <").append(part).append(">");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:ModifiersOrderCheck Modifiers should be declared in the correct order
squid:S1244 Floating point numbers should not be tested for equality
squid:S1192 String literals should not be duplicated

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/coding_rules#q=squid:ModifiersOrderCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1244
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1192


Please let me know if you have any questions.

Zeeshan