### PR TITLE
Moe Sync

### DIFF
--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/DiffResult.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/DiffResult.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Sets;
 import com.google.common.truth.extensions.proto.RecursableDiffEntity.WithResultCode.Result;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.ForOverride;
+import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
 import com.google.protobuf.UnknownFieldSet;
 import java.util.Set;
@@ -52,7 +53,10 @@ abstract class DiffResult extends RecursableDiffEntity.WithoutResultCode {
    */
   @AutoValue
   abstract static class SingularField extends RecursableDiffEntity.WithResultCode {
-    /** The human-readable name of the field compared. */
+    /** The type information for this field. May be absent if result code is {@code IGNORED}. */
+    abstract Optional<FieldDescriptorOrUnknown> fieldDescriptorOrUnknown();
+
+    /** The display name for this field. May include an array-index specifier. */
     abstract String fieldName();
 
     /** The field under test. */
@@ -99,6 +103,9 @@ abstract class DiffResult extends RecursableDiffEntity.WithoutResultCode {
     abstract static class Builder {
       abstract Builder setResult(Result result);
 
+      abstract Builder setFieldDescriptorOrUnknown(
+          FieldDescriptorOrUnknown fieldDescriptorOrUnknown);
+
       abstract Builder setFieldName(String fieldName);
 
       abstract Builder setActual(Object actual);
@@ -132,6 +139,9 @@ abstract class DiffResult extends RecursableDiffEntity.WithoutResultCode {
      */
     @AutoValue
     abstract static class PairResult extends RecursableDiffEntity.WithResultCode {
+      /** The {@link FieldDescriptor} describing the repeated field for this pair. */
+      abstract FieldDescriptor fieldDescriptor();
+
       /** The index of the element in the {@code actual()} list that was matched. */
       abstract Optional<Integer> actualFieldIndex();
 
@@ -165,6 +175,8 @@ abstract class DiffResult extends RecursableDiffEntity.WithoutResultCode {
       abstract static class Builder {
         abstract Builder setResult(Result result);
 
+        abstract Builder setFieldDescriptor(FieldDescriptor fieldDescriptor);
+
         abstract Builder setActualFieldIndex(int actualFieldIndex);
 
         abstract Builder setExpectedFieldIndex(int expectedFieldIndex);
@@ -179,8 +191,8 @@ abstract class DiffResult extends RecursableDiffEntity.WithoutResultCode {
       }
     }
 
-    /** The human-readable name of the field compared. */
-    abstract String fieldName();
+    /** The {@link FieldDescriptor} for this repeated field. */
+    abstract FieldDescriptor fieldDescriptor();
 
     /** The elements under test. */
     abstract ImmutableList<Object> actual();
@@ -207,7 +219,7 @@ abstract class DiffResult extends RecursableDiffEntity.WithoutResultCode {
     @CanIgnoreReturnValue
     @AutoValue.Builder
     abstract static class Builder {
-      abstract Builder setFieldName(String fieldName);
+      abstract Builder setFieldDescriptor(FieldDescriptor fieldDescriptor);
 
       abstract Builder setActual(Iterable<?> actual);
 

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/FieldDescriptorOrUnknown.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/FieldDescriptorOrUnknown.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.truth.extensions.proto;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Optional;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+
+/** An 'Either' of a {@link FieldDescriptor} or {@link UnknownFieldDescriptor}. */
+@AutoValue
+abstract class FieldDescriptorOrUnknown {
+  static FieldDescriptorOrUnknown fromFieldDescriptor(FieldDescriptor fieldDescriptor) {
+    return new AutoValue_FieldDescriptorOrUnknown(
+        Optional.of(fieldDescriptor), Optional.<UnknownFieldDescriptor>absent());
+  }
+
+  static FieldDescriptorOrUnknown fromUnknown(UnknownFieldDescriptor unknownFieldDescriptor) {
+    return new AutoValue_FieldDescriptorOrUnknown(
+        Optional.<FieldDescriptor>absent(), Optional.of(unknownFieldDescriptor));
+  }
+
+  abstract Optional<FieldDescriptor> fieldDescriptor();
+
+  abstract Optional<UnknownFieldDescriptor> unknownFieldDescriptor();
+
+  /** Returns a short, human-readable version of this identifier. */
+  final String shortName() {
+    if (fieldDescriptor().isPresent()) {
+      return fieldDescriptor().get().isExtension()
+          ? "[" + fieldDescriptor().get() + "]"
+          : fieldDescriptor().get().getName();
+    } else {
+      return String.valueOf(unknownFieldDescriptor().get().fieldNumber());
+    }
+  }
+}

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/FieldNumberTree.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/FieldNumberTree.java
@@ -20,8 +20,6 @@ import com.google.auto.value.AutoValue;
 import com.google.common.base.Optional;
 import com.google.common.collect.Maps;
 import com.google.common.truth.extensions.proto.MessageDifferencer.SpecificField;
-import com.google.common.truth.extensions.proto.ProtoTruthMessageDifferencer.FieldDescriptorOrUnknown;
-import com.google.common.truth.extensions.proto.ProtoTruthMessageDifferencer.UnknownFieldDescriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
 import com.google.protobuf.UnknownFieldSet;

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/FieldScopeLogic.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/FieldScopeLogic.java
@@ -29,7 +29,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.truth.extensions.proto.MessageDifferencer.IgnoreCriteria;
 import com.google.common.truth.extensions.proto.MessageDifferencer.SpecificField;
-import com.google.common.truth.extensions.proto.ProtoTruthMessageDifferencer.FieldDescriptorOrUnknown;
 import com.google.common.truth.extensions.proto.ProtoTruthMessageDifferencer.ShouldIgnore;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/UnknownFieldDescriptor.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/UnknownFieldDescriptor.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.truth.extensions.proto;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.UnknownFieldSet;
+import com.google.protobuf.WireFormat;
+import java.util.List;
+
+/** Convenience class encapsulating type information for unknown fields. */
+@AutoValue
+abstract class UnknownFieldDescriptor {
+
+  enum Type {
+    VARINT(WireFormat.WIRETYPE_VARINT) {
+      @Override
+      public List<?> getValues(UnknownFieldSet.Field field) {
+        return field.getVarintList();
+      }
+    },
+    FIXED32(WireFormat.WIRETYPE_FIXED32) {
+      @Override
+      public List<?> getValues(UnknownFieldSet.Field field) {
+        return field.getFixed32List();
+      }
+    },
+    FIXED64(WireFormat.WIRETYPE_FIXED64) {
+      @Override
+      public List<?> getValues(UnknownFieldSet.Field field) {
+        return field.getFixed64List();
+      }
+    },
+    LENGTH_DELIMITED(WireFormat.WIRETYPE_LENGTH_DELIMITED) {
+      @Override
+      public List<?> getValues(UnknownFieldSet.Field field) {
+        return field.getLengthDelimitedList();
+      }
+    },
+    GROUP(WireFormat.WIRETYPE_START_GROUP) {
+      @Override
+      public List<?> getValues(UnknownFieldSet.Field field) {
+        return field.getGroupList();
+      }
+    };
+
+    private static final ImmutableList<Type> TYPES = ImmutableList.copyOf(values());
+
+    static ImmutableList<Type> all() {
+      return TYPES;
+    }
+
+    private final int wireType;
+
+    Type(int wireType) {
+      this.wireType = wireType;
+    }
+
+    /** Returns the corresponding values from the given field. */
+    abstract List<?> getValues(UnknownFieldSet.Field field);
+
+    /** Returns the {@link WireFormat} constant for this field type. */
+    final int wireType() {
+      return wireType;
+    }
+  }
+
+  static UnknownFieldDescriptor create(int fieldNumber, Type type) {
+    return new AutoValue_UnknownFieldDescriptor(fieldNumber, type);
+  }
+
+  abstract int fieldNumber();
+
+  abstract Type type();
+
+  static ImmutableList<UnknownFieldDescriptor> descriptors(
+      int fieldNumber, UnknownFieldSet.Field field) {
+    ImmutableList.Builder<UnknownFieldDescriptor> builder = ImmutableList.builder();
+    for (Type type : Type.all()) {
+      if (!type.getValues(field).isEmpty()) {
+        builder.add(create(fieldNumber, type));
+      }
+    }
+    return builder.build();
+  }
+}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Store FieldDescriptor type information throughout the DiffResult, to enable proper escaping.

Also moves 'UnknownFieldDescriptor' and 'FieldDescriptorOrUnknown' to their own files, since they're needed by more than just ProtoTruthMessageDifferencer now.

RELNOTES=n/a

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=185090110

8e5a7930fbf1f6b8f46bdf2818908a8bb8ee5e9d