### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/AbstractArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/AbstractArraySubject.java
@@ -61,13 +61,9 @@ abstract class AbstractArraySubject<S extends AbstractArraySubject<S, T>, T> ext
   /** Returns a List representation suitable for displaying in a string. */
   abstract List<?> listRepresentation();
 
-  // TODO(cgruber): Kill once displayedAs() exists, since this attempts to make .named() do that.
   @Override
   protected String actualCustomStringRepresentation() {
-    Object listRepresentation = actual() == null ? "null" : listRepresentation();
-    return (internalCustomName() == null)
-        ? "(" + underlyingType() + brackets() + ") " + listRepresentation + ""
-        : "";
+    return actual() == null ? "null" : listRepresentation().toString();
   }
 
   void failWithBadType(Object expected) {

--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -513,6 +513,11 @@ public class Subject<S extends Subject<S, T>, T> {
     throw new UnsupportedOperationException("Subject.hashCode() is not supported.");
   }
 
+  @Override
+  public String toString() {
+    return getClass().getName() + "(" + actualCustomStringRepresentation() + ")";
+  }
+
   private static boolean classMetadataUnsupported() {
     // https://github.com/google/truth/issues/198
     // TODO(cpovirk): Consider whether to remove instanceof tests under GWT entirely.

--- a/core/src/test/java/com/google/common/truth/ObjectArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/ObjectArraySubjectTest.java
@@ -339,6 +339,16 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
         .isEqualTo("<[[1, 2], [3], [4, 5, 6]]> unexpectedly equal to [[1, 2], [3], [4, 5, 6]].");
   }
 
+  @Test
+  public void boxedAndUnboxed() {
+    /*
+     * TODO(cpovirk): This seems wrong: Either we should *always* treat int[] and Integer[]
+     * equivalently (as we do inside an Object[]), or we should always treat them differently (as we
+     * do with top-level arrays). Probably "differently" is what we want.
+     */
+    assertThat(new Object[] {new int[] {0}}).isEqualTo(new Object[] {new Integer[] {0}});
+  }
+
   private static Object[] objectArray(Object... ts) {
     return ts;
   }

--- a/core/src/test/java/com/google/common/truth/ObjectArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/ObjectArraySubjectTest.java
@@ -63,7 +63,15 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(objectArray("A", 5L)).hasLength(1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <(Object[]) [A, 5]> has length <1>");
+        .isEqualTo("Not true that <[A, 5]> has length <1>");
+  }
+
+  @Test
+  public void hasLengthFailNamed() {
+    expectFailure.whenTesting().that(objectArray("A", 5L)).named("foo").hasLength(1);
+    assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .isEqualTo("Not true that foo (<[A, 5]>) has length <1>");
   }
 
   @Test
@@ -71,7 +79,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(new Object[][] {{"A"}, {5L}}).hasLength(1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <(Object[][]) [[A], [5]]> has length <1>");
+        .isEqualTo("Not true that <[[A], [5]]> has length <1>");
   }
 
   @Test
@@ -94,7 +102,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(objectArray("A", 5L)).isEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <(Object[]) [A, 5]> is empty");
+        .isEqualTo("Not true that <[A, 5]> is empty");
   }
 
   @Test
@@ -108,7 +116,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(EMPTY).isNotEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <(Object[]) []> is not empty");
+        .isEqualTo("Not true that <[]> is not empty");
   }
 
   @Test
@@ -116,8 +124,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(objectArray("A", 5L)).isEqualTo(objectArray(5L, "A"));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo(
-            "Not true that <(Object[]) [A, 5]> is equal to <[5, A]>. It differs at index <[0]>");
+        .isEqualTo("Not true that <[A, 5]> is equal to <[5, A]>. It differs at index <[0]>");
   }
 
   @Test
@@ -129,7 +136,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(Object[][]) [[A], [5]]> is equal to <[[5], [A]]>."
+            "Not true that <[[A], [5]]> is equal to <[[5], [A]]>."
                 + " It differs at index <[0][0]>");
   }
 
@@ -142,7 +149,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(Object[][]) [[A, B], [5]]> is equal to <[[A], [5]]>."
+            "Not true that <[[A, B], [5]]> is equal to <[[A], [5]]>."
                 + " It differs at index <[0][1]>");
   }
 
@@ -155,7 +162,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(Object[][]) [[A], [5]]> is equal to <[[A], [5, 6]]>."
+            "Not true that <[[A], [5]]> is equal to <[[A], [5, 6]]>."
                 + " It differs at index <[1][1]>");
   }
 
@@ -191,7 +198,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(objectArray("A", 5L)).isNotEqualTo(objectArray("A", 5L));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("<(Object[]) [A, 5]> unexpectedly equal to [A, 5].");
+        .isEqualTo("<[A, 5]> unexpectedly equal to [A, 5].");
   }
 
   @Test
@@ -202,7 +209,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
         .isNotEqualTo(new Object[][] {{"A"}, {5L}});
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("<(Object[][]) [[A], [5]]> unexpectedly equal to [[A], [5]].");
+        .isEqualTo("<[[A], [5]]> unexpectedly equal to [[A], [5]].");
   }
 
   @SuppressWarnings("TruthSelfEquals")
@@ -212,7 +219,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(same).isNotEqualTo(same);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("<(Object[]) [A, 5]> unexpectedly equal to [A, 5].");
+        .isEqualTo("<[A, 5]> unexpectedly equal to [A, 5].");
   }
 
   @SuppressWarnings("TruthSelfEquals")
@@ -222,7 +229,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(same).isNotEqualTo(same);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("<(Object[][]) [[A], [5]]> unexpectedly equal to [[A], [5]].");
+        .isEqualTo("<[[A], [5]]> unexpectedly equal to [[A], [5]].");
   }
 
   @Test
@@ -247,7 +254,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(objectArray("A", "B")).isEqualTo(objectArray("B"));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("<(String[]) [A, B]> has length 2. Expected length is 1");
+        .isEqualTo("<[A, B]> has length 2. Expected length is 1");
   }
 
   @Test
@@ -258,7 +265,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
         .isEqualTo(new String[][] {{"A"}});
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("<(String[][]) [[A], [B]]> has length 2. Expected length is 1");
+        .isEqualTo("<[[A], [B]]> has length 2. Expected length is 1");
   }
 
   @Test
@@ -266,8 +273,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(objectArray("A", "B")).isEqualTo(objectArray("B", "A"));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo(
-            "Not true that <(String[]) [A, B]> is equal to <[B, A]>. It differs at index <[0]>");
+        .isEqualTo("Not true that <[A, B]> is equal to <[B, A]>. It differs at index <[0]>");
   }
 
   @Test
@@ -279,7 +285,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(String[][]) [[A], [B]]> is equal to <[[B], [A]]>."
+            "Not true that <[[A], [B]]> is equal to <[[B], [A]]>."
                 + " It differs at index <[0][0]>");
   }
 
@@ -292,8 +298,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(Set[]) [[A], [B]]> is equal to <[[B], [A]]>. "
-                + "It differs at index <[0]>");
+            "Not true that <[[A], [B]]> is equal to <[[B], [A]]>. It differs at index <[0]>");
     // Maybe one day:
     // .hasMessage("Not true that <(Set<String>[]) [[A], [B]]> is equal to <[[B], [A]]>");
   }
@@ -313,7 +318,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(int[][]) [[1, 2], [3], [4, 5, 6]]> "
+            "Not true that <[[1, 2], [3], [4, 5, 6]]> "
                 + "is equal to <[[1, 2], [3], [4, 5, 6, 7]]>. It differs at index <[2][3]>");
   }
 
@@ -331,9 +336,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
         .isNotEqualTo(new int[][] {{1, 2}, {3}, {4, 5, 6}});
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo(
-            "<(int[][]) [[1, 2], [3], [4, 5, 6]]> unexpectedly "
-                + "equal to [[1, 2], [3], [4, 5, 6]].");
+        .isEqualTo("<[[1, 2], [3], [4, 5, 6]]> unexpectedly equal to [[1, 2], [3], [4, 5, 6]].");
   }
 
   private static Object[] objectArray(Object... ts) {

--- a/core/src/test/java/com/google/common/truth/PrimitiveBooleanArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveBooleanArraySubjectTest.java
@@ -51,8 +51,7 @@ public class PrimitiveBooleanArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array(true, false, true)).isEqualTo(array(false, true, true));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo(
-            "Not true that <(boolean[]) [true, false, true]> is equal to <[false, true, true]>");
+        .isEqualTo("Not true that <[true, false, true]> is equal to <[false, true, true]>");
   }
 
   @Test
@@ -83,7 +82,7 @@ public class PrimitiveBooleanArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array(true, false)).isNotEqualTo(array(true, false));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("<(boolean[]) [true, false]> unexpectedly equal to [true, false].");
+        .isEqualTo("<[true, false]> unexpectedly equal to [true, false].");
   }
 
   @SuppressWarnings("TruthSelfEquals")
@@ -93,7 +92,7 @@ public class PrimitiveBooleanArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(same).isNotEqualTo(same);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("<(boolean[]) [true, false]> unexpectedly equal to [true, false].");
+        .isEqualTo("<[true, false]> unexpectedly equal to [true, false].");
   }
 
   private static boolean[] array(boolean... ts) {

--- a/core/src/test/java/com/google/common/truth/PrimitiveByteArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveByteArraySubjectTest.java
@@ -58,7 +58,7 @@ public class PrimitiveByteArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(byte[]) [124, 112, 12, 11, 10]> is equal to <[24, 12, 2, 1, 0]>; "
+            "Not true that <[124, 112, 12, 11, 10]> is equal to <[24, 12, 2, 1, 0]>; "
                 + "expected:<[180C020100]> but was:<[7C700C0B0A]>");
   }
 
@@ -79,7 +79,7 @@ public class PrimitiveByteArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(byte[]) [124, 112, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 7, 101, 120, 97, "
+            "Not true that <[124, 112, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 7, 101, 120, 97, "
                 + "109, 112, 108, 101, 3, 99, 111, 109, 0, 0, 1, 0, 0]> is equal to "
                 + "<[124, 112, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 7, 101, 120, 97, 109, 112, 108, "
                 + "101, 3, 99, 111, 109, 0, 0, 1, 0, 1]>; "
@@ -96,7 +96,7 @@ public class PrimitiveByteArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(byte[]) [0, 123]> is equal to <[123, 0]>; "
+            "Not true that <[0, 123]> is equal to <[123, 0]>; "
                 + "expected:<[7B00]> but was:<[007B]>");
   }
 
@@ -128,7 +128,7 @@ public class PrimitiveByteArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array(BYTE_0, BYTE_1)).isNotEqualTo(array(BYTE_0, BYTE_1));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("<(byte[]) [0, 1]> unexpectedly equal to [0, 1].");
+        .isEqualTo("<[0, 1]> unexpectedly equal to [0, 1].");
   }
 
   @SuppressWarnings("TruthSelfEquals")
@@ -138,7 +138,7 @@ public class PrimitiveByteArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(same).isNotEqualTo(same);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("<(byte[]) [0, 1]> unexpectedly equal to [0, 1].");
+        .isEqualTo("<[0, 1]> unexpectedly equal to [0, 1].");
   }
 
   private static byte[] array(byte... ts) {

--- a/core/src/test/java/com/google/common/truth/PrimitiveCharArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveCharArraySubjectTest.java
@@ -51,7 +51,7 @@ public class PrimitiveCharArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array('a', 'q')).isEqualTo(array('q', 'a'));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <(char[]) [a, q]> is equal to <[q, a]>");
+        .isEqualTo("Not true that <[a, q]> is equal to <[q, a]>");
   }
 
   @Test
@@ -82,7 +82,7 @@ public class PrimitiveCharArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array('a', 'q')).isNotEqualTo(array('a', 'q'));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("<(char[]) [a, q]> unexpectedly equal to [a, q].");
+        .isEqualTo("<[a, q]> unexpectedly equal to [a, q].");
   }
 
   @SuppressWarnings("TruthSelfEquals")
@@ -92,7 +92,7 @@ public class PrimitiveCharArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(same).isNotEqualTo(same);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("<(char[]) [a, q]> unexpectedly equal to [a, q].");
+        .isEqualTo("<[a, q]> unexpectedly equal to [a, q].");
   }
 
   private static char[] array(char... ts) {

--- a/core/src/test/java/com/google/common/truth/PrimitiveDoubleArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveDoubleArraySubjectTest.java
@@ -81,7 +81,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array(2.2d)).isEqualTo(array(OVER_2POINT2));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <(double[]) [2.2]> is equal to <[" + OVER_2POINT2 + "]>");
+        .isEqualTo("Not true that <[2.2]> is equal to <[" + OVER_2POINT2 + "]>");
   }
 
   @Test
@@ -89,7 +89,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array(2.2d, 3.3d)).isEqualTo(array(3.3d, 2.2d));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <(double[]) [2.2, 3.3]> is equal to <[3.3, 2.2]>");
+        .isEqualTo("Not true that <[2.2, 3.3]> is equal to <[3.3, 2.2]>");
   }
 
   @Test
@@ -97,7 +97,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array(2.2d, 3.3d)).isEqualTo(array(2.2d, 3.3d, 4.4d));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <(double[]) [2.2, 3.3]> is equal to <[2.2, 3.3, 4.4]>");
+        .isEqualTo("Not true that <[2.2, 3.3]> is equal to <[2.2, 3.3, 4.4]>");
   }
 
   @Test
@@ -105,7 +105,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array(2.2d, 3.3d)).isEqualTo(array(2.2d));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <(double[]) [2.2, 3.3]> is equal to <[2.2]>");
+        .isEqualTo("Not true that <[2.2, 3.3]> is equal to <[2.2]>");
   }
 
   @Test
@@ -113,7 +113,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array(0.0d)).isEqualTo(array(-0.0d));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <(double[]) [0.0]> is equal to <[-0.0]>");
+        .isEqualTo("Not true that <[0.0]> is equal to <[-0.0]>");
   }
 
   @Test
@@ -145,10 +145,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
         .isEqualTo(array(2.2d, INTOLERABLE_3POINT3), DEFAULT_TOLERANCE);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo(
-            "Not true that <(double[]) [2.2, 3.3]> is equal to <[2.2, "
-                + INTOLERABLE_3POINT3
-                + "]>");
+        .isEqualTo("Not true that <[2.2, 3.3]> is equal to <[2.2, " + INTOLERABLE_3POINT3 + "]>");
   }
 
   @SuppressWarnings("deprecation") // testing deprecated method
@@ -160,7 +157,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
         .isEqualTo(array(3.3d, 2.2d), DEFAULT_TOLERANCE);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <(double[]) [2.2, 3.3]> is equal to <[3.3, 2.2]>");
+        .isEqualTo("Not true that <[2.2, 3.3]> is equal to <[3.3, 2.2]>");
   }
 
   @SuppressWarnings("deprecation") // testing deprecated method
@@ -205,7 +202,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
         .isEqualTo(array(2.2d, POSITIVE_INFINITY), DEFAULT_TOLERANCE);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <(double[]) [2.2, Infinity]> is equal to <[2.2, Infinity]>");
+        .isEqualTo("Not true that <[2.2, Infinity]> is equal to <[2.2, Infinity]>");
   }
 
   @SuppressWarnings("deprecation") // testing deprecated method
@@ -226,7 +223,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
         .isEqualTo(array(2.2d, POSITIVE_INFINITY), DEFAULT_TOLERANCE);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <(double[]) [2.2, 3.3]> is equal to <[2.2, Infinity]>");
+        .isEqualTo("Not true that <[2.2, 3.3]> is equal to <[2.2, Infinity]>");
   }
 
   @SuppressWarnings("deprecation") // testing deprecated method
@@ -247,7 +244,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array(NaN)).isEqualTo(array(NaN), DEFAULT_TOLERANCE);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <(double[]) [NaN]> is equal to <[NaN]>");
+        .isEqualTo("Not true that <[NaN]> is equal to <[NaN]>");
   }
 
   @Test
@@ -259,7 +256,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "<(double[]) [2.2, 5.4, Infinity, -Infinity]> unexpectedly equal to "
+            "<[2.2, 5.4, Infinity, -Infinity]> unexpectedly equal to "
                 + "[2.2, 5.4, Infinity, -Infinity].");
   }
 
@@ -272,7 +269,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "<(double[]) [2.2, 5.4, Infinity, -Infinity, NaN, 0.0, -0.0]> unexpectedly equal to "
+            "<[2.2, 5.4, Infinity, -Infinity, NaN, 0.0, -0.0]> unexpectedly equal to "
                 + "[2.2, 5.4, Infinity, -Infinity, NaN, 0.0, -0.0].");
   }
 
@@ -339,7 +336,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
         .isNotEqualTo(array(2.2d, 3.3d), DEFAULT_TOLERANCE);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("<(double[]) [2.2, 3.3]> unexpectedly equal to [2.2, 3.3].");
+        .isEqualTo("<[2.2, 3.3]> unexpectedly equal to [2.2, 3.3].");
   }
 
   @SuppressWarnings("deprecation") // testing deprecated method
@@ -351,8 +348,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
         .isNotEqualTo(array(2.2d, TOLERABLE_3POINT3), DEFAULT_TOLERANCE);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo(
-            "<(double[]) [2.2, 3.3]> unexpectedly equal to [2.2, " + TOLERABLE_3POINT3 + "].");
+        .isEqualTo("<[2.2, 3.3]> unexpectedly equal to [2.2, " + TOLERABLE_3POINT3 + "].");
   }
 
   @SuppressWarnings("deprecation") // testing deprecated method
@@ -368,7 +364,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(same).isNotEqualTo(same, DEFAULT_TOLERANCE);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("<(double[]) [2.2, 3.3]> unexpectedly equal to [2.2, 3.3].");
+        .isEqualTo("<[2.2, 3.3]> unexpectedly equal to [2.2, 3.3].");
   }
 
   @SuppressWarnings("deprecation") // testing deprecated method
@@ -387,7 +383,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(same).isNotEqualTo(same, DEFAULT_TOLERANCE);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("<(double[]) [2.2, Infinity]> unexpectedly equal to [2.2, Infinity].");
+        .isEqualTo("<[2.2, Infinity]> unexpectedly equal to [2.2, Infinity].");
   }
 
   @SuppressWarnings("deprecation") // testing deprecated method
@@ -428,7 +424,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, 3.3]> has values within "
+            "Not true that <[2.2, 3.3]> has values within "
                 + DEFAULT_TOLERANCE
                 + " of <[2.2, "
                 + INTOLERABLE_3POINT3
@@ -445,7 +441,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, 3.3]> has values within "
+            "Not true that <[2.2, 3.3]> has values within "
                 + DEFAULT_TOLERANCE
                 + " of <[3.3, 2.2]>."
                 + " It differs at indexes <[0, 1]>");
@@ -461,7 +457,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, 3.3]> has values within "
+            "Not true that <[2.2, 3.3]> has values within "
                 + DEFAULT_TOLERANCE
                 + " of <[2.2, 3.3, 1.1]>."
                 + " Expected length <3> but got <2>");
@@ -473,7 +469,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, 3.3]> has values within "
+            "Not true that <[2.2, 3.3]> has values within "
                 + DEFAULT_TOLERANCE
                 + " of <[2.2]>."
                 + " Expected length <1> but got <2>");
@@ -489,7 +485,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, Infinity]> has values within "
+            "Not true that <[2.2, Infinity]> has values within "
                 + DEFAULT_TOLERANCE
                 + " of"
                 + " <[2.2, Infinity]>. It differs at indexes <[1]>");
@@ -502,7 +498,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, Infinity]> has values within "
+            "Not true that <[2.2, Infinity]> has values within "
                 + DEFAULT_TOLERANCE
                 + " of"
                 + " <[2.2, Infinity]>. It differs at indexes <[1]>");
@@ -518,7 +514,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, 3.3]> has values within "
+            "Not true that <[2.2, 3.3]> has values within "
                 + DEFAULT_TOLERANCE
                 + " of <[2.2, Infinity]>."
                 + " It differs at indexes <[1]>");
@@ -534,7 +530,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, 3.3]> has values within "
+            "Not true that <[2.2, 3.3]> has values within "
                 + DEFAULT_TOLERANCE
                 + " of <[Infinity]>."
                 + " Expected length <1> but got <2>");
@@ -546,7 +542,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [NaN]> has values within "
+            "Not true that <[NaN]> has values within "
                 + DEFAULT_TOLERANCE
                 + " of <[NaN]>."
                 + " It differs at indexes <[0]>");
@@ -620,7 +616,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, 3.3]> has values within "
+            "Not true that <[2.2, 3.3]> has values within "
                 + DEFAULT_TOLERANCE
                 + " of <[2.2, "
                 + INTOLERABLE_3POINT3
@@ -637,7 +633,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, 3.3]> has values within "
+            "Not true that <[2.2, 3.3]> has values within "
                 + DEFAULT_TOLERANCE
                 + " of <[3.3, 2.2]>."
                 + " It differs at indexes <[0, 1]>");
@@ -653,7 +649,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, 3.3]> has values within "
+            "Not true that <[2.2, 3.3]> has values within "
                 + DEFAULT_TOLERANCE
                 + " of <[2.2, 3.3, 1.1]>."
                 + " Expected length <3> but got <2>");
@@ -669,7 +665,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, 3.3]> has values within "
+            "Not true that <[2.2, 3.3]> has values within "
                 + DEFAULT_TOLERANCE
                 + " of <[2.2]>."
                 + " Expected length <1> but got <2>");
@@ -685,7 +681,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, Infinity]> has values within "
+            "Not true that <[2.2, Infinity]> has values within "
                 + DEFAULT_TOLERANCE
                 + " of"
                 + " <[2.2, Infinity]>. It differs at indexes <[1]>");
@@ -701,7 +697,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, 3.3]> has values within "
+            "Not true that <[2.2, 3.3]> has values within "
                 + DEFAULT_TOLERANCE
                 + " of <[2.2, Infinity]>."
                 + " It differs at indexes <[1]>");
@@ -717,7 +713,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, 3.3]> has values within "
+            "Not true that <[2.2, 3.3]> has values within "
                 + DEFAULT_TOLERANCE
                 + " of <[Infinity]>."
                 + " Expected length <1> but got <2>");
@@ -733,7 +729,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [NaN]> has values within "
+            "Not true that <[NaN]> has values within "
                 + DEFAULT_TOLERANCE
                 + " of <[NaN]>."
                 + " It differs at indexes <[0]>");
@@ -796,7 +792,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, 3.3]> has values not within "
+            "Not true that <[2.2, 3.3]> has values not within "
                 + DEFAULT_TOLERANCE
                 + " of <[2.2, 3.3]>");
   }
@@ -812,7 +808,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, 3.3]> has values not within "
+            "Not true that <[2.2, 3.3]> has values not within "
                 + DEFAULT_TOLERANCE
                 + " of <[2.2, "
                 + TOLERABLE_3POINT3
@@ -835,7 +831,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, 3.3]> has values not within "
+            "Not true that <[2.2, 3.3]> has values not within "
                 + DEFAULT_TOLERANCE
                 + " of <[2.2, 3.3]>");
   }
@@ -851,7 +847,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, Infinity]> has values not within "
+            "Not true that <[2.2, Infinity]> has values not within "
                 + DEFAULT_TOLERANCE
                 + " of"
                 + " <[2.2, Infinity]>");
@@ -865,7 +861,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, Infinity]> has values not within "
+            "Not true that <[2.2, Infinity]> has values not within "
                 + DEFAULT_TOLERANCE
                 + " of"
                 + " <[2.2, Infinity]>");
@@ -882,7 +878,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, 3.3]> has values not within "
+            "Not true that <[2.2, 3.3]> has values not within "
                 + DEFAULT_TOLERANCE
                 + " of"
                 + " <[2.2, Infinity]>");
@@ -901,9 +897,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [NaN]> has values not within "
-                + DEFAULT_TOLERANCE
-                + " of <[NaN]>");
+            "Not true that <[NaN]> has values not within " + DEFAULT_TOLERANCE + " of <[NaN]>");
   }
 
   @Test
@@ -982,7 +976,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, 3.3]> has values not within "
+            "Not true that <[2.2, 3.3]> has values not within "
                 + DEFAULT_TOLERANCE
                 + " of <[2.2, 3.3]>");
   }
@@ -998,7 +992,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, 3.3]> has values not within "
+            "Not true that <[2.2, 3.3]> has values not within "
                 + DEFAULT_TOLERANCE
                 + " of <[2.2, "
                 + TOLERABLE_3POINT3
@@ -1024,7 +1018,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, Infinity]> has values not within "
+            "Not true that <[2.2, Infinity]> has values not within "
                 + DEFAULT_TOLERANCE
                 + " of"
                 + " <[2.2, Infinity]>");
@@ -1041,7 +1035,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [2.2, 3.3]> has values not within "
+            "Not true that <[2.2, 3.3]> has values not within "
                 + DEFAULT_TOLERANCE
                 + " of"
                 + " <[2.2, Infinity]>");
@@ -1066,9 +1060,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <(double[]) [NaN]> has values not within "
-                + DEFAULT_TOLERANCE
-                + " of <[NaN]>");
+            "Not true that <[NaN]> has values not within " + DEFAULT_TOLERANCE + " of <[NaN]>");
   }
 
   @Test
@@ -1622,7 +1614,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array(10000.0)).isEqualTo(array(20000.0));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <(double[]) [10000.0]> is equal to <[20000.0]>");
+        .isEqualTo("Not true that <[10000.0]> is equal to <[20000.0]>");
   }
 
   private static double[] array(double... primitives) {

--- a/core/src/test/java/com/google/common/truth/PrimitiveFloatArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveFloatArraySubjectTest.java
@@ -74,8 +74,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array(2.2f)).isEqualTo(array(JUST_OVER_2POINT2));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo(
-            format("Not true that <(float[]) [%s]> is equal to <[%s]>", 2.2f, JUST_OVER_2POINT2));
+        .isEqualTo(format("Not true that <[%s]> is equal to <[%s]>", 2.2f, JUST_OVER_2POINT2));
   }
 
   @Test
@@ -84,9 +83,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            format(
-                "Not true that <(float[]) [%s, %s]> is equal to <[%s, %s]>",
-                2.2f, 3.3f, 3.3f, 2.2f));
+            format("Not true that <[%s, %s]> is equal to <[%s, %s]>", 2.2f, 3.3f, 3.3f, 2.2f));
   }
 
   @Test
@@ -96,7 +93,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, %s]> is equal to <[%s, %s, %s]>",
+                "Not true that <[%s, %s]> is equal to <[%s, %s, %s]>",
                 2.2f, 3.3f, 2.2f, 3.3f, 4.4f));
   }
 
@@ -105,8 +102,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array(2.2f, 3.3f)).isEqualTo(array(2.2f));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo(
-            format("Not true that <(float[]) [%s, %s]> is equal to <[%s]>", 2.2f, 3.3f, 2.2f));
+        .isEqualTo(format("Not true that <[%s, %s]> is equal to <[%s]>", 2.2f, 3.3f, 2.2f));
   }
 
   @Test
@@ -114,7 +110,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array(0.0f)).isEqualTo(array(-0.0f));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <(float[]) [0.0]> is equal to <[-0.0]>");
+        .isEqualTo("Not true that <[0.0]> is equal to <[-0.0]>");
   }
 
   @Test
@@ -148,7 +144,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, %s]> is equal to <[%s, %s]>",
+                "Not true that <[%s, %s]> is equal to <[%s, %s]>",
                 2.2f, 3.3f, 2.2f, INTOLERABLE_3POINT3));
   }
 
@@ -162,9 +158,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            format(
-                "Not true that <(float[]) [%s, %s]> is equal to <[%s, %s]>",
-                2.2f, 3.3f, 3.3f, 2.2f));
+            format("Not true that <[%s, %s]> is equal to <[%s, %s]>", 2.2f, 3.3f, 3.3f, 2.2f));
   }
 
   @SuppressWarnings("deprecation") // testing deprecated method
@@ -216,9 +210,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            format(
-                "Not true that <(float[]) [%s, Infinity]> is equal to <[%s, Infinity]>",
-                2.2f, 2.2f));
+            format("Not true that <[%s, Infinity]> is equal to <[%s, Infinity]>", 2.2f, 2.2f));
   }
 
   @SuppressWarnings("deprecation") // testing deprecated method
@@ -238,9 +230,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            format(
-                "Not true that <(float[]) [%s, %s]> is equal to <[%s, Infinity]>",
-                2.2f, 3.3f, 2.2f));
+            format("Not true that <[%s, %s]> is equal to <[%s, Infinity]>", 2.2f, 3.3f, 2.2f));
   }
 
   @SuppressWarnings("deprecation") // testing deprecated method
@@ -264,7 +254,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array(NaN)).isEqualTo(array(NaN), DEFAULT_TOLERANCE);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <(float[]) [NaN]> is equal to <[NaN]>");
+        .isEqualTo("Not true that <[NaN]> is equal to <[NaN]>");
   }
 
   @Test
@@ -277,7 +267,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "<(float[]) [%s, %s, Infinity, -Infinity, NaN, 0.0, -0.0]> unexpectedly equal to "
+                "<[%s, %s, Infinity, -Infinity, NaN, 0.0, -0.0]> unexpectedly equal to "
                     + "[%s, %s, Infinity, -Infinity, NaN, 0.0, -0.0].",
                 2.2f, 5.4f, 2.2f, 5.4f));
   }
@@ -345,8 +335,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .isNotEqualTo(array(2.2f, 3.3f), DEFAULT_TOLERANCE);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo(
-            format("<(float[]) [%s, %s]> unexpectedly equal to [%s, %s].", 2.2f, 3.3f, 2.2f, 3.3f));
+        .isEqualTo(format("<[%s, %s]> unexpectedly equal to [%s, %s].", 2.2f, 3.3f, 2.2f, 3.3f));
   }
 
   @SuppressWarnings("deprecation") // testing deprecated method
@@ -360,8 +349,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "<(float[]) [%s, %s]> unexpectedly equal to [%s, %s].",
-                2.2f, 3.3f, 2.2f, TOLERABLE_3POINT3));
+                "<[%s, %s]> unexpectedly equal to [%s, %s].", 2.2f, 3.3f, 2.2f, TOLERABLE_3POINT3));
   }
 
   @SuppressWarnings("deprecation") // testing deprecated method
@@ -377,8 +365,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(same).isNotEqualTo(same, DEFAULT_TOLERANCE);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo(
-            format("<(float[]) [%s, %s]> unexpectedly equal to [%s, %s].", 2.2f, 3.3f, 2.2f, 3.3f));
+        .isEqualTo(format("<[%s, %s]> unexpectedly equal to [%s, %s].", 2.2f, 3.3f, 2.2f, 3.3f));
   }
 
   @SuppressWarnings("deprecation") // testing deprecated method
@@ -395,8 +382,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(same).isNotEqualTo(same, DEFAULT_TOLERANCE);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo(
-            format("<(float[]) [%s, Infinity]> unexpectedly equal to [%s, Infinity].", 2.2f, 2.2f));
+        .isEqualTo(format("<[%s, Infinity]> unexpectedly equal to [%s, Infinity].", 2.2f, 2.2f));
   }
 
   @SuppressWarnings("deprecation") // testing deprecated method
@@ -438,7 +424,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, %s]> has values within %s of <[%s, %s]>."
+                "Not true that <[%s, %s]> has values within %s of <[%s, %s]>."
                     + " It differs at indexes <[1]>",
                 2.2f, 3.3f, DEFAULT_TOLERANCE, 2.2f, INTOLERABLE_3POINT3));
   }
@@ -454,7 +440,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, %s]> has values within %s of <[%s, %s]>."
+                "Not true that <[%s, %s]> has values within %s of <[%s, %s]>."
                     + " It differs at indexes <[0, 1]>",
                 2.2f, 3.3f, DEFAULT_TOLERANCE, 3.3f, 2.2f));
   }
@@ -470,7 +456,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, %s]> has values within %s of <[%s, %s, %s]>."
+                "Not true that <[%s, %s]> has values within %s of <[%s, %s, %s]>."
                     + " Expected length <3> but got <2>",
                 2.2f, 3.3f, DEFAULT_TOLERANCE, 2.2f, 3.3f, 1.1f));
   }
@@ -482,7 +468,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, %s]> has values within %s of <[%s]>."
+                "Not true that <[%s, %s]> has values within %s of <[%s]>."
                     + " Expected length <1> but got <2>",
                 2.2f, 3.3f, DEFAULT_TOLERANCE, 2.2f));
   }
@@ -498,7 +484,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, Infinity]> has values within %s of"
+                "Not true that <[%s, Infinity]> has values within %s of"
                     + " <[%s, Infinity]>. It differs at indexes <[1]>",
                 2.2f, DEFAULT_TOLERANCE, 2.2f));
   }
@@ -511,7 +497,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, Infinity]> has values within %s of"
+                "Not true that <[%s, Infinity]> has values within %s of"
                     + " <[%s, Infinity]>. It differs at indexes <[1]>",
                 2.2f, DEFAULT_TOLERANCE, 2.2f));
   }
@@ -527,7 +513,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, %s]> has values within %s of <[%s, Infinity]>."
+                "Not true that <[%s, %s]> has values within %s of <[%s, Infinity]>."
                     + " It differs at indexes <[1]>",
                 2.2f, 3.3f, DEFAULT_TOLERANCE, 2.2f));
   }
@@ -543,7 +529,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, %s]> has values within %s of <[Infinity]>."
+                "Not true that <[%s, %s]> has values within %s of <[Infinity]>."
                     + " Expected length <1> but got <2>",
                 2.2f, 3.3f, DEFAULT_TOLERANCE));
   }
@@ -555,7 +541,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [NaN]> has values within %s of <[NaN]>."
+                "Not true that <[NaN]> has values within %s of <[NaN]>."
                     + " It differs at indexes <[0]>",
                 DEFAULT_TOLERANCE));
   }
@@ -631,7 +617,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, %s]> has values within %s of"
+                "Not true that <[%s, %s]> has values within %s of"
                     + " <[%s, %s]>. It differs at indexes <[1]>",
                 2.2f, 3.3f, DEFAULT_TOLERANCE, 2.2f, INTOLERABLE_3POINT3));
   }
@@ -647,7 +633,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, %s]> has values within %s of <[%s, %s]>."
+                "Not true that <[%s, %s]> has values within %s of <[%s, %s]>."
                     + " It differs at indexes <[0, 1]>",
                 2.2f, 3.3f, DEFAULT_TOLERANCE, 3.3f, 2.2f));
   }
@@ -663,7 +649,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, %s]> has values within %s of <[%s, %s, %s]>."
+                "Not true that <[%s, %s]> has values within %s of <[%s, %s, %s]>."
                     + " Expected length <3> but got <2>",
                 2.2f, 3.3f, DEFAULT_TOLERANCE, 2.2f, 3.3f, 1.1f));
   }
@@ -679,7 +665,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, %s]> has values within %s of <[%s]>."
+                "Not true that <[%s, %s]> has values within %s of <[%s]>."
                     + " Expected length <1> but got <2>",
                 2.2f, 3.3f, DEFAULT_TOLERANCE, 2.2f));
   }
@@ -695,7 +681,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, Infinity]> has values within %s of"
+                "Not true that <[%s, Infinity]> has values within %s of"
                     + " <[%s, Infinity]>. It differs at indexes <[1]>",
                 2.2f, DEFAULT_TOLERANCE, 2.2f));
   }
@@ -711,7 +697,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, %s]> has values within %s of <[%s, Infinity]>."
+                "Not true that <[%s, %s]> has values within %s of <[%s, Infinity]>."
                     + " It differs at indexes <[1]>",
                 2.2f, 3.3f, DEFAULT_TOLERANCE, 2.2f));
   }
@@ -727,7 +713,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, %s]> has values within %s of <[Infinity]>."
+                "Not true that <[%s, %s]> has values within %s of <[Infinity]>."
                     + " Expected length <1> but got <2>",
                 2.2f, 3.3f, DEFAULT_TOLERANCE));
   }
@@ -743,7 +729,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [NaN]> has values within %s of <[NaN]>."
+                "Not true that <[NaN]> has values within %s of <[NaN]>."
                     + " It differs at indexes <[0]>",
                 DEFAULT_TOLERANCE));
   }
@@ -808,7 +794,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, %s]> has values not within %s of <[%s, %s]>",
+                "Not true that <[%s, %s]> has values not within %s of <[%s, %s]>",
                 2.2f, 3.3f, DEFAULT_TOLERANCE, 2.2f, 3.3f));
   }
 
@@ -824,7 +810,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, %s]> has values not within %s of <[%s, %s]>",
+                "Not true that <[%s, %s]> has values not within %s of <[%s, %s]>",
                 2.2f, 3.3f, DEFAULT_TOLERANCE, 2.2f, TOLERABLE_3POINT3));
   }
 
@@ -845,7 +831,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, %s]> has values not within %s of <[%s, %s]>",
+                "Not true that <[%s, %s]> has values not within %s of <[%s, %s]>",
                 2.2f, 3.3f, DEFAULT_TOLERANCE, 2.2f, 3.3f));
   }
 
@@ -861,8 +847,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, Infinity]> has values not within %s of"
-                    + " <[%s, Infinity]>",
+                "Not true that <[%s, Infinity]> has values not within %s of <[%s, Infinity]>",
                 2.2f, DEFAULT_TOLERANCE, 2.2f));
   }
 
@@ -875,8 +860,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, Infinity]> has values not within %s of"
-                    + " <[%s, Infinity]>",
+                "Not true that <[%s, Infinity]> has values not within %s of <[%s, Infinity]>",
                 2.2f, DEFAULT_TOLERANCE, 2.2f));
   }
 
@@ -892,7 +876,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, %s]> has values not within %s of <[%s, Infinity]>",
+                "Not true that <[%s, %s]> has values not within %s of <[%s, Infinity]>",
                 2.2f, 3.3f, DEFAULT_TOLERANCE, 2.2f));
   }
 
@@ -909,9 +893,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            format(
-                "Not true that <(float[]) [NaN]> has values not within %s of <[NaN]>",
-                DEFAULT_TOLERANCE));
+            format("Not true that <[NaN]> has values not within %s of <[NaN]>", DEFAULT_TOLERANCE));
   }
 
   @Test
@@ -993,7 +975,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, %s]> has values not within %s of <[%s, %s]>",
+                "Not true that <[%s, %s]> has values not within %s of <[%s, %s]>",
                 2.2f, 3.3f, DEFAULT_TOLERANCE, 2.2f, 3.3f));
   }
 
@@ -1009,7 +991,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, %s]> has values not within %s of <[%s, %s]>",
+                "Not true that <[%s, %s]> has values not within %s of <[%s, %s]>",
                 2.2f, 3.3f, DEFAULT_TOLERANCE, 2.2f, TOLERABLE_3POINT3));
   }
 
@@ -1033,8 +1015,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, Infinity]> has values not within %s of"
-                    + " <[%s, Infinity]>",
+                "Not true that <[%s, Infinity]> has values not within %s of <[%s, Infinity]>",
                 2.2f, DEFAULT_TOLERANCE, 2.2f));
   }
 
@@ -1050,8 +1031,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "Not true that <(float[]) [%s, %s]> has values not within %s of"
-                    + " <[%s, Infinity]>",
+                "Not true that <[%s, %s]> has values not within %s of <[%s, Infinity]>",
                 2.2f, 3.3f, DEFAULT_TOLERANCE, 2.2f));
   }
 
@@ -1074,9 +1054,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            format(
-                "Not true that <(float[]) [NaN]> has values not within %s of <[NaN]>",
-                DEFAULT_TOLERANCE));
+            format("Not true that <[NaN]> has values not within %s of <[NaN]>", DEFAULT_TOLERANCE));
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/PrimitiveIntArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveIntArraySubjectTest.java
@@ -59,7 +59,7 @@ public class PrimitiveIntArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array(2, 5)).hasLength(1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <(int[]) [2, 5]> has length <1>");
+        .isEqualTo("Not true that <[2, 5]> has length <1>");
   }
 
   @Test
@@ -81,7 +81,7 @@ public class PrimitiveIntArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array(2, 5)).isEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <(int[]) [2, 5]> is empty");
+        .isEqualTo("Not true that <[2, 5]> is empty");
   }
 
   @Test
@@ -94,7 +94,7 @@ public class PrimitiveIntArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(EMPTY).isNotEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <(int[]) []> is not empty");
+        .isEqualTo("Not true that <[]> is not empty");
   }
 
   @Test
@@ -102,7 +102,7 @@ public class PrimitiveIntArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array(2, 3)).isEqualTo(array(3, 2));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <(int[]) [2, 3]> is equal to <[3, 2]>");
+        .isEqualTo("Not true that <[2, 3]> is equal to <[3, 2]>");
   }
 
   @Test
@@ -133,7 +133,7 @@ public class PrimitiveIntArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array(2, 3)).isNotEqualTo(array(2, 3));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("<(int[]) [2, 3]> unexpectedly equal to [2, 3].");
+        .isEqualTo("<[2, 3]> unexpectedly equal to [2, 3].");
   }
 
   @SuppressWarnings("TruthSelfEquals")
@@ -143,7 +143,7 @@ public class PrimitiveIntArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(same).isNotEqualTo(same);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("<(int[]) [2, 3]> unexpectedly equal to [2, 3].");
+        .isEqualTo("<[2, 3]> unexpectedly equal to [2, 3].");
   }
 
   private static int[] array(int... ts) {

--- a/core/src/test/java/com/google/common/truth/PrimitiveLongArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveLongArraySubjectTest.java
@@ -51,7 +51,7 @@ public class PrimitiveLongArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array(2, 3)).isEqualTo(array(3, 2));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <(long[]) [2, 3]> is equal to <[3, 2]>");
+        .isEqualTo("Not true that <[2, 3]> is equal to <[3, 2]>");
   }
 
   @Test
@@ -82,7 +82,7 @@ public class PrimitiveLongArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array(2, 3)).isNotEqualTo(array(2, 3));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("<(long[]) [2, 3]> unexpectedly equal to [2, 3].");
+        .isEqualTo("<[2, 3]> unexpectedly equal to [2, 3].");
   }
 
   @SuppressWarnings("TruthSelfEquals")
@@ -92,7 +92,7 @@ public class PrimitiveLongArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(same).isNotEqualTo(same);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("<(long[]) [2, 3]> unexpectedly equal to [2, 3].");
+        .isEqualTo("<[2, 3]> unexpectedly equal to [2, 3].");
   }
 
   private static long[] array(long... ts) {

--- a/core/src/test/java/com/google/common/truth/PrimitiveShortArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveShortArraySubjectTest.java
@@ -62,7 +62,7 @@ public class PrimitiveShortArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array(1, 0, 1)).isEqualTo(array(0, 1, 1));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <(short[]) [1, 0, 1]> is equal to <[0, 1, 1]>");
+        .isEqualTo("Not true that <[1, 0, 1]> is equal to <[0, 1, 1]>");
   }
 
   @Test
@@ -93,7 +93,7 @@ public class PrimitiveShortArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(array(1, 0)).isNotEqualTo(array(1, 0));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("<(short[]) [1, 0]> unexpectedly equal to [1, 0].");
+        .isEqualTo("<[1, 0]> unexpectedly equal to [1, 0].");
   }
 
   @SuppressWarnings("TruthSelfEquals")
@@ -103,7 +103,7 @@ public class PrimitiveShortArraySubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(same).isNotEqualTo(same);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("<(short[]) [1, 0]> unexpectedly equal to [1, 0].");
+        .isEqualTo("<[1, 0]> unexpectedly equal to [1, 0].");
   }
 
   private static short[] array(int a, int b, int c) {

--- a/core/src/test/java/com/google/common/truth/SubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/SubjectTest.java
@@ -106,6 +106,16 @@ public class SubjectTest extends BaseSubjectTestCase {
               .isEqualTo("Not true that the subject is a non-null reference");
         }
 
+        subject.isEqualTo(null);
+        // TODO(cpovirk): Enable this test after fixing this and other null bugs in array subjects.
+        if (!(subject instanceof AbstractArraySubject)) {
+          try {
+            subject.isNotEqualTo(null); // should throw
+            throw new Error("assertThat(null).isNotEqualTo(null) should throw an exception!");
+          } catch (AssertionError expected) {
+          }
+        }
+
         subject.isSameAs(null);
         subject.isNotSameAs(new Object());
 
@@ -354,6 +364,40 @@ public class SubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
+  public void isEqualToStringWithNullVsNull() {
+    expectFailure.whenTesting().that("null").isEqualTo(null);
+    assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .isEqualTo("Not true that <\"null\"> is null");
+  }
+
+  @Test
+  public void isEqualToObjectWhoseToStringSaysNullVsNull() {
+    expectFailure.whenTesting().that(new ObjectWhoseToStringSaysNull()).isEqualTo(null);
+    assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .isEqualTo(
+            "Not true that <null> is equal to <null> (although their toString() representations are the same)");
+  }
+
+  private static final class ObjectWhoseToStringSaysNull {
+    @Override
+    public String toString() {
+      return "null";
+    }
+  }
+
+  @Test
+  public void isEqualToNullVsStringWithNull() {
+    Object o = null;
+    expectFailure.whenTesting().that(o).isEqualTo("null");
+    assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .isEqualTo(
+            "Not true that <null> is equal to <null> (although their toString() representations are the same)");
+  }
+
+  @Test
   public void isEqualToWithSameObject() {
     Object a = new Object();
     Object b = a;
@@ -422,11 +466,11 @@ public class SubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isNotEqualToFailureWithObjects() {
-    Object o = null;
-    expectFailure.whenTesting().that(o).isNotEqualTo(null);
+    Object o = new Integer(1);
+    expectFailure.whenTesting().that(o).isNotEqualTo(new Integer(1));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("Not true that <null> is not equal to <null>");
+        .isEqualTo("Not true that <1> is not equal to <1>");
   }
 
   @Test

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/FluentEqualityConfig.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/FluentEqualityConfig.java
@@ -44,8 +44,8 @@ abstract class FluentEqualityConfig {
       new AutoValue_FluentEqualityConfig.Builder()
           .setIgnoreFieldAbsence(false)
           .setIgnoreRepeatedFieldOrder(false)
-          .setReportMismatchesOnly(false)
           .setFieldScopeLogic(FieldScopeLogic.all())
+          .setReportMismatchesOnly(false)
           .setUsingCorrespondenceStringFunction(Functions.constant(""))
           .build();
 
@@ -72,6 +72,10 @@ abstract class FluentEqualityConfig {
   abstract boolean ignoreRepeatedFieldOrder();
 
   abstract boolean reportMismatchesOnly();
+
+  abstract Optional<Correspondence<Number, Number>> doubleCorrespondence();
+
+  abstract Optional<Correspondence<Number, Number>> floatCorrespondence();
 
   abstract FieldScopeLogic fieldScopeLogic();
 
@@ -104,6 +108,20 @@ abstract class FluentEqualityConfig {
     return toBuilder()
         .setReportMismatchesOnly(true)
         .addUsingCorrespondenceString(".reportingMismatchesOnly()")
+        .build();
+  }
+
+  final FluentEqualityConfig usingDoubleTolerance(double tolerance) {
+    return toBuilder()
+        .setDoubleCorrespondence(Correspondence.tolerance(tolerance))
+        .addUsingCorrespondenceString(".usingDoubleTolerance(" + tolerance + ")")
+        .build();
+  }
+
+  final FluentEqualityConfig usingFloatTolerance(float tolerance) {
+    return toBuilder()
+        .setFloatCorrespondence(Correspondence.tolerance(tolerance))
+        .addUsingCorrespondenceString(".usingFloatTolerance(" + tolerance + ")")
         .build();
   }
 
@@ -189,6 +207,10 @@ abstract class FluentEqualityConfig {
     abstract Builder setIgnoreRepeatedFieldOrder(boolean ignoringRepeatedFieldOrder);
 
     abstract Builder setReportMismatchesOnly(boolean reportMismatchesOnly);
+
+    abstract Builder setDoubleCorrespondence(Correspondence<Number, Number> doubleCorrespondence);
+
+    abstract Builder setFloatCorrespondence(Correspondence<Number, Number> floatCorrespondence);
 
     abstract Builder setFieldScopeLogic(FieldScopeLogic fieldScopeLogic);
 

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosFluentAssertion.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosFluentAssertion.java
@@ -116,6 +116,22 @@ public interface IterableOfProtosFluentAssertion<M extends Message> {
   IterableOfProtosFluentAssertion<M> ignoringRepeatedFieldOrder();
 
   /**
+   * Compares double fields as equal if they are both finite and their absolute difference is less
+   * than or equal to {@code tolerance}.
+   *
+   * @param tolerance A finite, non-negative tolerance.
+   */
+  IterableOfProtosFluentAssertion<M> usingDoubleTolerance(double tolerance);
+
+  /**
+   * Compares float fields as equal if they are both finite and their absolute difference is less
+   * than or equal to {@code tolerance}.
+   *
+   * @param tolerance A finite, non-negative tolerance.
+   */
+  IterableOfProtosFluentAssertion<M> usingFloatTolerance(float tolerance);
+
+  /**
    * Limits the comparison of Protocol buffers to the defined {@link FieldScope}.
    *
    * <p>This method is additive and has well-defined ordering semantics. If the invoking {@link

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosSubject.java
@@ -454,6 +454,26 @@ public class IterableOfProtosSubject<
   }
 
   /**
+   * Compares double fields as equal if they are both finite and their absolute difference is less
+   * than or equal to {@code tolerance}.
+   *
+   * @param tolerance A finite, non-negative tolerance.
+   */
+  public IterableOfProtosFluentAssertion<M> usingDoubleTolerance(double tolerance) {
+    return usingConfig(config.usingDoubleTolerance(tolerance));
+  }
+
+  /**
+   * Compares float fields as equal if they are both finite and their absolute difference is less
+   * than or equal to {@code tolerance}.
+   *
+   * @param tolerance A finite, non-negative tolerance.
+   */
+  public IterableOfProtosFluentAssertion<M> usingFloatTolerance(float tolerance) {
+    return usingConfig(config.usingFloatTolerance(tolerance));
+  }
+
+  /**
    * Limits the comparison of Protocol buffers to the defined {@link FieldScope}.
    *
    * <p>This method is additive and has well-defined ordering semantics. If the invoking {@link
@@ -583,6 +603,16 @@ public class IterableOfProtosSubject<
     @Override
     public IterableOfProtosFluentAssertion<M> ignoringRepeatedFieldOrder() {
       return subject.ignoringRepeatedFieldOrder();
+    }
+
+    @Override
+    public IterableOfProtosFluentAssertion<M> usingDoubleTolerance(double tolerance) {
+      return subject.usingDoubleTolerance(tolerance);
+    }
+
+    @Override
+    public IterableOfProtosFluentAssertion<M> usingFloatTolerance(float tolerance) {
+      return subject.usingFloatTolerance(tolerance);
     }
 
     @Override

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesFluentAssertion.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesFluentAssertion.java
@@ -122,6 +122,22 @@ public interface MapWithProtoValuesFluentAssertion<M extends Message> {
   MapWithProtoValuesFluentAssertion<M> ignoringRepeatedFieldOrderForValues();
 
   /**
+   * Compares double fields as equal if they are both finite and their absolute difference is less
+   * than or equal to {@code tolerance}.
+   *
+   * @param tolerance A finite, non-negative tolerance.
+   */
+  MapWithProtoValuesFluentAssertion<M> usingDoubleToleranceForValues(double tolerance);
+
+  /**
+   * Compares float fields as equal if they are both finite and their absolute difference is less
+   * than or equal to {@code tolerance}.
+   *
+   * @param tolerance A finite, non-negative tolerance.
+   */
+  MapWithProtoValuesFluentAssertion<M> usingFloatToleranceForValues(float tolerance);
+
+  /**
    * Limits the comparison of Protocol buffers to the defined {@link FieldScope}.
    *
    * <p>This method is additive and has well-defined ordering semantics. If the invoking {@link

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubject.java
@@ -299,6 +299,26 @@ public class MapWithProtoValuesSubject<
   }
 
   /**
+   * Compares double fields as equal if they are both finite and their absolute difference is less
+   * than or equal to {@code tolerance}.
+   *
+   * @param tolerance A finite, non-negative tolerance.
+   */
+  public MapWithProtoValuesFluentAssertion<M> usingDoubleToleranceForValues(double tolerance) {
+    return usingConfig(config.usingDoubleTolerance(tolerance));
+  }
+
+  /**
+   * Compares float fields as equal if they are both finite and their absolute difference is less
+   * than or equal to {@code tolerance}.
+   *
+   * @param tolerance A finite, non-negative tolerance.
+   */
+  public MapWithProtoValuesFluentAssertion<M> usingFloatToleranceForValues(float tolerance) {
+    return usingConfig(config.usingFloatTolerance(tolerance));
+  }
+
+  /**
    * Limits the comparison of Protocol buffers to the defined {@link FieldScope}.
    *
    * <p>This method is additive and has well-defined ordering semantics. If the invoking {@link
@@ -430,6 +450,16 @@ public class MapWithProtoValuesSubject<
     @Override
     public MapWithProtoValuesFluentAssertion<M> ignoringRepeatedFieldOrderForValues() {
       return subject.ignoringRepeatedFieldOrderForValues();
+    }
+
+    @Override
+    public MapWithProtoValuesFluentAssertion<M> usingDoubleToleranceForValues(double tolerance) {
+      return subject.usingDoubleToleranceForValues(tolerance);
+    }
+
+    @Override
+    public MapWithProtoValuesFluentAssertion<M> usingFloatToleranceForValues(float tolerance) {
+      return subject.usingFloatToleranceForValues(tolerance);
     }
 
     @Override

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesFluentAssertion.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesFluentAssertion.java
@@ -122,6 +122,22 @@ public interface MultimapWithProtoValuesFluentAssertion<M extends Message> {
   MultimapWithProtoValuesFluentAssertion<M> ignoringRepeatedFieldOrderForValues();
 
   /**
+   * Compares double fields as equal if they are both finite and their absolute difference is less
+   * than or equal to {@code tolerance}.
+   *
+   * @param tolerance A finite, non-negative tolerance.
+   */
+  MultimapWithProtoValuesFluentAssertion<M> usingDoubleToleranceForValues(double tolerance);
+
+  /**
+   * Compares float fields as equal if they are both finite and their absolute difference is less
+   * than or equal to {@code tolerance}.
+   *
+   * @param tolerance A finite, non-negative tolerance.
+   */
+  MultimapWithProtoValuesFluentAssertion<M> usingFloatToleranceForValues(float tolerance);
+
+  /**
    * Limits the comparison of Protocol buffers to the defined {@link FieldScope}.
    *
    * <p>This method is additive and has well-defined ordering semantics. If the invoking {@link

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubject.java
@@ -342,6 +342,26 @@ public class MultimapWithProtoValuesSubject<
   }
 
   /**
+   * Compares double fields as equal if they are both finite and their absolute difference is less
+   * than or equal to {@code tolerance}.
+   *
+   * @param tolerance A finite, non-negative tolerance.
+   */
+  public MultimapWithProtoValuesFluentAssertion<M> usingDoubleToleranceForValues(double tolerance) {
+    return usingConfig(config.usingDoubleTolerance(tolerance));
+  }
+
+  /**
+   * Compares float fields as equal if they are both finite and their absolute difference is less
+   * than or equal to {@code tolerance}.
+   *
+   * @param tolerance A finite, non-negative tolerance.
+   */
+  public MultimapWithProtoValuesFluentAssertion<M> usingFloatToleranceForValues(float tolerance) {
+    return usingConfig(config.usingFloatTolerance(tolerance));
+  }
+
+  /**
    * Limits the comparison of Protocol buffers to the defined {@link FieldScope}.
    *
    * <p>This method is additive and has well-defined ordering semantics. If the invoking {@link
@@ -475,6 +495,17 @@ public class MultimapWithProtoValuesSubject<
     @Override
     public MultimapWithProtoValuesFluentAssertion<M> ignoringRepeatedFieldOrderForValues() {
       return subject.ignoringRepeatedFieldOrderForValues();
+    }
+
+    @Override
+    public MultimapWithProtoValuesFluentAssertion<M> usingDoubleToleranceForValues(
+        double tolerance) {
+      return subject.usingDoubleToleranceForValues(tolerance);
+    }
+
+    @Override
+    public MultimapWithProtoValuesFluentAssertion<M> usingFloatToleranceForValues(float tolerance) {
+      return subject.usingFloatToleranceForValues(tolerance);
     }
 
     @Override

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoFluentAssertion.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoFluentAssertion.java
@@ -111,6 +111,22 @@ public interface ProtoFluentAssertion {
   ProtoFluentAssertion ignoringRepeatedFieldOrder();
 
   /**
+   * Compares double fields as equal if they are both finite and their absolute difference is less
+   * than or equal to {@code tolerance}.
+   *
+   * @param tolerance A finite, non-negative tolerance.
+   */
+  ProtoFluentAssertion usingDoubleTolerance(double tolerance);
+
+  /**
+   * Compares float fields as equal if they are both finite and their absolute difference is less
+   * than or equal to {@code tolerance}.
+   *
+   * @param tolerance A finite, non-negative tolerance.
+   */
+  ProtoFluentAssertion usingFloatTolerance(float tolerance);
+
+  /**
    * Limits the comparison of Protocol buffers to the defined {@link FieldScope}.
    *
    * <p>This method is additive and has well-defined ordering semantics. If the invoking {@link

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoSubject.java
@@ -83,6 +83,16 @@ public class ProtoSubject<S extends ProtoSubject<S, M>, M extends Message>
   }
 
   @Override
+  public ProtoFluentAssertion usingDoubleTolerance(double tolerance) {
+    return usingConfig(config.usingDoubleTolerance(tolerance));
+  }
+
+  @Override
+  public ProtoFluentAssertion usingFloatTolerance(float tolerance) {
+    return usingConfig(config.usingFloatTolerance(tolerance));
+  }
+
+  @Override
   public ProtoFluentAssertion withPartialScope(FieldScope fieldScope) {
     return usingConfig(config.withPartialScope(checkNotNull(fieldScope, "fieldScope")));
   }

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoTruthMessageDifferencer.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoTruthMessageDifferencer.java
@@ -530,8 +530,15 @@ final class ProtoTruthMessageDifferencer {
     result.markRemovedIf(actual == null);
     result.markAddedIf(expected == null);
 
-    // TODO(user): Implement approximate equality testing for floats/doubles.
-    result.markModifiedIf(!Objects.equal(actual, expected));
+    if (actual != null && expected != null) {
+      if (actual instanceof Double) {
+        result.markModifiedIf(!doublesEqual((double) actual, (double) expected));
+      } else if (actual instanceof Float) {
+        result.markModifiedIf(!floatsEqual((float) actual, (float) expected));
+      } else {
+        result.markModifiedIf(!Objects.equal(actual, expected));
+      }
+    }
 
     SingularField.Builder singularFieldBuilder =
         SingularField.newBuilder()
@@ -546,6 +553,22 @@ final class ProtoTruthMessageDifferencer {
       singularFieldBuilder.setExpected(expected);
     }
     return singularFieldBuilder.build();
+  }
+
+  private boolean doublesEqual(double x, double y) {
+    if (config.doubleCorrespondence().isPresent()) {
+      return config.doubleCorrespondence().get().compare(x, y);
+    } else {
+      return Double.compare(x, y) == 0;
+    }
+  }
+
+  private boolean floatsEqual(float x, float y) {
+    if (config.floatCorrespondence().isPresent()) {
+      return config.floatCorrespondence().get().compare(x, y);
+    } else {
+      return Float.compare(x, y) == 0;
+    }
   }
 
   private UnknownFieldSetDiff diffUnknowns(

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/FieldScopesTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/FieldScopesTest.java
@@ -84,15 +84,13 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
     expectThat(diffMessage).withPartialScope(FieldScopes.all()).isNotEqualTo(message);
     expectThat(diffMessage).ignoringFieldScope(FieldScopes.all()).isEqualTo(message);
 
-    try {
-      // TODO(user): Switch ProtoTruth tests to use ExpectFailure.
-      assertThat(diffMessage).ignoringFieldScope(FieldScopes.all()).isNotEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsNotEqualToFailed(e);
-      expectSubstr(e, "ignored: o_int");
-      expectSubstr(e, "ignored: r_string");
-    }
+    expectFailureWhenTesting()
+        .that(diffMessage)
+        .ignoringFieldScope(FieldScopes.all())
+        .isNotEqualTo(message);
+    expectIsNotEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("ignored: o_int");
+    expectThatFailure().hasMessageThat().contains("ignored: r_string");
   }
 
   @Test
@@ -103,14 +101,13 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
     expectThat(diffMessage).ignoringFieldScope(FieldScopes.none()).isNotEqualTo(message);
     expectThat(diffMessage).withPartialScope(FieldScopes.none()).isEqualTo(message);
 
-    try {
-      assertThat(diffMessage).withPartialScope(FieldScopes.none()).isNotEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsNotEqualToFailed(e);
-      expectSubstr(e, "ignored: o_int");
-      expectSubstr(e, "ignored: r_string");
-    }
+    expectFailureWhenTesting()
+        .that(diffMessage)
+        .withPartialScope(FieldScopes.none())
+        .isNotEqualTo(message);
+    expectIsNotEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("ignored: o_int");
+    expectThatFailure().hasMessageThat().contains("ignored: r_string");
   }
 
   @Test
@@ -122,25 +119,19 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
         .ignoringFields(badFieldNumber)
         .isEqualTo(ignoringFieldMessage);
 
-    try {
-      assertThat(ignoringFieldDiffMessage)
-          .ignoringFields(goodFieldNumber)
-          .isEqualTo(ignoringFieldMessage);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsEqualToFailed(e);
-      expectSubstr(e, "modified: r_string[0]: \"foo\" -> \"bar\"");
-    }
+    expectFailureWhenTesting()
+        .that(ignoringFieldDiffMessage)
+        .ignoringFields(goodFieldNumber)
+        .isEqualTo(ignoringFieldMessage);
+    expectIsEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("modified: r_string[0]: \"foo\" -> \"bar\"");
 
-    try {
-      assertThat(ignoringFieldDiffMessage)
-          .ignoringFields(badFieldNumber)
-          .isNotEqualTo(ignoringFieldMessage);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsNotEqualToFailed(e);
-      expectSubstr(e, "ignored: r_string");
-    }
+    expectFailureWhenTesting()
+        .that(ignoringFieldDiffMessage)
+        .ignoringFields(badFieldNumber)
+        .isNotEqualTo(ignoringFieldMessage);
+    expectIsNotEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("ignored: r_string");
   }
 
   @Test
@@ -221,21 +212,13 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
     expectThat(eqMessage2).ignoringFields(fieldNumber).isEqualTo(message);
     expectThat(eqMessage3).ignoringFields(fieldNumber).isEqualTo(message);
 
-    try {
-      assertThat(diffMessage).ignoringFields(fieldNumber).isEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsEqualToFailed(e);
-      expectSubstr(e, "modified: o_int: 1 -> 2");
-    }
+    expectFailureWhenTesting().that(diffMessage).ignoringFields(fieldNumber).isEqualTo(message);
+    expectIsEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("modified: o_int: 1 -> 2");
 
-    try {
-      assertThat(eqMessage3).ignoringFields(fieldNumber).isNotEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsNotEqualToFailed(e);
-      expectSubstr(e, "ignored: o_sub_test_message");
-    }
+    expectFailureWhenTesting().that(eqMessage3).ignoringFields(fieldNumber).isNotEqualTo(message);
+    expectIsNotEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("ignored: o_sub_test_message");
   }
 
   @Test
@@ -254,21 +237,15 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
     expectThat(diffMessage2).withPartialScope(partialScope).isNotEqualTo(message);
     expectThat(eqMessage).withPartialScope(partialScope).isEqualTo(message);
 
-    try {
-      assertThat(diffMessage1).withPartialScope(partialScope).isEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsEqualToFailed(e);
-      expectSubstr(e, "modified: o_int: 1 -> 2");
-    }
+    expectFailureWhenTesting().that(diffMessage1).withPartialScope(partialScope).isEqualTo(message);
+    expectIsEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("modified: o_int: 1 -> 2");
 
-    try {
-      assertThat(diffMessage2).withPartialScope(partialScope).isEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsEqualToFailed(e);
-      expectSubstr(e, "modified: o_sub_test_message.r_string[0]: \"foo\" -> \"bar\"");
-    }
+    expectFailureWhenTesting().that(diffMessage2).withPartialScope(partialScope).isEqualTo(message);
+    expectIsEqualToFailed();
+    expectThatFailure()
+        .hasMessageThat()
+        .contains("modified: o_sub_test_message.r_string[0]: \"foo\" -> \"bar\"");
   }
 
   @Test
@@ -315,21 +292,15 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
     expectThat(diffMessage4).withPartialScope(fieldScope).isNotEqualTo(message);
     expectThat(eqMessage).withPartialScope(fieldScope).isEqualTo(message);
 
-    try {
-      assertThat(diffMessage4).withPartialScope(fieldScope).isEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsEqualToFailed(e);
-      expectSubstr(e, "modified: r_sub_test_message[0].r_string[0]: \"bar\" -> \"999999\"");
-    }
+    expectFailureWhenTesting().that(diffMessage4).withPartialScope(fieldScope).isEqualTo(message);
+    expectIsEqualToFailed();
+    expectThatFailure()
+        .hasMessageThat()
+        .contains("modified: r_sub_test_message[0].r_string[0]: \"bar\" -> \"999999\"");
 
-    try {
-      assertThat(eqMessage).withPartialScope(fieldScope).isNotEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsNotEqualToFailed(e);
-      expectSubstr(e, "ignored: o_sub_test_message.r_string");
-    }
+    expectFailureWhenTesting().that(eqMessage).withPartialScope(fieldScope).isNotEqualTo(message);
+    expectIsNotEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("ignored: o_sub_test_message.r_string");
   }
 
   @Test
@@ -371,41 +342,33 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
         .withPartialScope(FieldScopes.fromSetFields(scopeMessage))
         .isEqualTo(message);
 
-    try {
-      assertThat(diffMessage).isEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsEqualToFailed(e);
-      expectSubstr(e, "1 -> 4");
-      expectSubstr(e, "\"1\" -> \"4\"");
-      expectSubstr(e, "2 -> 3");
-      expectSubstr(e, "\"2\" -> \"3\"");
-    }
+    expectFailureWhenTesting().that(diffMessage).isEqualTo(message);
+    expectIsEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("1 -> 4");
+    expectThatFailure().hasMessageThat().contains("\"1\" -> \"4\"");
+    expectThatFailure().hasMessageThat().contains("2 -> 3");
+    expectThatFailure().hasMessageThat().contains("\"2\" -> \"3\"");
 
-    try {
-      assertThat(diffMessage)
-          .withPartialScope(FieldScopes.fromSetFields(scopeMessage))
-          .isEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsEqualToFailed(e);
-      expectSubstr(e, "1 -> 4");
-      expectSubstr(e, "\"1\" -> \"4\"");
-      expectNoSubstr(e, "2 -> 3");
-      expectNoSubstr(e, "\"2\" -> \"3\"");
-    }
+    expectFailureWhenTesting()
+        .that(diffMessage)
+        .withPartialScope(FieldScopes.fromSetFields(scopeMessage))
+        .isEqualTo(message);
+    expectIsEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("1 -> 4");
+    expectThatFailure().hasMessageThat().contains("\"1\" -> \"4\"");
+    expectThatFailure().hasMessageThat().doesNotContain("2 -> 3");
+    expectThatFailure().hasMessageThat().doesNotContain("\"2\" -> \"3\"");
 
-    try {
-      assertThat(eqMessage)
-          .withPartialScope(FieldScopes.fromSetFields(scopeMessage))
-          .isNotEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsNotEqualToFailed(e);
-      expectSubstr(e, "ignored: o_test_message.r_string");
-      expectSubstr(e, "ignored: o_sub_test_message.o_int");
-      expectSubstr(e, "ignored: o_sub_test_message.o_test_message.r_string");
-    }
+    expectFailureWhenTesting()
+        .that(eqMessage)
+        .withPartialScope(FieldScopes.fromSetFields(scopeMessage))
+        .isNotEqualTo(message);
+    expectIsNotEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("ignored: o_test_message.r_string");
+    expectThatFailure().hasMessageThat().contains("ignored: o_sub_test_message.o_int");
+    expectThatFailure()
+        .hasMessageThat()
+        .contains("ignored: o_sub_test_message.o_test_message.r_string");
   }
 
   public void testFromSetFields_unknownFields() throws InvalidProtocolBufferException {
@@ -541,42 +504,32 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
         .withPartialScope(FieldScopes.fromSetFields(scopeMessage))
         .isEqualTo(message);
 
-    try {
-      assertThat(diffMessage).isEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsEqualToFailed(e);
-      expectSubstr(e, "1 -> 4");
-      expectSubstr(e, "\"1\" -> \"4\"");
-      expectSubstr(e, "2 -> 3");
-      expectSubstr(e, "\"2\" -> \"3\"");
-    }
+    expectFailureWhenTesting().that(diffMessage).isEqualTo(message);
+    expectIsEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("1 -> 4");
+    expectThatFailure().hasMessageThat().contains("\"1\" -> \"4\"");
+    expectThatFailure().hasMessageThat().contains("2 -> 3");
+    expectThatFailure().hasMessageThat().contains("\"2\" -> \"3\"");
 
-    try {
-      assertThat(diffMessage)
-          .withPartialScope(FieldScopes.fromSetFields(scopeMessage))
-          .isEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsEqualToFailed(e);
-      expectSubstr(e, "1 -> 4");
-      expectSubstr(e, "\"1\" -> \"4\"");
-      expectNoSubstr(e, "2 -> 3");
-      expectNoSubstr(e, "\"2\" -> \"3\"");
-    }
+    expectFailureWhenTesting()
+        .that(diffMessage)
+        .withPartialScope(FieldScopes.fromSetFields(scopeMessage))
+        .isEqualTo(message);
+    expectIsEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("1 -> 4");
+    expectThatFailure().hasMessageThat().contains("\"1\" -> \"4\"");
+    expectThatFailure().hasMessageThat().doesNotContain("2 -> 3");
+    expectThatFailure().hasMessageThat().doesNotContain("\"2\" -> \"3\"");
 
-    try {
-      assertThat(eqMessage)
-          .withPartialScope(FieldScopes.fromSetFields(scopeMessage))
-          .isNotEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsNotEqualToFailed(e);
-      expectSubstr(e, "1 -> 4");
-      expectSubstr(e, "\"1\" -> \"4\"");
-      expectNoSubstr(e, "2 -> 3");
-      expectNoSubstr(e, "\"2\" -> \"3\"");
-    }
+    expectFailureWhenTesting()
+        .that(eqMessage)
+        .withPartialScope(FieldScopes.fromSetFields(scopeMessage))
+        .isNotEqualTo(message);
+    expectIsNotEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("1 -> 4");
+    expectThatFailure().hasMessageThat().contains("\"1\" -> \"4\"");
+    expectThatFailure().hasMessageThat().doesNotContain("2 -> 3");
+    expectThatFailure().hasMessageThat().doesNotContain("\"2\" -> \"3\"");
   }
 
   @Test
@@ -604,26 +557,20 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
         .withPartialScope(FieldScopes.allowingFieldDescriptors(fieldDescriptor))
         .isEqualTo(message);
 
-    try {
-      assertThat(diffMessage)
-          .withPartialScope(FieldScopes.allowingFields(fieldNumber))
-          .isEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsEqualToFailed(e);
-      expectSubstr(e, "modified: o_int: 1 -> 2");
-      expectSubstr(e, "modified: r_test_message[0].o_int: 2 -> 1");
-    }
+    expectFailureWhenTesting()
+        .that(diffMessage)
+        .withPartialScope(FieldScopes.allowingFields(fieldNumber))
+        .isEqualTo(message);
+    expectIsEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("modified: o_int: 1 -> 2");
+    expectThatFailure().hasMessageThat().contains("modified: r_test_message[0].o_int: 2 -> 1");
 
-    try {
-      assertThat(eqMessage)
-          .withPartialScope(FieldScopes.allowingFields(fieldNumber))
-          .isNotEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsNotEqualToFailed(e);
-      expectSubstr(e, "ignored: r_test_message[0].r_string");
-    }
+    expectFailureWhenTesting()
+        .that(eqMessage)
+        .withPartialScope(FieldScopes.allowingFields(fieldNumber))
+        .isNotEqualTo(message);
+    expectIsNotEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("ignored: r_test_message[0].r_string");
   }
 
   @Test
@@ -639,23 +586,15 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
     expectThat(diffMessage).withPartialScope(fieldScope).isNotEqualTo(message);
     expectThat(eqMessage).withPartialScope(fieldScope).isEqualTo(message);
 
-    try {
-      assertThat(diffMessage).withPartialScope(fieldScope).isEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsEqualToFailed(e);
-      expectSubstr(e, "modified: o_int: 1 -> 2");
-      expectSubstr(e, "modified: r_string[0]: \"x\" -> \"y\"");
-    }
+    expectFailureWhenTesting().that(diffMessage).withPartialScope(fieldScope).isEqualTo(message);
+    expectIsEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("modified: o_int: 1 -> 2");
+    expectThatFailure().hasMessageThat().contains("modified: r_string[0]: \"x\" -> \"y\"");
 
-    try {
-      assertThat(eqMessage).withPartialScope(fieldScope).isNotEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsNotEqualToFailed(e);
-      expectSubstr(e, "ignored: o_enum");
-      expectSubstr(e, "ignored: o_sub_test_message");
-    }
+    expectFailureWhenTesting().that(eqMessage).withPartialScope(fieldScope).isNotEqualTo(message);
+    expectIsNotEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("ignored: o_enum");
+    expectThatFailure().hasMessageThat().contains("ignored: o_sub_test_message");
   }
 
   @Test
@@ -664,12 +603,12 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
     Message message2 = parse("o_int: 33");
 
     try {
-      expectThat(message1).ignoringFields(999).isEqualTo(message2);
-      expectedFailure();
-    } catch (Exception e) {
+      assertThat(message1).ignoringFields(999).isEqualTo(message2);
+      fail("Expected failure.");
+    } catch (Exception expected) {
       // TODO(user): Use hasTransitiveCauseThat() if/when it becomes available.
 
-      Throwable cause = e;
+      Throwable cause = expected;
       while (cause != null) {
         if (cause
             .getMessage()
@@ -683,7 +622,6 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
         fail("No cause with field number error message.");
       }
     }
-
   }
 
   @Test
@@ -779,39 +717,34 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
             FieldScopes.fromSetFields(parse("o_int: -1"), nullMessage, parse("r_string: \"NaN\"")))
         .containsExactly(eqMessage1, eqMessage2);
 
-    try {
-      assertThat(listOf(message1, message2))
-          .withPartialScope(FieldScopes.fromSetFields(messages))
-          .containsExactly(eqIgnoredMessage1, eqIgnoredMessage2);
-      fail("Expected failure.");
-    } catch (AssertionError expected) {
-      expectSubstr(
-          expected,
-          "is equivalent according to "
-              + "assertThat(proto)"
-              + ".withPartialScope("
-              + "FieldScopes.fromSetFields(["
-              + "{o_int: -1\n}, null, {r_string: \"NaN\"\n}]))"
-              + ".isEqualTo(target)");
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1, message2))
+        .withPartialScope(FieldScopes.fromSetFields(messages))
+        .containsExactly(eqIgnoredMessage1, eqIgnoredMessage2);
+    expectThatFailure()
+        .hasMessageThat()
+        .contains(
+            "is equivalent according to "
+                + "assertThat(proto)"
+                + ".withPartialScope("
+                + "FieldScopes.fromSetFields(["
+                + "{o_int: -1\n}, null, {r_string: \"NaN\"\n}]))"
+                + ".isEqualTo(target)");
 
-    try {
-      assertThat(listOf(message1, message2))
-          .withPartialScope(
-              FieldScopes.fromSetFields(
-                  parse("o_int: -1"), nullMessage, parse("r_string: \"NaN\"")))
-          .containsExactly(eqIgnoredMessage1, eqIgnoredMessage2);
-      fail("Expected failure.");
-    } catch (AssertionError expected) {
-      expectSubstr(
-          expected,
-          "is equivalent according to "
-              + "assertThat(proto)"
-              + ".withPartialScope("
-              + "FieldScopes.fromSetFields(["
-              + "{o_int: -1\n}, null, {r_string: \"NaN\"\n}]))"
-              + ".isEqualTo(target)");
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1, message2))
+        .withPartialScope(
+            FieldScopes.fromSetFields(parse("o_int: -1"), nullMessage, parse("r_string: \"NaN\"")))
+        .containsExactly(eqIgnoredMessage1, eqIgnoredMessage2);
+    expectThatFailure()
+        .hasMessageThat()
+        .contains(
+            "is equivalent according to "
+                + "assertThat(proto)"
+                + ".withPartialScope("
+                + "FieldScopes.fromSetFields(["
+                + "{o_int: -1\n}, null, {r_string: \"NaN\"\n}]))"
+                + ".isEqualTo(target)");
   }
 
   @Test
@@ -832,23 +765,16 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
         .withPartialScope(FieldScopes.fromSetFields(messages))
         .containsExactly(eqIgnoredMessage1, eqIgnoredMessage2);
 
-    try {
-      assertThat(listOf(message1, message2))
-          .withPartialScope(FieldScopes.fromSetFields(listOf()))
-          .containsNoneOf(eqIgnoredMessage1, eqIgnoredMessage2);
-      fail("Expected failure.");
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1, message2))
+        .withPartialScope(FieldScopes.fromSetFields(listOf()))
+        .containsNoneOf(eqIgnoredMessage1, eqIgnoredMessage2);
 
-    try {
-      assertThat(listOf(message1, message2))
-          .withPartialScope(FieldScopes.fromSetFields(messages))
-          .containsNoneOf(eqIgnoredMessage1, eqIgnoredMessage2);
-      fail("Expected failure.");
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1, message2))
+        .withPartialScope(FieldScopes.fromSetFields(messages))
+        .containsNoneOf(eqIgnoredMessage1, eqIgnoredMessage2);
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -864,9 +790,12 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
           TestMessage3.newBuilder().setOInt(2).build());
       fail("Expected failure.");
     } catch (RuntimeException expected) {
-      expectSubstr(expected, "Cannot create scope from messages with different descriptors");
-      expectSubstr(expected, TestMessage2.getDescriptor().getFullName());
-      expectSubstr(expected, TestMessage3.getDescriptor().getFullName());
+      expect
+          .that(expected)
+          .hasMessageThat()
+          .contains("Cannot create scope from messages with different descriptors");
+      expect.that(expected).hasMessageThat().contains(TestMessage2.getDescriptor().getFullName());
+      expect.that(expected).hasMessageThat().contains(TestMessage3.getDescriptor().getFullName());
     }
   }
 
@@ -891,12 +820,14 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
           .isEqualTo(eqMessage);
       fail("Expected failure.");
     } catch (RuntimeException expected) {
-      expectSubstr(
-          expected,
-          "Message given to FieldScopes.fromSetFields() "
-              + "does not have the same descriptor as the message being tested");
-      expectSubstr(expected, TestMessage2.getDescriptor().getFullName());
-      expectSubstr(expected, TestMessage3.getDescriptor().getFullName());
+      expect
+          .that(expected)
+          .hasMessageThat()
+          .contains(
+              "Message given to FieldScopes.fromSetFields() "
+                  + "does not have the same descriptor as the message being tested");
+      expect.that(expected).hasMessageThat().contains(TestMessage2.getDescriptor().getFullName());
+      expect.that(expected).hasMessageThat().contains(TestMessage3.getDescriptor().getFullName());
     }
   }
 
@@ -910,13 +841,11 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
         .ignoringFieldScope(FieldScopes.fromSetFields(parse("o_int: 1"), parse("o_enum: TWO")))
         .containsExactly(diffMessage1);
 
-    try {
-      assertThat(listOf(message))
-          .ignoringFieldScope(FieldScopes.fromSetFields(parse("o_int: 1"), parse("o_enum: TWO")))
-          .containsExactly(diffMessage2);
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message))
+        .ignoringFieldScope(FieldScopes.fromSetFields(parse("o_int: 1"), parse("o_enum: TWO")))
+        .containsExactly(diffMessage2);
+    expectThatFailure().isNotNull();
   }
 
   @Test

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/IterableOfProtosSubjectTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/IterableOfProtosSubjectTest.java
@@ -16,8 +16,6 @@
 
 package com.google.common.truth.extensions.proto;
 
-import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
-
 import com.google.protobuf.Message;
 import java.util.Collection;
 import java.util.Comparator;
@@ -62,43 +60,27 @@ public class IterableOfProtosSubjectTest extends ProtoSubjectTestBase {
     expectThat(listOf()).isEmpty();
     expectThat(listOf(message1)).isNotEmpty();
 
-    try {
-      assertThat(listOf(message1)).isEmpty();
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting().that(listOf(message1)).isEmpty();
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(listOf()).isNotEmpty();
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting().that(listOf()).isNotEmpty();
+    expectThatFailure().isNotNull();
   }
 
   @Test
   public void testPlain_hasSize() {
     expectThat(listOf(message1, message2)).hasSize(2);
 
-    try {
-      assertThat(listOf(message1)).hasSize(3);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting().that(listOf(message1)).hasSize(3);
+    expectThatFailure().isNotNull();
   }
 
   @Test
   public void testPlain_containsNoDuplicates() {
     expectThat(listOf(message1, message2)).containsNoDuplicates();
 
-    try {
-      assertThat(listOf(message1, eqMessage1)).containsNoDuplicates();
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting().that(listOf(message1, eqMessage1)).containsNoDuplicates();
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -106,19 +88,11 @@ public class IterableOfProtosSubjectTest extends ProtoSubjectTestBase {
     expectThat(listOf(message1, message2)).contains(eqMessage2);
     expectThat(listOf(message1, message2)).doesNotContain(eqIgnoredMessage1);
 
-    try {
-      assertThat(listOf(message1, message2)).contains(eqIgnoredMessage1);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting().that(listOf(message1, message2)).contains(eqIgnoredMessage1);
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(listOf(message1, message2)).doesNotContain(eqMessage1);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting().that(listOf(message1, message2)).doesNotContain(eqMessage1);
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -127,28 +101,20 @@ public class IterableOfProtosSubjectTest extends ProtoSubjectTestBase {
     expectThat(listOf(message1, message2)).containsAnyIn(listOf(eqIgnoredMessage1, eqMessage2));
     expectThat(listOf(message1, message2)).containsAnyIn(arrayOf(eqIgnoredMessage1, eqMessage2));
 
-    try {
-      assertThat(listOf(message1, message2)).containsAnyOf(eqIgnoredMessage1, eqIgnoredMessage2);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1, message2))
+        .containsAnyOf(eqIgnoredMessage1, eqIgnoredMessage2);
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(listOf(message1, message2))
-          .containsAnyIn(listOf(eqIgnoredMessage1, eqIgnoredMessage2));
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1, message2))
+        .containsAnyIn(listOf(eqIgnoredMessage1, eqIgnoredMessage2));
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(listOf(message1, message2))
-          .containsAnyIn(arrayOf(eqIgnoredMessage1, eqIgnoredMessage2));
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1, message2))
+        .containsAnyIn(arrayOf(eqIgnoredMessage1, eqIgnoredMessage2));
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -159,26 +125,16 @@ public class IterableOfProtosSubjectTest extends ProtoSubjectTestBase {
     expectThat(listOf(message1, message2, eqIgnoredMessage1))
         .containsAllIn(arrayOf(eqMessage1, eqMessage2));
 
-    try {
-      assertThat(listOf(message1)).containsAllOf(eqMessage1, eqMessage2);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting().that(listOf(message1)).containsAllOf(eqMessage1, eqMessage2);
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(listOf(message1)).containsAllIn(listOf(eqMessage1, eqMessage2));
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting().that(listOf(message1)).containsAllIn(listOf(eqMessage1, eqMessage2));
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(listOf(message1)).containsAllIn(arrayOf(eqMessage1, eqMessage2));
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1))
+        .containsAllIn(arrayOf(eqMessage1, eqMessage2));
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -196,51 +152,36 @@ public class IterableOfProtosSubjectTest extends ProtoSubjectTestBase {
         .containsExactlyElementsIn(arrayOf(eqMessage1, eqMessage2))
         .inOrder();
 
-    try {
-      assertThat(listOf(message1)).containsExactly(eqMessage1, eqMessage2);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting().that(listOf(message1)).containsExactly(eqMessage1, eqMessage2);
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(listOf(message1, message2)).containsExactly(eqMessage2, eqMessage1).inOrder();
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1, message2))
+        .containsExactly(eqMessage2, eqMessage1)
+        .inOrder();
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(listOf(message1)).containsExactlyElementsIn(listOf(eqMessage1, eqMessage2));
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1))
+        .containsExactlyElementsIn(listOf(eqMessage1, eqMessage2));
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(listOf(message1, message2))
-          .containsExactlyElementsIn(listOf(eqMessage2, eqMessage1))
-          .inOrder();
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1, message2))
+        .containsExactlyElementsIn(listOf(eqMessage2, eqMessage1))
+        .inOrder();
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(listOf(message1)).containsExactlyElementsIn(arrayOf(eqMessage1, eqMessage2));
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1))
+        .containsExactlyElementsIn(arrayOf(eqMessage1, eqMessage2));
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(listOf(message1, message2))
-          .containsExactlyElementsIn(arrayOf(eqMessage2, eqMessage1))
-          .inOrder();
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1, message2))
+        .containsExactlyElementsIn(arrayOf(eqMessage2, eqMessage1))
+        .inOrder();
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -249,26 +190,20 @@ public class IterableOfProtosSubjectTest extends ProtoSubjectTestBase {
     expectThat(listOf(message1)).containsNoneIn(listOf(eqMessage2, eqIgnoredMessage1));
     expectThat(listOf(message1)).containsNoneIn(arrayOf(eqMessage2, eqIgnoredMessage1));
 
-    try {
-      assertThat(listOf(message1, message2)).containsNoneOf(eqMessage2, eqIgnoredMessage1);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1, message2))
+        .containsNoneOf(eqMessage2, eqIgnoredMessage1);
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(listOf(message1, message2)).containsNoneIn(listOf(eqMessage2, eqIgnoredMessage1));
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1, message2))
+        .containsNoneIn(listOf(eqMessage2, eqIgnoredMessage1));
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(listOf(message1, message2)).containsNoneIn(arrayOf(eqMessage2, eqIgnoredMessage1));
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1, message2))
+        .containsNoneIn(arrayOf(eqMessage2, eqIgnoredMessage1));
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -276,20 +211,13 @@ public class IterableOfProtosSubjectTest extends ProtoSubjectTestBase {
     expectThat(listOf(message1, eqMessage1, message2)).isOrdered(compareByOIntAscending());
     expectThat(listOf(message1, message2)).isStrictlyOrdered(compareByOIntAscending());
 
-    try {
-      assertThat(listOf(message2, message1)).isOrdered(compareByOIntAscending());
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting().that(listOf(message2, message1)).isOrdered(compareByOIntAscending());
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(listOf(message1, eqMessage1, message2))
-          .isStrictlyOrdered(compareByOIntAscending());
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1, eqMessage1, message2))
+        .isStrictlyOrdered(compareByOIntAscending());
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -301,33 +229,29 @@ public class IterableOfProtosSubjectTest extends ProtoSubjectTestBase {
         .ignoringRepeatedFieldOrder()
         .doesNotContain(eqIgnoredMessage1);
 
-    try {
-      assertThat(listOf(message1, message2))
-          .ignoringFields(ignoreFieldNumber)
-          .contains(eqRepeatedMessage1);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectSubstr(
-          expected,
-          "is equivalent according to "
-              + "assertThat(proto)"
-              + ".ignoringFields("
-              + fullMessageName()
-              + ".o_int)"
-              + ".isEqualTo(target)");
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1, message2))
+        .ignoringFields(ignoreFieldNumber)
+        .contains(eqRepeatedMessage1);
+    expectThatFailure()
+        .hasMessageThat()
+        .contains(
+            "is equivalent according to "
+                + "assertThat(proto)"
+                + ".ignoringFields("
+                + fullMessageName()
+                + ".o_int)"
+                + ".isEqualTo(target)");
 
-    try {
-      assertThat(listOf(message1, message2))
-          .ignoringRepeatedFieldOrder()
-          .doesNotContain(eqRepeatedMessage1);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectSubstr(
-          expected,
-          "is equivalent according to "
-              + "assertThat(proto).ignoringRepeatedFieldOrder().isEqualTo(target)");
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1, message2))
+        .ignoringRepeatedFieldOrder()
+        .doesNotContain(eqRepeatedMessage1);
+    expectThatFailure()
+        .hasMessageThat()
+        .contains(
+            "is equivalent according to "
+                + "assertThat(proto).ignoringRepeatedFieldOrder().isEqualTo(target)");
   }
 
   @Test
@@ -339,33 +263,29 @@ public class IterableOfProtosSubjectTest extends ProtoSubjectTestBase {
         .ignoringRepeatedFieldOrder()
         .containsAnyIn(listOf(eqIgnoredMessage1, eqRepeatedMessage2));
 
-    try {
-      assertThat(listOf(message1, message2))
-          .ignoringFields(ignoreFieldNumber)
-          .containsAnyOf(eqRepeatedMessage1, eqRepeatedMessage2);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectSubstr(
-          expected,
-          "is equivalent according to "
-              + "assertThat(proto)"
-              + ".ignoringFields("
-              + fullMessageName()
-              + ".o_int)"
-              + ".isEqualTo(target)");
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1, message2))
+        .ignoringFields(ignoreFieldNumber)
+        .containsAnyOf(eqRepeatedMessage1, eqRepeatedMessage2);
+    expectThatFailure()
+        .hasMessageThat()
+        .contains(
+            "is equivalent according to "
+                + "assertThat(proto)"
+                + ".ignoringFields("
+                + fullMessageName()
+                + ".o_int)"
+                + ".isEqualTo(target)");
 
-    try {
-      assertThat(listOf(message1, message2))
-          .ignoringRepeatedFieldOrder()
-          .containsAnyIn(listOf(eqIgnoredMessage1, eqIgnoredMessage2));
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectSubstr(
-          expected,
-          "is equivalent according to "
-              + "assertThat(proto).ignoringRepeatedFieldOrder().isEqualTo(target)");
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1, message2))
+        .ignoringRepeatedFieldOrder()
+        .containsAnyIn(listOf(eqIgnoredMessage1, eqIgnoredMessage2));
+    expectThatFailure()
+        .hasMessageThat()
+        .contains(
+            "is equivalent according to "
+                + "assertThat(proto).ignoringRepeatedFieldOrder().isEqualTo(target)");
   }
 
   @Test
@@ -380,23 +300,17 @@ public class IterableOfProtosSubjectTest extends ProtoSubjectTestBase {
         .ignoringRepeatedFieldOrder()
         .containsAllIn(listOf(eqRepeatedMessage1, eqRepeatedMessage2));
 
-    try {
-      assertThat(listOf(message1))
-          .ignoringRepeatedFieldOrder()
-          .containsAllOf(eqMessage1, eqMessage2);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1))
+        .ignoringRepeatedFieldOrder()
+        .containsAllOf(eqMessage1, eqMessage2);
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(listOf(message1))
-          .ignoringRepeatedFieldOrder()
-          .containsAllIn(listOf(eqMessage1, eqMessage2));
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1))
+        .ignoringRepeatedFieldOrder()
+        .containsAllIn(listOf(eqMessage1, eqMessage2));
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -416,43 +330,31 @@ public class IterableOfProtosSubjectTest extends ProtoSubjectTestBase {
         .containsExactlyElementsIn(listOf(eqRepeatedMessage1, eqRepeatedMessage2))
         .inOrder();
 
-    try {
-      assertThat(listOf(message1))
-          .ignoringRepeatedFieldOrder()
-          .containsExactly(eqMessage1, eqMessage2);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1))
+        .ignoringRepeatedFieldOrder()
+        .containsExactly(eqMessage1, eqMessage2);
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(listOf(message1, message2))
-          .ignoringRepeatedFieldOrder()
-          .containsExactly(eqMessage2, eqMessage1)
-          .inOrder();
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1, message2))
+        .ignoringRepeatedFieldOrder()
+        .containsExactly(eqMessage2, eqMessage1)
+        .inOrder();
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(listOf(message1))
-          .ignoringRepeatedFieldOrder()
-          .containsExactlyElementsIn(listOf(eqMessage1, eqMessage2));
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1))
+        .ignoringRepeatedFieldOrder()
+        .containsExactlyElementsIn(listOf(eqMessage1, eqMessage2));
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(listOf(message1, message2))
-          .ignoringRepeatedFieldOrder()
-          .containsExactlyElementsIn(listOf(eqMessage2, eqMessage1))
-          .inOrder();
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1, message2))
+        .ignoringRepeatedFieldOrder()
+        .containsExactlyElementsIn(listOf(eqMessage2, eqMessage1))
+        .inOrder();
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -464,33 +366,29 @@ public class IterableOfProtosSubjectTest extends ProtoSubjectTestBase {
         .ignoringRepeatedFieldOrder()
         .containsNoneIn(listOf(eqMessage2, eqIgnoredMessage1));
 
-    try {
-      assertThat(listOf(message1, message2))
-          .ignoringFields(ignoreFieldNumber)
-          .containsNoneOf(eqRepeatedMessage1, eqIgnoredMessage2);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectSubstr(
-          expected,
-          "is equivalent according to "
-              + "assertThat(proto)"
-              + ".ignoringFields("
-              + fullMessageName()
-              + ".o_int)"
-              + ".isEqualTo(target)");
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1, message2))
+        .ignoringFields(ignoreFieldNumber)
+        .containsNoneOf(eqRepeatedMessage1, eqIgnoredMessage2);
+    expectThatFailure()
+        .hasMessageThat()
+        .contains(
+            "is equivalent according to "
+                + "assertThat(proto)"
+                + ".ignoringFields("
+                + fullMessageName()
+                + ".o_int)"
+                + ".isEqualTo(target)");
 
-    try {
-      assertThat(listOf(message1, message2))
-          .ignoringRepeatedFieldOrder()
-          .containsNoneIn(listOf(eqIgnoredMessage1, eqRepeatedMessage2));
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectSubstr(
-          expected,
-          "is equivalent according to "
-              + "assertThat(proto).ignoringRepeatedFieldOrder().isEqualTo(target)");
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1, message2))
+        .ignoringRepeatedFieldOrder()
+        .containsNoneIn(listOf(eqIgnoredMessage1, eqRepeatedMessage2));
+    expectThatFailure()
+        .hasMessageThat()
+        .contains(
+            "is equivalent according to "
+                + "assertThat(proto).ignoringRepeatedFieldOrder().isEqualTo(target)");
   }
 
   @Test
@@ -502,81 +400,75 @@ public class IterableOfProtosSubjectTest extends ProtoSubjectTestBase {
     // error messages look prettier. Might require some thought to avoid eating too much vertical
     // space, also indentation adds complexity.
 
-    try {
-      assertThat(listOf(message1))
-          .withPartialScope(FieldScopes.fromSetFields(message2))
-          .ignoringRepeatedFieldOrder()
-          .contains(message2);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectSubstr(
-          expected,
-          "assertThat(proto).withPartialScope(FieldScopes.fromSetFields({o_int: 3\n"
-              + "r_string: \"baz\"\n"
-              + "r_string: \"qux\"\n"
-              + "})).ignoringRepeatedFieldOrder().isEqualTo(target)");
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1))
+        .withPartialScope(FieldScopes.fromSetFields(message2))
+        .ignoringRepeatedFieldOrder()
+        .contains(message2);
+    expectThatFailure()
+        .hasMessageThat()
+        .contains(
+            "assertThat(proto).withPartialScope(FieldScopes.fromSetFields({o_int: 3\n"
+                + "r_string: \"baz\"\n"
+                + "r_string: \"qux\"\n"
+                + "})).ignoringRepeatedFieldOrder().isEqualTo(target)");
 
-    try {
-      assertThat(listOf(message1))
-          .ignoringRepeatedFieldOrder()
-          .ignoringFieldScope(
-              FieldScopes.ignoringFields(getFieldNumber("o_int"), getFieldNumber("r_string")))
-          .ignoringFieldAbsence()
-          .contains(message2);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectSubstr(
-          expected,
-          "assertThat(proto)"
-              + ".ignoringRepeatedFieldOrder()"
-              + ".ignoringFieldScope("
-              + "FieldScopes.ignoringFields("
-              + fullMessageName()
-              + ".o_int, "
-              + fullMessageName()
-              + ".r_string))"
-              + ".ignoringFieldAbsence()"
-              + ".isEqualTo(target)");
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1))
+        .ignoringRepeatedFieldOrder()
+        .ignoringFieldScope(
+            FieldScopes.ignoringFields(getFieldNumber("o_int"), getFieldNumber("r_string")))
+        .ignoringFieldAbsence()
+        .contains(message2);
+    expectThatFailure()
+        .hasMessageThat()
+        .contains(
+            "assertThat(proto)"
+                + ".ignoringRepeatedFieldOrder()"
+                + ".ignoringFieldScope("
+                + "FieldScopes.ignoringFields("
+                + fullMessageName()
+                + ".o_int, "
+                + fullMessageName()
+                + ".r_string))"
+                + ".ignoringFieldAbsence()"
+                + ".isEqualTo(target)");
 
-    try {
-      assertThat(listOf(message1))
-          .ignoringFields(4, 7)
-          .reportingMismatchesOnly()
-          .contains(message2);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectSubstr(
-          expected,
-          "assertThat(proto)"
-              + ".ignoringFields("
-              + fullMessageName()
-              + ".o_enum, "
-              + fullMessageName()
-              + ".o_test_message)"
-              + ".reportingMismatchesOnly()"
-              + ".isEqualTo(target)");
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1))
+        .ignoringFields(4, 7)
+        .reportingMismatchesOnly()
+        .contains(message2);
+    expectThatFailure()
+        .hasMessageThat()
+        .contains(
+            "assertThat(proto)"
+                + ".ignoringFields("
+                + fullMessageName()
+                + ".o_enum, "
+                + fullMessageName()
+                + ".o_test_message)"
+                + ".reportingMismatchesOnly()"
+                + ".isEqualTo(target)");
   }
 
   @Test
   public void testFormatDiff() {
-    try {
-      assertThat(listOf(message1)).ignoringRepeatedFieldOrder().containsExactly(message2);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectSubstr(
-          expected,
-          "(diff: Differences were found:\n"
-              + "modified: o_int: 3 -> 1\n"
-              + "added: r_string[0]: \"foo\"\n"
-              + "added: r_string[1]: \"bar\"\n"
-              + "deleted: r_string[0]: \"baz\"\n"
-              + "deleted: r_string[1]: \"qux\"\n"
-              + "\n"
-              + "Full diff report:\n");
-    }
+    expectFailureWhenTesting()
+        .that(listOf(message1))
+        .ignoringRepeatedFieldOrder()
+        .containsExactly(message2);
+    expectThatFailure()
+        .hasMessageThat()
+        .contains(
+            "(diff: Differences were found:\n"
+                + "modified: o_int: 3 -> 1\n"
+                + "added: r_string[0]: \"foo\"\n"
+                + "added: r_string[1]: \"bar\"\n"
+                + "deleted: r_string[0]: \"baz\"\n"
+                + "deleted: r_string[1]: \"qux\"\n"
+                + "\n"
+                + "Full diff report:\n");
   }
 
   @Test

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/IterableOfProtosSubjectTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/IterableOfProtosSubjectTest.java
@@ -436,7 +436,7 @@ public class IterableOfProtosSubjectTest extends ProtoSubjectTestBase {
 
     expectFailureWhenTesting()
         .that(listOf(message1))
-        .ignoringFields(4, 7)
+        .ignoringFields(getFieldNumber("o_enum"), getFieldNumber("o_test_message"))
         .reportingMismatchesOnly()
         .contains(message2);
     expectThatFailure()

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubjectTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubjectTest.java
@@ -16,8 +16,6 @@
 
 package com.google.common.truth.extensions.proto;
 
-import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Message;
 import java.util.Collection;
@@ -62,19 +60,13 @@ public class MapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
     expectThat(mapOf(1, message1, 2, message2)).isEqualTo(mapOf(2, eqMessage2, 1, eqMessage1));
     expectThat(mapOf(1, message2)).isNotEqualTo(mapOf(1, message1));
 
-    try {
-      assertThat(mapOf(1, message2, 2, message1)).isEqualTo(mapOf(1, eqMessage1, 2, eqMessage2));
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(mapOf(1, message2, 2, message1))
+        .isEqualTo(mapOf(1, eqMessage1, 2, eqMessage2));
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(mapOf(1, message1)).isNotEqualTo(mapOf(1, eqMessage1));
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting().that(mapOf(1, message1)).isNotEqualTo(mapOf(1, eqMessage1));
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -82,31 +74,19 @@ public class MapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
     expectThat(ImmutableMap.of()).isEmpty();
     expectThat(mapOf(1, message1)).isNotEmpty();
 
-    try {
-      assertThat(mapOf(1, message1)).isEmpty();
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting().that(mapOf(1, message1)).isEmpty();
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(ImmutableMap.of()).isNotEmpty();
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting().that(ImmutableMap.of()).isNotEmpty();
+    expectThatFailure().isNotNull();
   }
 
   @Test
   public void testPlain_hasSize() {
     expectThat(mapOf(1, message1, 2, message2)).hasSize(2);
 
-    try {
-      assertThat(mapOf(1, message1)).hasSize(3);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting().that(mapOf(1, message1)).hasSize(3);
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -114,19 +94,11 @@ public class MapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
     expectThat(mapOf(1, message1, 2, message2)).containsKey(1);
     expectThat(mapOf(1, message1, 2, message2)).doesNotContainKey(3);
 
-    try {
-      assertThat(mapOf(1, message1, 2, message2)).containsKey(3);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting().that(mapOf(1, message1, 2, message2)).containsKey(3);
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(mapOf(1, message1, 2, message2)).doesNotContainKey(2);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting().that(mapOf(1, message1, 2, message2)).doesNotContainKey(2);
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -134,19 +106,13 @@ public class MapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
     expectThat(mapOf(1, message1, 2, message2)).containsEntry(2, eqMessage2);
     expectThat(mapOf(1, message1, 2, message2)).doesNotContainEntry(1, eqMessage2);
 
-    try {
-      assertThat(mapOf(1, message1, 2, message2)).containsEntry(2, eqMessage1);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting().that(mapOf(1, message1, 2, message2)).containsEntry(2, eqMessage1);
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(mapOf(1, message1, 2, message2)).doesNotContainEntry(2, eqMessage2);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(mapOf(1, message1, 2, message2))
+        .doesNotContainEntry(2, eqMessage2);
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -161,37 +127,27 @@ public class MapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
         .containsExactlyEntriesIn(mapOf(1, eqMessage1, 2, eqMessage2))
         .inOrder();
 
-    try {
-      assertThat(mapOf(1, message1)).containsExactly(1, eqMessage1, 2, eqMessage2);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(mapOf(1, message1))
+        .containsExactly(1, eqMessage1, 2, eqMessage2);
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(mapOf(1, message1, 2, message2))
-          .containsExactly(2, eqMessage2, 1, eqMessage1)
-          .inOrder();
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(mapOf(1, message1, 2, message2))
+        .containsExactly(2, eqMessage2, 1, eqMessage1)
+        .inOrder();
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(mapOf(1, message1)).containsExactlyEntriesIn(mapOf(2, eqMessage2, 1, eqMessage1));
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(mapOf(1, message1))
+        .containsExactlyEntriesIn(mapOf(2, eqMessage2, 1, eqMessage1));
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(mapOf(1, message1, 2, message2))
-          .containsExactlyEntriesIn(mapOf(2, eqMessage2, 1, eqMessage1))
-          .inOrder();
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(mapOf(1, message1, 2, message2))
+        .containsExactlyEntriesIn(mapOf(2, eqMessage2, 1, eqMessage1))
+        .inOrder();
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -203,33 +159,29 @@ public class MapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
         .ignoringRepeatedFieldOrderForValues()
         .doesNotContainEntry(1, eqIgnoredMessage1);
 
-    try {
-      assertThat(mapOf(1, message1, 2, message2))
-          .ignoringFieldsForValues(ignoreFieldNumber)
-          .containsEntry(1, eqRepeatedMessage1);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectSubstr(
-          expected,
-          "is equivalent according to "
-              + "assertThat(proto)"
-              + ".ignoringFields("
-              + fullMessageName()
-              + ".o_int)"
-              + ".isEqualTo(target)");
-    }
+    expectFailureWhenTesting()
+        .that(mapOf(1, message1, 2, message2))
+        .ignoringFieldsForValues(ignoreFieldNumber)
+        .containsEntry(1, eqRepeatedMessage1);
+    expectThatFailure()
+        .hasMessageThat()
+        .contains(
+            "is equivalent according to "
+                + "assertThat(proto)"
+                + ".ignoringFields("
+                + fullMessageName()
+                + ".o_int)"
+                + ".isEqualTo(target)");
 
-    try {
-      assertThat(mapOf(1, message1, 2, message2))
-          .ignoringRepeatedFieldOrderForValues()
-          .doesNotContainEntry(1, eqRepeatedMessage1);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectSubstr(
-          expected,
-          "is equivalent according to "
-              + "assertThat(proto).ignoringRepeatedFieldOrder().isEqualTo(target)");
-    }
+    expectFailureWhenTesting()
+        .that(mapOf(1, message1, 2, message2))
+        .ignoringRepeatedFieldOrderForValues()
+        .doesNotContainEntry(1, eqRepeatedMessage1);
+    expectThatFailure()
+        .hasMessageThat()
+        .contains(
+            "is equivalent according to "
+                + "assertThat(proto).ignoringRepeatedFieldOrder().isEqualTo(target)");
   }
 
   @Test
@@ -249,43 +201,31 @@ public class MapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
         .containsExactlyEntriesIn(mapOf(1, eqRepeatedMessage1, 2, eqRepeatedMessage2))
         .inOrder();
 
-    try {
-      assertThat(mapOf(1, message1))
-          .ignoringRepeatedFieldOrderForValues()
-          .containsExactly(1, eqRepeatedMessage1, 2, eqMessage2);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(mapOf(1, message1))
+        .ignoringRepeatedFieldOrderForValues()
+        .containsExactly(1, eqRepeatedMessage1, 2, eqMessage2);
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(mapOf(1, message1, 2, message2))
-          .ignoringFieldsForValues(ignoreFieldNumber)
-          .containsExactly(2, eqIgnoredMessage2, 1, eqIgnoredMessage1)
-          .inOrder();
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(mapOf(1, message1, 2, message2))
+        .ignoringFieldsForValues(ignoreFieldNumber)
+        .containsExactly(2, eqIgnoredMessage2, 1, eqIgnoredMessage1)
+        .inOrder();
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(mapOf(1, message1))
-          .ignoringRepeatedFieldOrderForValues()
-          .containsExactlyEntriesIn(mapOf(2, eqRepeatedMessage2, 1, eqRepeatedMessage1));
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(mapOf(1, message1))
+        .ignoringRepeatedFieldOrderForValues()
+        .containsExactlyEntriesIn(mapOf(2, eqRepeatedMessage2, 1, eqRepeatedMessage1));
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(mapOf(1, message1, 2, message2))
-          .ignoringFieldsForValues(ignoreFieldNumber)
-          .containsExactlyEntriesIn(mapOf(2, eqIgnoredMessage2, 1, eqIgnoredMessage1))
-          .inOrder();
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(mapOf(1, message1, 2, message2))
+        .ignoringFieldsForValues(ignoreFieldNumber)
+        .containsExactlyEntriesIn(mapOf(2, eqIgnoredMessage2, 1, eqIgnoredMessage1))
+        .inOrder();
+    expectThatFailure().isNotNull();
   }
 
   @Test

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/MultiExpectFailure.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/MultiExpectFailure.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.common.truth.extensions.proto;
+
+import com.google.common.base.Preconditions;
+import com.google.common.truth.ExpectFailure;
+import com.google.common.truth.StandardSubjectBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * A collection of {@link ExpectFailure} rules, for use in a single test case.
+ *
+ * <p>Users should instantiate {@code MultiExpectFailure} as a {@code @Rule}, then use {@link
+ * #whenTesting()} and {@link #getFailure()} just like you would with an ordinary {@link
+ * ExpectFailure} rule. Each call to {@link #whenTesting()} will clobber the previous {@link
+ * #getFailure()} results.
+ */
+class MultiExpectFailure implements TestRule {
+
+  private final List<ExpectFailure> expectFailures;
+  private int currentIndex = -1;
+
+  MultiExpectFailure(int size) {
+    expectFailures = new ArrayList<>(size);
+    for (int i = 0; i < size; i++) {
+      expectFailures.add(new ExpectFailure());
+    }
+  }
+
+  StandardSubjectBuilder whenTesting() {
+    Preconditions.checkState(
+        currentIndex < expectFailures.size() - 1,
+        "Not enough ExpectFailures (%s)",
+        expectFailures.size());
+    return expectFailures.get(++currentIndex).whenTesting();
+  }
+
+  AssertionError getFailure() {
+    Preconditions.checkState(currentIndex >= 0, "Must call 'whenTesting()' first.");
+    return expectFailures.get(currentIndex).getFailure();
+  }
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    Statement statement = base;
+    for (ExpectFailure expectFailure : expectFailures) {
+      statement = expectFailure.apply(statement, description);
+    }
+    return statement;
+  }
+}

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubjectTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubjectTest.java
@@ -16,8 +16,6 @@
 
 package com.google.common.truth.extensions.proto;
 
-import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.protobuf.Message;
@@ -63,31 +61,19 @@ public class MultimapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
     expectThat(ImmutableMultimap.of()).isEmpty();
     expectThat(multimapOf(1, message1)).isNotEmpty();
 
-    try {
-      assertThat(multimapOf(1, message1)).isEmpty();
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting().that(multimapOf(1, message1)).isEmpty();
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(ImmutableMap.of()).isNotEmpty();
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting().that(ImmutableMap.of()).isNotEmpty();
+    expectThatFailure().isNotNull();
   }
 
   @Test
   public void testPlain_hasSize() {
     expectThat(multimapOf(1, message1, 1, message2, 2, message1)).hasSize(3);
 
-    try {
-      assertThat(multimapOf(1, message1)).hasSize(3);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting().that(multimapOf(1, message1)).hasSize(3);
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -95,19 +81,15 @@ public class MultimapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
     expectThat(multimapOf(1, message1, 1, message2, 2, message1)).containsKey(1);
     expectThat(multimapOf(1, message1, 1, message2, 2, message1)).doesNotContainKey(3);
 
-    try {
-      assertThat(multimapOf(1, message1, 1, message2, 2, message1)).containsKey(3);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(multimapOf(1, message1, 1, message2, 2, message1))
+        .containsKey(3);
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(multimapOf(1, message1, 1, message2, 2, message1)).doesNotContainKey(2);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(multimapOf(1, message1, 1, message2, 2, message1))
+        .doesNotContainKey(2);
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -116,20 +98,15 @@ public class MultimapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
     expectThat(multimapOf(1, message1, 1, message2, 2, message1))
         .doesNotContainEntry(2, eqMessage2);
 
-    try {
-      assertThat(multimapOf(1, message1, 1, message2, 2, message1)).containsEntry(2, eqMessage2);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(multimapOf(1, message1, 1, message2, 2, message1))
+        .containsEntry(2, eqMessage2);
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(multimapOf(1, message1, 1, message2, 2, message1))
-          .doesNotContainEntry(1, eqMessage2);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(multimapOf(1, message1, 1, message2, 2, message1))
+        .doesNotContainEntry(1, eqMessage2);
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -140,22 +117,16 @@ public class MultimapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
         .containsExactlyEntriesIn(multimapOf(1, eqMessage1, 1, eqMessage2, 2, eqMessage1))
         .inOrder();
 
-    try {
-      assertThat(multimapOf(1, message1))
-          .containsExactlyEntriesIn(multimapOf(1, eqMessage1, 2, eqMessage2));
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(multimapOf(1, message1))
+        .containsExactlyEntriesIn(multimapOf(1, eqMessage1, 2, eqMessage2));
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(multimapOf(1, message1, 2, message2))
-          .containsExactlyEntriesIn(multimapOf(2, eqMessage2, 1, eqMessage1))
-          .inOrder();
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(multimapOf(1, message1, 2, message2))
+        .containsExactlyEntriesIn(multimapOf(2, eqMessage2, 1, eqMessage1))
+        .inOrder();
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -163,12 +134,8 @@ public class MultimapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
     expectThat(ImmutableMultimap.of()).containsExactly();
     expectThat(ImmutableMultimap.of()).containsExactly().inOrder();
 
-    try {
-      assertThat(multimapOf(1, message1)).containsExactly();
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting().that(multimapOf(1, message1)).containsExactly();
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -179,21 +146,16 @@ public class MultimapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
         .containsExactly(1, eqMessage1, 1, eqMessage2, 2, eqMessage1)
         .inOrder();
 
-    try {
-      assertThat(multimapOf(1, message1)).containsExactly(1, eqMessage1, 2, eqMessage2);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(multimapOf(1, message1))
+        .containsExactly(1, eqMessage1, 2, eqMessage2);
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(multimapOf(1, message1, 2, message2))
-          .containsExactly(2, eqMessage2, 1, eqMessage1)
-          .inOrder();
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(multimapOf(1, message1, 2, message2))
+        .containsExactly(2, eqMessage2, 1, eqMessage1)
+        .inOrder();
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -203,15 +165,12 @@ public class MultimapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
         .containsExactly(eqMessage2, eqMessage1);
     expectThat(multimapOf(1, message1, 1, message2, 2, message1)).valuesForKey(2).hasSize(1);
 
-    try {
-      assertThat(multimapOf(1, message1, 1, message2, 2, message1))
-          .valuesForKey(1)
-          .containsExactly(eqMessage2, eqMessage1)
-          .inOrder();
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(multimapOf(1, message1, 1, message2, 2, message1))
+        .valuesForKey(1)
+        .containsExactly(eqMessage2, eqMessage1)
+        .inOrder();
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -223,33 +182,29 @@ public class MultimapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
         .ignoringRepeatedFieldOrderForValues()
         .doesNotContainEntry(1, eqIgnoredMessage2);
 
-    try {
-      assertThat(multimapOf(1, message1, 1, message2, 2, message1))
-          .ignoringFieldsForValues(ignoreFieldNumber)
-          .containsEntry(1, eqRepeatedMessage2);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectSubstr(
-          expected,
-          "is equivalent according to "
-              + "assertThat(proto)"
-              + ".ignoringFields("
-              + fullMessageName()
-              + ".o_int)"
-              + ".isEqualTo(target)");
-    }
+    expectFailureWhenTesting()
+        .that(multimapOf(1, message1, 1, message2, 2, message1))
+        .ignoringFieldsForValues(ignoreFieldNumber)
+        .containsEntry(1, eqRepeatedMessage2);
+    expectThatFailure()
+        .hasMessageThat()
+        .contains(
+            "is equivalent according to "
+                + "assertThat(proto)"
+                + ".ignoringFields("
+                + fullMessageName()
+                + ".o_int)"
+                + ".isEqualTo(target)");
 
-    try {
-      assertThat(multimapOf(1, message1, 1, message2, 2, message1))
-          .ignoringRepeatedFieldOrderForValues()
-          .doesNotContainEntry(1, eqRepeatedMessage2);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectSubstr(
-          expected,
-          "is equivalent according to "
-              + "assertThat(proto).ignoringRepeatedFieldOrder().isEqualTo(target)");
-    }
+    expectFailureWhenTesting()
+        .that(multimapOf(1, message1, 1, message2, 2, message1))
+        .ignoringRepeatedFieldOrderForValues()
+        .doesNotContainEntry(1, eqRepeatedMessage2);
+    expectThatFailure()
+        .hasMessageThat()
+        .contains(
+            "is equivalent according to "
+                + "assertThat(proto).ignoringRepeatedFieldOrder().isEqualTo(target)");
   }
 
   @Test
@@ -264,24 +219,18 @@ public class MultimapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
             multimapOf(1, eqRepeatedMessage1, 1, eqRepeatedMessage2, 2, eqRepeatedMessage1))
         .inOrder();
 
-    try {
-      assertThat(multimapOf(1, message1))
-          .ignoringRepeatedFieldOrderForValues()
-          .containsExactlyEntriesIn(multimapOf(2, eqRepeatedMessage2, 1, eqRepeatedMessage1));
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(multimapOf(1, message1))
+        .ignoringRepeatedFieldOrderForValues()
+        .containsExactlyEntriesIn(multimapOf(2, eqRepeatedMessage2, 1, eqRepeatedMessage1));
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(multimapOf(1, message1, 2, message2))
-          .ignoringFieldsForValues(ignoreFieldNumber)
-          .containsExactlyEntriesIn(multimapOf(2, eqIgnoredMessage2, 1, eqIgnoredMessage1))
-          .inOrder();
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(multimapOf(1, message1, 2, message2))
+        .ignoringFieldsForValues(ignoreFieldNumber)
+        .containsExactlyEntriesIn(multimapOf(2, eqIgnoredMessage2, 1, eqIgnoredMessage1))
+        .inOrder();
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -292,12 +241,11 @@ public class MultimapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
         .containsExactly()
         .inOrder();
 
-    try {
-      assertThat(multimapOf(1, message1)).ignoringRepeatedFieldOrderForValues().containsExactly();
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(multimapOf(1, message1))
+        .ignoringRepeatedFieldOrderForValues()
+        .containsExactly();
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -310,24 +258,18 @@ public class MultimapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
         .containsExactly(1, eqRepeatedMessage1, 1, eqRepeatedMessage2, 2, eqRepeatedMessage1)
         .inOrder();
 
-    try {
-      assertThat(multimapOf(1, message1))
-          .ignoringRepeatedFieldOrderForValues()
-          .containsExactly(2, eqRepeatedMessage2, 1, eqRepeatedMessage1);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(multimapOf(1, message1))
+        .ignoringRepeatedFieldOrderForValues()
+        .containsExactly(2, eqRepeatedMessage2, 1, eqRepeatedMessage1);
+    expectThatFailure().isNotNull();
 
-    try {
-      assertThat(multimapOf(1, message1, 2, message2))
-          .ignoringFieldsForValues(ignoreFieldNumber)
-          .containsExactly(2, eqIgnoredMessage2, 1, eqIgnoredMessage1)
-          .inOrder();
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(multimapOf(1, message1, 2, message2))
+        .ignoringFieldsForValues(ignoreFieldNumber)
+        .containsExactly(2, eqIgnoredMessage2, 1, eqIgnoredMessage1)
+        .inOrder();
+    expectThatFailure().isNotNull();
   }
 
   @Test
@@ -341,15 +283,12 @@ public class MultimapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
         .ignoringRepeatedFieldOrder()
         .containsExactly(eqRepeatedMessage1);
 
-    try {
-      assertThat(multimapOf(1, message1, 1, message2, 2, message1))
-          .valuesForKey(1)
-          .ignoringFields(ignoreFieldNumber)
-          .containsExactly(eqRepeatedMessage1, eqRepeatedMessage2);
-      expectedFailure();
-    } catch (AssertionError expected) {
-      expectFailureNotMissing(expected);
-    }
+    expectFailureWhenTesting()
+        .that(multimapOf(1, message1, 1, message2, 2, message1))
+        .valuesForKey(1)
+        .ignoringFields(ignoreFieldNumber)
+        .containsExactly(eqRepeatedMessage1, eqRepeatedMessage2);
+    expectThatFailure().isNotNull();
   }
 
   @Test

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTest.java
@@ -173,6 +173,30 @@ public class ProtoSubjectTest extends ProtoSubjectTestBase {
   }
 
   @Test
+  public void testDoubleTolerance() {
+    Message message = parse("o_double: 1.0");
+    Message diffMessage = parse("o_double: 1.1");
+
+    expectThat(diffMessage).isNotEqualTo(message);
+    expectThat(diffMessage).usingDoubleTolerance(0.2).isEqualTo(message);
+    expectThat(diffMessage).usingDoubleTolerance(0.05).isNotEqualTo(message);
+    expectThat(diffMessage).usingFloatTolerance(0.2f).isNotEqualTo(message);
+
+  }
+
+  @Test
+  public void testFloatTolerance() {
+    Message message = parse("o_float: 1.0");
+    Message diffMessage = parse("o_float: 1.1");
+
+    expectThat(diffMessage).isNotEqualTo(message);
+    expectThat(diffMessage).usingFloatTolerance(0.2f).isEqualTo(message);
+    expectThat(diffMessage).usingFloatTolerance(0.05f).isNotEqualTo(message);
+    expectThat(diffMessage).usingDoubleTolerance(0.2).isNotEqualTo(message);
+
+  }
+
+  @Test
   public void testReportingMismatchesOnly_isEqualTo() {
     Message message = parse("r_string: \"foo\" r_string: \"bar\"");
     Message diffMessage = parse("r_string: \"foo\" r_string: \"not_bar\"");

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTest.java
@@ -15,8 +15,6 @@
  */
 package com.google.common.truth.extensions.proto;
 
-import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
-
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.UnknownFieldSet;
@@ -66,25 +64,17 @@ public class ProtoSubjectTest extends ProtoSubjectTestBase {
     }
 
     if (!isProto3()) {
-      try {
-        assertThat(diffMessage).isEqualTo(message);
-        expectedFailure();
-      } catch (AssertionError e) {
-        expectIsEqualToFailed(e);
-        expectSubstr(e, "added: o_enum: DEFAULT");
-      }
+      expectFailureWhenTesting().that(diffMessage).isEqualTo(message);
+      expectIsEqualToFailed();
+      expectThatFailure().hasMessageThat().contains("added: o_enum: DEFAULT");
     }
 
-    try {
-      assertThat(diffMessage).ignoringFieldAbsence().isNotEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsNotEqualToFailed(e);
-      expectSubstr(e, "matched: o_int: 3");
-      if (!isProto3()) {
-        // Proto 3 doesn't cover the field at all when it's not set.
-        expectSubstr(e, "matched: o_enum: DEFAULT");
-      }
+    expectFailureWhenTesting().that(diffMessage).ignoringFieldAbsence().isNotEqualTo(message);
+    expectIsNotEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("matched: o_int: 3");
+    if (!isProto3()) {
+      // Proto 3 doesn't cover the field at all when it's not set.
+      expectThatFailure().hasMessageThat().contains("matched: o_enum: DEFAULT");
     }
   }
 
@@ -110,21 +100,13 @@ public class ProtoSubjectTest extends ProtoSubjectTestBase {
     expectThat(diffMessage).isNotEqualTo(message);
     expectThat(diffMessage).ignoringFieldAbsence().isEqualTo(message);
 
-    try {
-      assertThat(diffMessage).isEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsEqualToFailed(e);
-      expectSubstr(e, "added: 93[0]: 42");
-      expectSubstr(e, "deleted: 99[0]: 42");
-    }
+    expectFailureWhenTesting().that(diffMessage).isEqualTo(message);
+    expectIsEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("added: 93[0]: 42");
+    expectThatFailure().hasMessageThat().contains("deleted: 99[0]: 42");
 
-    try {
-      assertThat(diffMessage).ignoringFieldAbsence().isNotEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsNotEqualToFailed(e);
-    }
+    expectFailureWhenTesting().that(diffMessage).ignoringFieldAbsence().isNotEqualTo(message);
+    expectIsNotEqualToFailed();
   }
 
   @Test
@@ -162,33 +144,21 @@ public class ProtoSubjectTest extends ProtoSubjectTestBase {
     expectThat(eqNestedMessage).isNotEqualTo(nestedMessage);
     expectThat(eqNestedMessage).ignoringRepeatedFieldOrder().isEqualTo(nestedMessage);
 
-    try {
-      assertThat(eqMessage).isEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsEqualToFailed(e);
-      expectSubstr(e, "modified: r_string[0]: \"foo\" -> \"bar\"");
-      expectSubstr(e, "modified: r_string[1]: \"bar\" -> \"foo\"");
-    }
+    expectFailureWhenTesting().that(eqMessage).isEqualTo(message);
+    expectIsEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("modified: r_string[0]: \"foo\" -> \"bar\"");
+    expectThatFailure().hasMessageThat().contains("modified: r_string[1]: \"bar\" -> \"foo\"");
 
-    try {
-      assertThat(eqMessage).ignoringRepeatedFieldOrder().isNotEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsNotEqualToFailed(e);
-      expectSubstr(e, "moved: r_string[0] -> r_string[1]: \"foo\"");
-      expectSubstr(e, "moved: r_string[1] -> r_string[0]: \"bar\"");
-    }
+    expectFailureWhenTesting().that(eqMessage).ignoringRepeatedFieldOrder().isNotEqualTo(message);
+    expectIsNotEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("moved: r_string[0] -> r_string[1]: \"foo\"");
+    expectThatFailure().hasMessageThat().contains("moved: r_string[1] -> r_string[0]: \"bar\"");
 
-    try {
-      assertThat(diffMessage).ignoringRepeatedFieldOrder().isEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsEqualToFailed(e);
-      expectSubstr(e, "matched: r_string[0]: \"foo\"");
-      expectSubstr(e, "moved: r_string[1] -> r_string[2]: \"bar\"");
-      expectSubstr(e, "added: r_string[1]: \"foo\"");
-    }
+    expectFailureWhenTesting().that(diffMessage).ignoringRepeatedFieldOrder().isEqualTo(message);
+    expectIsEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("matched: r_string[0]: \"foo\"");
+    expectThatFailure().hasMessageThat().contains("moved: r_string[1] -> r_string[2]: \"bar\"");
+    expectThatFailure().hasMessageThat().contains("added: r_string[1]: \"foo\"");
   }
 
   @Test
@@ -196,25 +166,17 @@ public class ProtoSubjectTest extends ProtoSubjectTestBase {
     Message message = parse("r_string: \"foo\" r_string: \"bar\"");
     Message diffMessage = parse("r_string: \"foo\" r_string: \"not_bar\"");
 
-    try {
-      assertThat(diffMessage).isEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsEqualToFailed(e);
-      expectSubstr(e, "foo");
-      expectSubstr(e, "bar");
-      expectSubstr(e, "not_bar");
-    }
+    expectFailureWhenTesting().that(diffMessage).isEqualTo(message);
+    expectIsEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("foo");
+    expectThatFailure().hasMessageThat().contains("bar");
+    expectThatFailure().hasMessageThat().contains("not_bar");
 
-    try {
-      assertThat(diffMessage).reportingMismatchesOnly().isEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsEqualToFailed(e);
-      expectNoSubstr(e, "foo");
-      expectSubstr(e, "bar");
-      expectSubstr(e, "not_bar");
-    }
+    expectFailureWhenTesting().that(diffMessage).reportingMismatchesOnly().isEqualTo(message);
+    expectIsEqualToFailed();
+    expectThatFailure().hasMessageThat().doesNotContain("foo");
+    expectThatFailure().hasMessageThat().contains("bar");
+    expectThatFailure().hasMessageThat().contains("not_bar");
   }
 
   @Test
@@ -222,28 +184,21 @@ public class ProtoSubjectTest extends ProtoSubjectTestBase {
     Message message = parse("o_int: 33 r_string: \"foo\" r_string: \"bar\"");
     Message diffMessage = parse("o_int: 33 r_string: \"bar\" r_string: \"foo\"");
 
-    try {
-      assertThat(diffMessage).ignoringRepeatedFieldOrder().isNotEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsNotEqualToFailed(e);
-      expectSubstr(e, "33");
-      expectSubstr(e, "foo");
-      expectSubstr(e, "bar");
-    }
+    expectFailureWhenTesting().that(diffMessage).ignoringRepeatedFieldOrder().isNotEqualTo(message);
+    expectIsNotEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("33");
+    expectThatFailure().hasMessageThat().contains("foo");
+    expectThatFailure().hasMessageThat().contains("bar");
 
-    try {
-      assertThat(diffMessage)
-          .ignoringRepeatedFieldOrder()
-          .reportingMismatchesOnly()
-          .isNotEqualTo(message);
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectIsNotEqualToFailed(e);
-      expectNoSubstr(e, "33");
-      expectNoSubstr(e, "foo");
-      expectNoSubstr(e, "bar");
-    }
+    expectFailureWhenTesting()
+        .that(diffMessage)
+        .ignoringRepeatedFieldOrder()
+        .reportingMismatchesOnly()
+        .isNotEqualTo(message);
+    expectIsNotEqualToFailed();
+    expectThatFailure().hasMessageThat().doesNotContain("33");
+    expectThatFailure().hasMessageThat().doesNotContain("foo");
+    expectThatFailure().hasMessageThat().doesNotContain("bar");
   }
 
   @Test
@@ -257,22 +212,19 @@ public class ProtoSubjectTest extends ProtoSubjectTestBase {
     expectThat(parsePartial("o_required_string_message: { required_string: \"foo\" }"))
         .hasAllRequiredFields();
 
-    try {
-      assertThat(parsePartial("o_required_string_message: {}")).hasAllRequiredFields();
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectRegex(e, "Not true that <.*> has all required fields set\\.\\s*Missing: \\[.*\\].*");
-      expectSubstr(e, "[o_required_string_message.required_string]");
-    }
+    expectFailureWhenTesting()
+        .that(parsePartial("o_required_string_message: {}"))
+        .hasAllRequiredFields();
+    expectFailureMatches(
+        "Not true that <.*> has all required fields set\\.\\s*Missing: \\[.*\\].*");
+    expectThatFailure().hasMessageThat().contains("[o_required_string_message.required_string]");
 
-    try {
-      assertThat(parsePartial("r_required_string_message: {} r_required_string_message: {}"))
-          .hasAllRequiredFields();
-      expectedFailure();
-    } catch (AssertionError e) {
-      expectRegex(e, "Not true that <.*> has all required fields set\\.\\s*Missing: \\[.*\\].*");
-      expectSubstr(e, "r_required_string_message[0].required_string");
-      expectSubstr(e, "r_required_string_message[1].required_string");
-    }
+    expectFailureWhenTesting()
+        .that(parsePartial("r_required_string_message: {} r_required_string_message: {}"))
+        .hasAllRequiredFields();
+    expectFailureMatches(
+        "Not true that <.*> has all required fields set\\.\\s*Missing: \\[.*\\].*");
+    expectThatFailure().hasMessageThat().contains("r_required_string_message[0].required_string");
+    expectThatFailure().hasMessageThat().contains("r_required_string_message[1].required_string");
   }
 }

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTest.java
@@ -15,6 +15,7 @@
  */
 package com.google.common.truth.extensions.proto;
 
+import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.UnknownFieldSet;
@@ -35,6 +36,16 @@ public class ProtoSubjectTest extends ProtoSubjectTestBase {
 
   public ProtoSubjectTest(TestType testType) {
     super(testType);
+  }
+
+  @Test
+  public void testDifferentClasses() throws InvalidProtocolBufferException {
+    Message message = parse("o_int: 3");
+    DynamicMessage dynamicMessage =
+        DynamicMessage.parseFrom(message.getDescriptorForType(), message.toByteString());
+
+    expectThat(message).isEqualTo(dynamicMessage);
+    expectThat(dynamicMessage).isEqualTo(message);
   }
 
   @Test

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/proto_files/test_message2.proto
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/proto_files/test_message2.proto
@@ -19,13 +19,15 @@ message TestMessage2 {
   repeated string r_string = 2;
   optional int64 o_long_defaults_to_42 = 3 [default = 42];
   optional TestEnum2 o_enum = 4;
+  optional float o_float = 5;
+  optional double o_double = 6;
 
-  optional RequiredStringMessage2 o_required_string_message = 5;
-  repeated RequiredStringMessage2 r_required_string_message = 6;
-  optional TestMessage2 o_test_message = 7;
-  repeated TestMessage2 r_test_message = 8;
-  optional SubTestMessage2 o_sub_test_message = 9;
-  repeated SubTestMessage2 r_sub_test_message = 10;
+  optional RequiredStringMessage2 o_required_string_message = 7;
+  repeated RequiredStringMessage2 r_required_string_message = 8;
+  optional TestMessage2 o_test_message = 9;
+  repeated TestMessage2 r_test_message = 10;
+  optional SubTestMessage2 o_sub_test_message = 11;
+  repeated SubTestMessage2 r_sub_test_message = 12;
 }
 
 message RequiredStringMessage2 {

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/proto_files/test_message3.proto
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/proto_files/test_message3.proto
@@ -23,13 +23,15 @@ message TestMessage3 {
   repeated string r_string = 2;
   // optional int64 o_long_defaults_to_42 = 3 [default = 42];
   TestEnum3 o_enum = 4;
+  float o_float = 5;
+  double o_double = 6;
 
-  // optional RequiredStringMessage3 o_required_string_message = 5;
-  // repeated RequiredStringMessage3 r_required_string_message = 6;
-  TestMessage3 o_test_message = 7;
-  repeated TestMessage3 r_test_message = 8;
-  SubTestMessage3 o_sub_test_message = 9;
-  repeated SubTestMessage3 r_sub_test_message = 10;
+  // optional RequiredStringMessage3 o_required_string_message = 7;
+  // repeated RequiredStringMessage3 r_required_string_message = 8;
+  TestMessage3 o_test_message = 9;
+  repeated TestMessage3 r_test_message = 10;
+  SubTestMessage3 o_sub_test_message = 11;
+  repeated SubTestMessage3 r_sub_test_message = 12;
 }
 
 // message RequiredStringMessage3 {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Implement Subject.toString().

The inherited implementation throws UnsupportedOperationException because it calls hashCode() (and not identityHashCode() as I would have guessed).

It's been this way since we chose to override hashCode(); I just happened to get bit today when trying to use toString() to debug something.

280522122cc6766790cc5fc699c8bb56d0f4cf78

-------

<p> Migrate ProtoTruth tests to use ExpectFailure.

42c928b193471f9553e0f23796379b46144d6a95

-------

<p> Check only the descriptor identity before comparing messages, not the class identity.

RELNOTES=Check only the descriptor identity before comparing messages in ProtoSubject.

4c4a944369e047b3391636647fe1321b2bc3f950

-------

<p> Add support for float and double comparisons in ProtoTruth as per the API doc, https://docs.google.com/document/d/1T3wGIlanCu61_3-ozSL4u_lhfRoUpBcv0alqEM-UesE/edit.  Include a deprecated, stripped legacy mode to mimic ProtoAssert behavior.

RELNOTES=Add support for float and double comparisons in ProtoTruth.

24b1b7fd128e4200f758964fc295687dc00af55a

-------

<p> Remove 2 special cases for printing arrays:

1. Remove the type name from the output:

Not true that <(Object[]) [A, 5]> is empty
=>
Not true that <[A, 5]> is empty

Rationale: We don't include type names for Iterables (though of course that's in part because we would have to guess in some cases), and no one seems to mind. Similarly, when we introduced types like ImmutableIntArray, we didn't seem to think it was important to include there. Note that we still display the types in case of type mismatch (at least in most cases -- I'm not sure about nested array mismatches offhand, but there's not always a good way to represent such types, anyway).

2. Make named() supplement the existing actual value text, not replace it.

Not true that foo has length <1>
=>
Not true that foo (<[A, 5]>) has length <1>

Rationale: This is how named() behaves for normal types. The current behavior has been there since Truth was imported into [], so I don't know of any particular requests for it to be this way. My best guess is that it's intended to avoid "Not true that <... extremely long array ...> is...," most checks are probably going to be isEqualTo() checks, so we're going to end up with an extremely long array in the message, anyway, for the expected value. I suppose that abbreviation could help somewhat with length checks, but if someone really needs to avoid printing the value, I'd suggest `assertThat(array.length).isEqualTo(...)`.

RELNOTES:
  - Removed the type name from the output of arrays.
  - For array subjects, made `named()` supplement the existing actual value text, not replace it. This brings it in line with other subjects' behaviors.

eb698e4d8f0cdc5c967ddd9561f4ba7f912f6d21

-------

<p> Improvements to SubjectTest:

- Add tests for assertThat(null).is{,Not}EqualTo(null) for all built-in subjects.
- Add tests for comparing objects whose toString() is "null" to null.
- Rewrite isNotEqualToFailureWithObjects(), currently a duplicate of isNotEqualToFailureWithNulls(), to do what it was probably intended to do.

dde600e7d7fea2cb14672db0bd7eaebbc2642499

-------

<p> Add test for a questionable behavior.

38e390dcb803f45c583e4c3eab5d16ff53c1cf93