### PR TITLE
Add ThrowableSubject.hasMessageContaining()

### DIFF
--- a/core/src/main/java/com/google/common/truth/ThrowableSubject.java
+++ b/core/src/main/java/com/google/common/truth/ThrowableSubject.java
@@ -15,6 +15,8 @@
  */
 package com.google.common.truth;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.base.Objects;
 
 import javax.annotation.Nullable;
@@ -36,6 +38,18 @@ public final class ThrowableSubject extends Subject<ThrowableSubject, Throwable>
   public void hasMessage(@Nullable String message) {
     if (!Objects.equal(message, getSubject().getMessage())) {
       fail("has message", message);
+    }
+  }
+
+  /**
+   * Fails if the subject's message does not contain the given sequence.
+   */
+  public void hasMessageContaining(CharSequence string) {
+    checkNotNull(string);
+    if (getSubject().getMessage() == null) {
+      failWithRawMessage("Not true that null message reference contains <%s>", string);
+    } else if (!getSubject().getMessage().contains(string)) {
+      fail("has message containing", string);
     }
   }
 

--- a/core/src/test/java/com/google/common/truth/ThrowableTest.java
+++ b/core/src/test/java/com/google/common/truth/ThrowableTest.java
@@ -77,6 +77,47 @@ public class ThrowableTest {
   }
 
   @Test
+  public void hasMessageContaining() {
+    NullPointerException npe = new NullPointerException("abc");
+    assertThat(npe).hasMessageContaining("b");
+  }
+
+  @Test
+  public void hasMessageContaining_failure() {
+    NullPointerException npe = new NullPointerException("abc");
+    try {
+      assertThat(npe).hasMessageContaining("foobar");
+      throw new Error("Expected to fail.");
+    } catch (AssertionError expected) {
+      assertThat(expected.getMessage()).isEqualTo(
+          "Not true that <java.lang.NullPointerException: abc> has message containing <foobar>");
+    }
+  }
+
+  @Test
+  public void hasMessageContaining_HasNullMessage_failure() {
+    NullPointerException npe = new NullPointerException();
+    try {
+      assertThat(npe).hasMessageContaining("foobar");
+      throw new Error("Expected to fail.");
+    } catch (AssertionError expected) {
+      assertThat(expected.getMessage()).isEqualTo(
+          "Not true that null message reference contains <foobar>");
+    }
+  }
+
+  @Test
+  public void hasMessageContaining_NullMessageExpected_failure() {
+    NullPointerException npe = new NullPointerException("abc");
+    try {
+      assertThat(npe).hasMessageContaining(null);
+      throw new Error("Expected to fail.");
+    } catch (NullPointerException expected) {
+      // Expected
+    }
+  }
+
+  @Test
   public void inheritedMethodChainsSubject() {
     NullPointerException expected = new NullPointerException("expected");
     NullPointerException actual = new NullPointerException("actual");


### PR DESCRIPTION
I frequently run into Throwable messages that are either very long or contain non-deterministic values (e.g. Java's default toString()). This method allows for assertions on the partial contents of a Throwable's message.