### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/PrimitiveByteArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveByteArraySubject.java
@@ -57,7 +57,7 @@ public final class PrimitiveByteArraySubject
       if (!Arrays.equals(actual, expectedArray)) {
         failComparing(
             "Not true that "
-                + getDisplaySubject()
+                + actualAsString()
                 + " is equal to <"
                 + Arrays.toString(expectedArray)
                 + ">;",

--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -279,24 +279,6 @@ public class Subject<S extends Subject<S, T>, T> {
     return getSubject();
   }
 
-  /** @deprecated Prefer {@code #actualAsString()} for display-formatted access to the subject. */
-  @Deprecated
-  protected String getDisplaySubject() {
-    // TODO(cgruber) migrate people from this method once no one is subclassing it.
-    String formatted = actualCustomStringRepresentation();
-    if (customName != null) {
-      // Covers some rare cases where a type might return "" from their custom formatter.
-      // This is actually pretty terrible, as it comes from subjects overriding (formerly)
-      // getDisplaySubject() in cases of .named() to make it not prefixing but replacing.
-      // That goes against the stated contract of .named().  Once displayedAs() is in place,
-      // we can rip this out and callers can use that instead.
-      // TODO(cgruber)
-      return customName + (formatted.isEmpty() ? "" : " (<" + formatted + ">)");
-    } else {
-      return "<" + formatted + ">";
-    }
-  }
-
   /**
    * Returns a string representation of the actual value. This will either be the toString() of the
    * value or a prefixed "name" along with the string representation.
@@ -311,7 +293,18 @@ public class Subject<S extends Subject<S, T>, T> {
    * use this from FailureMetadata, at least in the short term, for better or for worse.
    */
   protected final String actualAsString() {
-    return getDisplaySubject();
+    String formatted = actualCustomStringRepresentation();
+    if (customName != null) {
+      // Covers some rare cases where a type might return "" from their custom formatter.
+      // This is actually pretty terrible, as it comes from subjects overriding (formerly)
+      // getDisplaySubject() in cases of .named() to make it not prefixing but replacing.
+      // That goes against the stated contract of .named().  Once displayedAs() is in place,
+      // we can rip this out and callers can use that instead.
+      // TODO(cgruber)
+      return customName + (formatted.isEmpty() ? "" : " (<" + formatted + ">)");
+    } else {
+      return "<" + formatted + ">";
+    }
   }
 
   /**

--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -23,6 +23,7 @@ import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.CompatibleWith;
+import com.google.errorprone.annotations.ForOverride;
 import java.util.Arrays;
 import javax.annotation.Nullable;
 
@@ -323,6 +324,7 @@ public class Subject<S extends Subject<S, T>, T> {
    *
    * <p>By default, this returns {@code String.ValueOf(getActualValue())}.
    */
+  @ForOverride
   protected String actualCustomStringRepresentation() {
     return String.valueOf(actual());
   }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Mark actualCustomStringRepresentation() as @ForOverride.

The intention is:
- actualAsString() is the method that people call.
- actualCustomStringRepresentation() is the method that people override.

Fortunately, no one actually calls actualCustomStringRepresentation(), aside from some tests that call it to test a subject's implementation. That's easy enough to work around by extracting a method.
(Arguably @ForOverride should permit calls from tests in some cases (now that Error Prone knows how to identify test code). But it's not entirely clear, since, e.g., people shouldn't be testing Converter.doForward(null) because the method can never be invoked that way.

f4d80687812b09c275893eec7e272b3733e3b4d3

-------

<p> Migrate from deprecated getDisplaySubject() to equivalent actualAsString().

8f0aff2573fb925c7178ab3fe1eebf3d02c1b0b1

-------

<p> Delete getDisplaySubject().

RELNOTES=Removed `getDisplaySubject()`. Callers should use `actualAsString()`; overriders should use `actualCustomStringRepresentation()`.

c19e2ba17519c3d517acdeb9c44b56d527575cda