### PR TITLE
Arrayequals

### DIFF
--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -131,7 +131,7 @@ public class Subject<S extends Subject<S, T>, T> {
       subject = rawSubject;
       other = rawOther;
     }
-    if (doCheckEquals(subject, other) != expectEqual) {
+    if (Objects.equal(subject, other) != expectEqual) {
       failComparingToStrings(
           expectEqual ? "is equal to" : "is not equal to", subject, other, rawOther, expectEqual);
     }
@@ -153,64 +153,6 @@ public class Subject<S extends Subject<S, T>, T> {
     } else {
       throw new AssertionError(o + " must be either a Character or a Number.");
     }
-  }
-  
-  private static boolean doCheckEquals(Object subject, Object other) {
-    if (subject instanceof boolean[]) {
-      if (other instanceof boolean[]) {
-        return Arrays.equals((boolean[]) subject, (boolean[]) other);
-      }
-      return false;
-    }
-    if (subject instanceof int[]) {
-      if (other instanceof int[]) {
-        return Arrays.equals((int[]) subject, (int[]) other);
-      }
-      return false;
-    } 
-    if (subject instanceof long[]) {
-      if (other instanceof long[]) {
-        return Arrays.equals((long[]) subject, (long[]) other);
-      }
-      return false;
-    } 
-    if (subject instanceof short[]) {
-      if (other instanceof short[]) {
-        return Arrays.equals((short[]) subject, (short[]) other);
-      }
-      return false;
-    } 
-    if (subject instanceof byte[]) {
-      if (other instanceof byte[]) {
-        return Arrays.equals((byte[]) subject, (byte[]) other);
-      }
-      return false;
-    } 
-    if (subject instanceof double[]) {
-      if (other instanceof double[]) {
-        return Arrays.equals((double[]) subject, (double[]) other);
-      }
-      return false;
-    } 
-    if (subject instanceof float[]) {
-      if (other instanceof float[]) {
-        return Arrays.equals((float[]) subject, (float[]) other);
-      }
-      return false;
-    } 
-    if (subject instanceof char[]) {
-      if (other instanceof char[]) {
-        return Arrays.equals((char[]) subject, (char[]) other);
-      }
-      return false;
-    } 
-    if (subject instanceof Object[]) {
-      if (other instanceof Object[]) {
-        return Arrays.equals((Object[]) subject, (Object[]) other);
-      }
-      return false;
-    }
-    return Objects.equal(subject, other);
   }
 
   /** Fails if the subject is not the same instance as the given object. */

--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -210,7 +210,7 @@ public class Subject<S extends Subject<S, T>, T> {
       }
       return false;
     }
-    return Objects.equal(other, subject);
+    return Objects.equal(subject, other);
   }
 
   /** Fails if the subject is not the same instance as the given object. */

--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -23,6 +23,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -130,7 +131,7 @@ public class Subject<S extends Subject<S, T>, T> {
       subject = rawSubject;
       other = rawOther;
     }
-    if (Objects.equal(subject, other) != expectEqual) {
+    if (doCheckEquals(subject, other) != expectEqual) {
       failComparingToStrings(
           expectEqual ? "is equal to" : "is not equal to", subject, other, rawOther, expectEqual);
     }
@@ -152,6 +153,64 @@ public class Subject<S extends Subject<S, T>, T> {
     } else {
       throw new AssertionError(o + " must be either a Character or a Number.");
     }
+  }
+  
+  private static boolean doCheckEquals(Object subject, Object other) {
+    if (subject instanceof boolean[]) {
+      if (other instanceof boolean[]) {
+        return Arrays.equals((boolean[]) subject, (boolean[]) other);
+      }
+      return false;
+    }
+    if (subject instanceof int[]) {
+      if (other instanceof int[]) {
+        return Arrays.equals((int[]) subject, (int[]) other);
+      }
+      return false;
+    } 
+    if (subject instanceof long[]) {
+      if (other instanceof long[]) {
+        return Arrays.equals((long[]) subject, (long[]) other);
+      }
+      return false;
+    } 
+    if (subject instanceof short[]) {
+      if (other instanceof short[]) {
+        return Arrays.equals((short[]) subject, (short[]) other);
+      }
+      return false;
+    } 
+    if (subject instanceof byte[]) {
+      if (other instanceof byte[]) {
+        return Arrays.equals((byte[]) subject, (byte[]) other);
+      }
+      return false;
+    } 
+    if (subject instanceof double[]) {
+      if (other instanceof double[]) {
+        return Arrays.equals((double[]) subject, (double[]) other);
+      }
+      return false;
+    } 
+    if (subject instanceof float[]) {
+      if (other instanceof float[]) {
+        return Arrays.equals((float[]) subject, (float[]) other);
+      }
+      return false;
+    } 
+    if (subject instanceof char[]) {
+      if (other instanceof char[]) {
+        return Arrays.equals((char[]) subject, (char[]) other);
+      }
+      return false;
+    } 
+    if (subject instanceof Object[]) {
+      if (other instanceof Object[]) {
+        return Arrays.equals((Object[]) subject, (Object[]) other);
+      }
+      return false;
+    }
+    return Objects.equal(other, subject);
   }
 
   /** Fails if the subject is not the same instance as the given object. */

--- a/core/src/main/java/com/google/common/truth/TestVerb.java
+++ b/core/src/main/java/com/google/common/truth/TestVerb.java
@@ -18,6 +18,7 @@ package com.google.common.truth;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.GwtIncompatible;
+import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
@@ -26,6 +27,7 @@ import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Table;
 import com.google.common.util.concurrent.AtomicLongMap;
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -58,8 +60,8 @@ public class TestVerb extends AbstractVerb<TestVerb> {
     return new BigDecimalSubject(getFailureStrategy(), target);
   }
 
-  public Subject<DefaultSubject, Object> that(@Nullable Object target) {
-    return new DefaultSubject(getFailureStrategy(), target);
+  public Subject<? extends Subject<?, ?>, ?> that(@Nullable Object target) {
+    return getSubject(target);
   }
 
   @GwtIncompatible("ClassSubject.java")
@@ -216,5 +218,37 @@ public class TestVerb extends AbstractVerb<TestVerb> {
   @Override
   public TestVerb withMessage(@Nullable String format, Object /* @NullableType */... args) {
     return new TestVerb(getFailureStrategy(), format, args); // Must be a new instance.
+  }
+  
+  private Subject<?, ?> getSubject(Object subject) {
+    FailureStrategy failureStrategy = getFailureStrategy();
+    if (subject instanceof boolean[]) {
+      return new PrimitiveBooleanArraySubject(failureStrategy, (boolean[]) subject);
+    }
+    if (subject instanceof int[]) {
+      return new PrimitiveIntArraySubject(failureStrategy, (int[]) subject);
+    } 
+    if (subject instanceof long[]) {
+      return new PrimitiveLongArraySubject(failureStrategy, (long[]) subject);
+    } 
+    if (subject instanceof short[]) {
+      return new PrimitiveShortArraySubject(failureStrategy, (short[]) subject);
+    } 
+    if (subject instanceof byte[]) {
+      return new PrimitiveByteArraySubject(failureStrategy, (byte[]) subject);
+    } 
+    if (subject instanceof double[]) {
+      return new PrimitiveDoubleArraySubject(failureStrategy, (double[]) subject);
+    } 
+    if (subject instanceof float[]) {
+      return new PrimitiveFloatArraySubject(failureStrategy, (float[]) subject);
+    } 
+    if (subject instanceof char[]) {
+      return new PrimitiveCharArraySubject(failureStrategy, (char[]) subject);
+    } 
+    if (subject instanceof Object[]) {
+      return new ObjectArraySubject(failureStrategy, (Object[]) subject);
+    }
+    return new DefaultSubject(getFailureStrategy(), subject);
   }
 }

--- a/core/src/main/java/com/google/common/truth/Truth.java
+++ b/core/src/main/java/com/google/common/truth/Truth.java
@@ -164,7 +164,7 @@ public final class Truth {
     return assert_().that(target);
   }
 
-  public static Subject<DefaultSubject, Object> assertThat(@Nullable Object target) {
+  public static Subject<?, ?> assertThat(@Nullable Object target) {
     return assert_().that(target);
   }
 

--- a/core/src/test/java/com/google/common/truth/SubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/SubjectTest.java
@@ -361,6 +361,13 @@ public class SubjectTest {
   }
 
   @Test
+  public void isEqualToWithArrays() {
+    Object a = new byte[] {1, 2, 3};
+    Object b = new byte[] {1, 2, 3};;
+    assertThat(a).isEqualTo(b);
+  }
+
+  @Test
   public void isEqualToFailureWithObjects() {
     Object a = OBJECT_1;
     Object b = OBJECT_2;

--- a/core/src/test/java/com/google/common/truth/SubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/SubjectTest.java
@@ -361,9 +361,20 @@ public class SubjectTest {
   }
 
   @Test
-  public void isEqualToWithArrays() {
+  public void isEqualToWithByteArrays() {
     Object a = new byte[] {1, 2, 3};
-    Object b = new byte[] {1, 2, 3};;
+    Object b = new byte[] {1, 2, 3};
+    assertThat(a).isEqualTo(b);
+  }
+
+  @Test
+  public void isEqualToWithObjectArrays() {
+    Integer i1 = Integer.valueOf(1);
+    Integer i2 = Integer.valueOf(2);
+    Integer i3 = Integer.valueOf(3);
+    
+    Object a = new Integer[] {i1, i2, i3};
+    Object b = new Integer[] {i1, i2, i3};
     assertThat(a).isEqualTo(b);
   }
 


### PR DESCRIPTION
As explained on #335, current implementation of Subject.isEqualTo doesn't work properly when subject and/or other are arrays. As suggested on the issue thread, I have created a PR trying to fix that. The code is tested by two new tests on SubjectTest and it is a little bit more verbose than necessary to do not use reflexion (so it can be  be compatible, AFAIK, with GWT).