### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -20,12 +20,10 @@ import static com.google.common.truth.StringUtil.format;
 import static com.google.common.truth.SubjectUtils.accumulate;
 
 import com.google.common.base.Objects;
-import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.CompatibleWith;
 import java.util.Arrays;
-import java.util.List;
 import javax.annotation.Nullable;
 
 /**
@@ -250,19 +248,13 @@ public class Subject<S extends Subject<S, T>, T> {
       @Nullable @CompatibleWith("T") Object first,
       @Nullable @CompatibleWith("T") Object second,
       @Nullable Object... rest) {
-    List<Object> list = accumulate(first, second, rest);
-    if (!list.contains(actual())) {
-      fail("is equal to any of", list);
-    }
+    isIn(accumulate(first, second, rest));
   }
 
   /** Fails if the subject is equal to any element in the given iterable. */
   public void isNotIn(Iterable<?> iterable) {
-    int index = Iterables.indexOf(iterable, Predicates.<Object>equalTo(actual()));
-    if (index != -1) {
-      failWithRawMessage(
-          "Not true that %s is not in %s. It was found at index %s",
-          actualAsString(), iterable, index);
+    if (Iterables.contains(iterable, actual())) {
+      failWithRawMessage("Not true that %s is not in %s.", actualAsString(), iterable);
     }
   }
 

--- a/core/src/test/java/com/google/common/truth/SubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/SubjectTest.java
@@ -643,7 +643,7 @@ public class SubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that("x").isAnyOf("a", "b", "c");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <\"x\"> is equal to any of <[a, b, c]>");
+        .isEqualTo("Not true that <\"x\"> is equal to any element in <[a, b, c]>");
   }
 
   @Test
@@ -661,7 +661,7 @@ public class SubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that((String) null).isAnyOf("a", "b", "c");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <null> is equal to any of <[a, b, c]>");
+        .isEqualTo("Not true that <null> is equal to any element in <[a, b, c]>");
   }
 
   @Test
@@ -674,7 +674,7 @@ public class SubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that("b").isNotIn(oneShotIterable("a", "b", "c"));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <\"b\"> is not in [a, b, c]. It was found at index 1");
+        .isEqualTo("Not true that <\"b\"> is not in [a, b, c].");
   }
 
   @Test
@@ -690,7 +690,7 @@ public class SubjectTest extends BaseSubjectTestCase {
         .isNotIn(oneShotIterable("a", "b", (String) null));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <null> is not in [a, b, null]. It was found at index 2");
+        .isEqualTo("Not true that <null> is not in [a, b, null].");
   }
 
   @Test
@@ -708,7 +708,7 @@ public class SubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that("b").isNoneOf("a", "b", "c");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <\"b\"> is not in [a, b, c]. It was found at index 1");
+        .isEqualTo("Not true that <\"b\"> is not in [a, b, c].");
   }
 
   @Test
@@ -721,7 +721,7 @@ public class SubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that((String) null).isNoneOf("a", "b", (String) null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <null> is not in [a, b, null]. It was found at index 2");
+        .isEqualTo("Not true that <null> is not in [a, b, null].");
   }
 
   @Test


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Start simplifying fail() methods:

1. Merge fail(String), fail(String, Object), and fail(String, Object...), which have identical behavior -- except that fail(String, Object) currently tells Truth to print class names if actual() has the same toString() as the Object parameter. I've removed that behavior. Identical toString()s should be rare except in isEqualTo() assertions. And Subject.isEqualTo() doesn't call fail(String, Object), so it's unaffected. It's possible that a custom Subject's isEqualTo() implementation could be affected, but I would generally expect for such implementations to contain an instanceof check already, since they're probably adding behavior for a specific type, so they're likely to handle mismatched types already, either explicitly or by delegating to super.isEqualTo(...). It looks like we had realized that the extra information might not be useful in the case of isNotEqualTo() but hadn't extended that to other non-equality assertions.

(I've merged the implementations but keep all the methods around for binary compatibility.)

2. In isNotEqualTo() checks, stop distinguishing between other/displayOther and actual/actual(). As best I can tell, all that the distinction is accomplishing is preventing us from printing the type names in failures like "Not true that 42 (java.lang.Integer) is not equal to 42 (java.lang.Long)." But we can do that just as easily by calling the revised fail(String, Object).

RELNOTES=Changed `Subject.fail(String, Object)` to stop including class names if the Object's toString() representation matches the value under test's. (This is likely to be uncommon unless you are overriding `isEqualTo()`, in which case we recommend delegating to `super.isEqualTo()` when possible.)

89f686d70f45bf51ebf43d108ecc11768443fd75

-------

<p> Simplify isAnyOf and isNoneOf+isNotIn:

- Make isAnyOf delegate to isIn, just as isNoneOf delegates to isNotIn. This slightly changes its failure message, but that seems fine, especially given that isNoneOf and isNotIn already use the same message.

- Make isNoneOf and isNotIn stop printing the index at which the element was found. I could believe that this is useful in some cases, but I think we added it speculatively: http://[] And given that we haven't seen a need for it in the more common reverse assertion, assertThat(foos).contains(foo), it seems unlikely that there's a need here. We can of course always reintroduce it if demand surfaces, or perhaps you'd like to make the case for keeping it now?

RELNOTES=Tweaked failure messages for `isAnyOf`, `isNone`, and `isNotIn` to be more consistent.

b529f79ea8d6379b8ee9de1527b3cfd31b5cec80