### PR TITLE
Fix a minor bug in some sample code in a Javadoc

### DIFF
--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/FieldScopes.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/FieldScopes.java
@@ -39,7 +39,7 @@ public final class FieldScopes {
    * // Fails, because actual.getBaz() != expected.getBaz().
    * assertThat(actual).isEqualTo(expected);
    *
-   * Foo scope = Foo.newBuilder().setBar(2);
+   * Foo scope = Foo.newBuilder().setBar(2).build();
    * // Succeeds, because only the field 'bar' is compared.
    * assertThat(actual).withPartialScope(FieldScopes.fromSetFields(scope)).isEqualTo(expected);
    *


### PR DESCRIPTION
The sample code in the documentation for FieldScopes.fromSetFields was missing a build().