### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/ComparisonFailureWithFields.java
+++ b/core/src/main/java/com/google/common/truth/ComparisonFailureWithFields.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2014 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.truth;
+
+import com.google.common.truth.Platform.PlatformComparisonFailure;
+
+final class ComparisonFailureWithFields extends PlatformComparisonFailure {
+  ComparisonFailureWithFields(String message, String expected, String actual, Throwable cause) {
+    super(message, expected, actual, cause);
+  }
+
+  @Override
+  public String getMessage() {
+    return getMessagePassedToConstructor();
+  }
+}

--- a/core/src/main/java/com/google/common/truth/Expect.java
+++ b/core/src/main/java/com/google/common/truth/Expect.java
@@ -187,8 +187,8 @@ public final class Expect extends StandardSubjectBuilder implements TestRule {
       if (hasFailures()) {
         String message =
             caught instanceof AssumptionViolatedException
-                ? "Failures occurred before an assumption was violated"
-                : "Failures occurred before an exception was thrown while the test was running";
+                ? "Also, after those failures, an assumption was violated"
+                : "Also, after those failures, an exception was thrown";
         record(SimpleAssertionError.createWithNoStack(message + ": " + caught, caught));
         throw SimpleAssertionError.createWithNoStack(this.toString());
       } else {

--- a/core/src/main/java/com/google/common/truth/ExpectFailure.java
+++ b/core/src/main/java/com/google/common/truth/ExpectFailure.java
@@ -120,7 +120,9 @@ public final class ExpectFailure implements Platform.JUnitTestRule {
    */
   void ensureFailureCaught() {
     if (failureExpected && failure == null) {
-      throw new AssertionError("ExpectFailure.whenTesting() invoked, but no failure was caught.");
+      throw new AssertionError(
+          "ExpectFailure.whenTesting() invoked, but no failure was caught."
+              + Platform.EXPECT_FAILURE_WARNING_IF_GWT);
     }
   }
 

--- a/core/src/main/java/com/google/common/truth/FailureMetadata.java
+++ b/core/src/main/java/com/google/common/truth/FailureMetadata.java
@@ -17,7 +17,6 @@ package com.google.common.truth;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.truth.Platform.comparisonFailure;
 import static com.google.common.truth.StackTraceCleaner.cleanStackTrace;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -137,12 +136,14 @@ public final class FailureMetadata {
 
   void failComparing(String message, CharSequence expected, CharSequence actual) {
     doFail(
-        comparisonFailure(
+        new JUnitComparisonFailure(
             addToMessage(message), expected.toString(), actual.toString(), rootCause()));
   }
 
   void failComparing(String message, CharSequence expected, CharSequence actual, Throwable cause) {
-    doFail(comparisonFailure(addToMessage(message), expected.toString(), actual.toString(), cause));
+    doFail(
+        new JUnitComparisonFailure(
+            addToMessage(message), expected.toString(), actual.toString(), cause));
     // TODO(cpovirk): add rootCause() as a suppressed exception?
   }
 

--- a/core/src/main/java/com/google/common/truth/JUnitComparisonFailure.java
+++ b/core/src/main/java/com/google/common/truth/JUnitComparisonFailure.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2014 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.truth;
+
+import com.google.common.truth.Platform.PlatformComparisonFailure;
+
+final class JUnitComparisonFailure extends PlatformComparisonFailure {
+  JUnitComparisonFailure(String message, String expected, String actual, Throwable cause) {
+    super(message, expected, actual, cause);
+  }
+
+  @Override
+  public String getMessage() {
+    return getMessageComputedByComparisonFailure();
+  }
+}

--- a/core/src/main/java/com/google/common/truth/Platform.java
+++ b/core/src/main/java/com/google/common/truth/Platform.java
@@ -140,4 +140,6 @@ final class Platform {
    * implementation.
    */
   interface JUnitTestRule extends TestRule {}
+
+  static final String EXPECT_FAILURE_WARNING_IF_GWT = "";
 }

--- a/core/src/main/java/com/google/common/truth/StackTraceCleaner.java
+++ b/core/src/main/java/com/google/common/truth/StackTraceCleaner.java
@@ -233,16 +233,16 @@ final class StackTraceCleaner {
     NEVER_REMOVE("N/A"),
     TEST_FRAMEWORK(
         "Testing framework",
-        "junit.",
-        "org.junit.",
-        "com.google.testing.junit.",
-        "com.google.testing.testsize.",
-        "com.google.testing.util."),
-    REFLECTION("Reflective call", "java.lang.reflect.", "sun.reflect."),
+        "junit",
+        "org.junit",
+        "com.google.testing.junit",
+        "com.google.testing.testsize",
+        "com.google.testing.util"),
+    REFLECTION("Reflective call", "java.lang.reflect", "sun.reflect"),
     CONCURRENT_FRAMEWORK(
         "Concurrent framework",
         "com.google.tracing.CurrentContext",
-        "com.google.common.util.concurrent.",
+        "com.google.common.util.concurrent",
         "java.util.concurrent.ForkJoin");
 
     /** Helper method to determine the frame type from the fully qualified class name. */
@@ -287,7 +287,9 @@ final class StackTraceCleaner {
      */
     boolean belongsToType(String fullyQualifiedClassName) {
       for (String prefix : prefixes) {
-        if (fullyQualifiedClassName.startsWith(prefix)) {
+        // TODO(cpovirk): Should we also check prefix + "$"?
+        if (fullyQualifiedClassName.equals(prefix)
+            || fullyQualifiedClassName.startsWith(prefix + ".")) {
           return true;
         }
       }

--- a/core/src/main/java/com/google/common/truth/super/com/google/common/truth/Platform.java
+++ b/core/src/main/java/com/google/common/truth/super/com/google/common/truth/Platform.java
@@ -141,6 +141,16 @@ final class Platform {
    */
   interface JUnitTestRule {}
 
+  static final String EXPECT_FAILURE_WARNING_IF_GWT =
+      " Note: One possible reason for a failure not to be caught is for the test to throw some "
+          + "other exception before the failure would have happened. Under GWT, such an exception "
+          + "is hidden by this message. The non-GWT tests do not have this problem, so you may "
+          + "wish to debug them first. If you're still having this problem, consider temporarily "
+          + "modifying the GWT copy of BaseSubjectTestCase to remove the call to "
+          + "ensureFailureCaught(). Removing that call will let any other exception fall through. "
+          + "(But of course it will also prevent the test from verifying that the expected failure "
+          + "occurred.)";
+
   // TODO(user): Move this logic to a common location.
   private static NativeRegExp compile(String pattern) {
     return new NativeRegExp(pattern);

--- a/core/src/main/java/com/google/common/truth/super/com/google/common/truth/Platform.java
+++ b/core/src/main/java/com/google/common/truth/super/com/google/common/truth/Platform.java
@@ -20,7 +20,6 @@ import static java.lang.Double.parseDouble;
 import static java.lang.Float.parseFloat;
 import static jsinterop.annotations.JsPackage.GLOBAL;
 
-import com.google.common.truth.Truth.SimpleAssertionError;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 
@@ -50,10 +49,33 @@ final class Platform {
     return false;
   }
 
-  static AssertionError comparisonFailure(
-      String message, String expected, String actual, Throwable cause) {
-    return SimpleAssertionError.create(
-        format("%s expected:<[%s]> but was:<[%s]>", message, expected, actual), cause);
+  abstract static class PlatformComparisonFailure extends AssertionError {
+    private final String message;
+    private final String expected;
+    private final String actual;
+
+    PlatformComparisonFailure(String message, String expected, String actual, Throwable cause) {
+      super(message, cause);
+      this.message = message;
+      this.expected = expected;
+      this.actual = actual;
+    }
+
+    @Override
+    public abstract String getMessage();
+
+    final String getMessageComputedByComparisonFailure() {
+      return format("%s expected:<[%s]> but was:<[%s]>", message, expected, actual);
+    }
+
+    final String getMessagePassedToConstructor() {
+      return message;
+    }
+
+    @Override
+    public final String toString() {
+      return getLocalizedMessage();
+    }
   }
 
   /** Determines if the given subject contains a match for the given regex. */

--- a/core/src/test/java/com/google/common/truth/ExpectTest.java
+++ b/core/src/test/java/com/google/common/truth/ExpectTest.java
@@ -113,7 +113,7 @@ public class ExpectTest {
     thrown.expectMessage("1. Not true that <\"abc\"> contains <\"x\">");
     thrown.expectMessage("2. Not true that <\"abc\"> contains <\"y\">");
     thrown.expectMessage(
-        "3. Failures occurred before an exception was thrown while the test was running: "
+        "3. Also, after those failures, an exception was thrown: "
             + "java.lang.IllegalStateException");
     expect.that("abc").contains("x");
     expect.that("abc").contains("y");
@@ -126,7 +126,7 @@ public class ExpectTest {
     thrown.expectMessage("1. Not true that <\"abc\"> contains <\"x\">");
     thrown.expectMessage("2. Not true that <\"abc\"> contains <\"y\">");
     thrown.expectMessage(
-        "3. Failures occurred before an exception was thrown while the test was running: "
+        "3. Also, after those failures, an exception was thrown: "
             + "java.lang.IllegalStateException: testing");
     expect.that("abc").contains("x");
     expect.that("abc").contains("y");
@@ -152,7 +152,7 @@ public class ExpectTest {
     thrown.expectMessage("1. Not true that <\"abc\"> contains <\"x\">");
     thrown.expectMessage("2. Not true that <\"abc\"> contains <\"y\">");
     thrown.expectMessage(
-        "3. Failures occurred before an assumption was violated: "
+        "3. Also, after those failures, an assumption was violated: "
             + "com.google.common.truth.TruthJUnit$ThrowableAssumptionViolatedException: testing");
     expect.that("abc").contains("x");
     expect.that("abc").contains("y");

--- a/core/src/test/java/com/google/common/truth/super/com/google/common/truth/BaseSubjectTestCase.java
+++ b/core/src/test/java/com/google/common/truth/super/com/google/common/truth/BaseSubjectTestCase.java
@@ -15,9 +15,21 @@
  */
 package com.google.common.truth;
 
-import org.junit.Rule;
+import org.junit.After;
+import org.junit.Before;
 
-/** Base class for truth subject tests to extend. */
 public abstract class BaseSubjectTestCase {
-  @Rule public final ExpectFailure expectFailure = new ExpectFailure();
+
+  final ExpectFailure expectFailure = new ExpectFailure();
+
+  @Before
+  public void setupExpectFailure() {
+    expectFailure.enterRuleContext(); // safe since @After forces leaving the context
+  }
+
+  @After
+  public void ensureExpectedFailureCaught() {
+    expectFailure.leaveRuleContext();
+    expectFailure.ensureFailureCaught();
+  }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Tweak the message used when Expect has both failures and another exception.

To me, the current phrasing just seems backward: We already know about the failures, so the part we want to explain is what happened later.

fe988124ef8ec3e21b62ad5f8b827d654ee1a5fc

-------

<p> In StackTraceCleaner class matching, check for both exact matches and prefixes.

This lets us explicitly add a "." to the end of patterns when searching for prefixes. That way, if we want to remove "com.google.common.truth.Expect" from stack traces, we can do so without also removing "com.google.common.truth.ExpectFailure." (We probably won't need to match Expect by class name, though: We're more likely to match its enclosed Statement implementation. Still, this CL seems like a good thing, as it makes the API behave more like people would expect.)

1cc33bd35ccc92cc86d75e436baab67d6d020586

-------

<p> Fix use of ExpectFailure from Truth's own tests, which we accidentally broke in 06e03c143e3ed0cba608fbd3c610d9d7e5701b64.

Also, use ExpectFailure in different ways from GWT and non-GWT tests. For GWT tests, we're doing the best we can, but for non-GWT tests, we can go back to using @Rule.

f607e01ab24d9a6019d40659a36ab24d54e273ae

-------

<p> Introduce a ComparisonFailure that overrides the message generated by JUnit.

This lets us use ComparisonFailure in more situations without worrying that we'll be dramatically changing existing messages.

The new class is called "ComparisonFailureWithFields" because eventually it will take on the "value of," "expected," "but was," etc. format discussed in API Review.

204e63c7f3ca0b4e6e3ec65b70322bd9059da344