### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/ComparisonFailureWithFields.java
+++ b/core/src/main/java/com/google/common/truth/ComparisonFailureWithFields.java
@@ -16,15 +16,13 @@
 
 package com.google.common.truth;
 
+import static com.google.common.truth.Platform.ComparisonFailureMessageStrategy.OMIT_COMPARISON_FAILURE_GENERATED_MESSAGE;
+
 import com.google.common.truth.Platform.PlatformComparisonFailure;
 
 final class ComparisonFailureWithFields extends PlatformComparisonFailure {
-  ComparisonFailureWithFields(String message, String expected, String actual, Throwable cause) {
-    super(message, expected, actual, cause);
-  }
-
-  @Override
-  public String getMessage() {
-    return getMessagePassedToConstructor();
+  ComparisonFailureWithFields(
+      String message, String expected, String actual, String suffix, Throwable cause) {
+    super(message, expected, actual, suffix, cause, OMIT_COMPARISON_FAILURE_GENERATED_MESSAGE);
   }
 }

--- a/core/src/main/java/com/google/common/truth/ExpectFailure.java
+++ b/core/src/main/java/com/google/common/truth/ExpectFailure.java
@@ -89,7 +89,8 @@ public final class ExpectFailure implements Platform.JUnitTestRule {
   public StandardSubjectBuilder whenTesting() {
     checkState(inRuleContext, "ExpectFailure must be used as a JUnit @Rule");
     if (failure != null) {
-      throw SimpleAssertionError.create("ExpectFailure already captured a failure", failure);
+      throw SimpleAssertionError.create(
+          "ExpectFailure already captured a failure", /*suffix=*/ null, failure);
     }
     if (failureExpected) {
       throw new AssertionError(

--- a/core/src/main/java/com/google/common/truth/JUnitComparisonFailure.java
+++ b/core/src/main/java/com/google/common/truth/JUnitComparisonFailure.java
@@ -16,15 +16,13 @@
 
 package com.google.common.truth;
 
+import static com.google.common.truth.Platform.ComparisonFailureMessageStrategy.INCLUDE_COMPARISON_FAILURE_GENERATED_MESSAGE;
+
 import com.google.common.truth.Platform.PlatformComparisonFailure;
 
 final class JUnitComparisonFailure extends PlatformComparisonFailure {
-  JUnitComparisonFailure(String message, String expected, String actual, Throwable cause) {
-    super(message, expected, actual, cause);
-  }
-
-  @Override
-  public String getMessage() {
-    return getMessageComputedByComparisonFailure();
+  JUnitComparisonFailure(
+      String message, String expected, String actual, String suffix, Throwable cause) {
+    super(message, expected, actual, suffix, cause, INCLUDE_COMPARISON_FAILURE_GENERATED_MESSAGE);
   }
 }

--- a/core/src/main/java/com/google/common/truth/LazyMessage.java
+++ b/core/src/main/java/com/google/common/truth/LazyMessage.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2011 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.common.truth;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.truth.StringUtil.format;
+
+import com.google.common.annotations.VisibleForTesting;
+import javax.annotation.Nullable;
+
+final class LazyMessage {
+  private static final String PLACEHOLDER_ERR =
+      "Incorrect number of args (%s) for the given placeholders (%s) in string template:\"%s\"";
+
+  private final String format;
+  private final Object[] args;
+
+  LazyMessage(@Nullable String format, @Nullable Object... args) {
+    this.format = format;
+    this.args = args;
+    int placeholders = countPlaceholders(format);
+    checkArgument(placeholders == args.length, PLACEHOLDER_ERR, args.length, placeholders, format);
+  }
+
+  @Override
+  public String toString() {
+    return format(format, args);
+  }
+
+  @VisibleForTesting
+  static int countPlaceholders(@Nullable String template) {
+    if (template == null) {
+      return 0;
+    }
+    int index = 0;
+    int count = 0;
+    while (true) {
+      index = template.indexOf("%s", index);
+      if (index == -1) {
+        break;
+      }
+      index++;
+      count++;
+    }
+    return count;
+  }
+}

--- a/core/src/main/java/com/google/common/truth/ListMultimapSubject.java
+++ b/core/src/main/java/com/google/common/truth/ListMultimapSubject.java
@@ -27,8 +27,11 @@ import javax.annotation.Nullable;
  * @author Daniel Ploch
  */
 public final class ListMultimapSubject extends MultimapSubject {
-  ListMultimapSubject(FailureMetadata metadata, @Nullable ListMultimap<?, ?> multimap) {
-    super(metadata, multimap);
+  ListMultimapSubject(
+      FailureMetadata metadata,
+      @Nullable ListMultimap<?, ?> multimap,
+      @Nullable String typeDescription) {
+    super(metadata, multimap, typeDescription);
   }
 
   @Override

--- a/core/src/main/java/com/google/common/truth/MultimapSubject.java
+++ b/core/src/main/java/com/google/common/truth/MultimapSubject.java
@@ -60,8 +60,11 @@ public class MultimapSubject extends Subject<MultimapSubject, Multimap<?, ?>> {
         public void inOrder() {}
       };
 
-  MultimapSubject(FailureMetadata metadata, @Nullable Multimap<?, ?> multimap) {
-    super(metadata, multimap);
+  MultimapSubject(
+      FailureMetadata metadata,
+      @Nullable Multimap<?, ?> multimap,
+      @Nullable String typeDescription) {
+    super(metadata, multimap, typeDescription);
   }
 
   /** Fails if the multimap is not empty. */
@@ -163,9 +166,7 @@ public class MultimapSubject extends Subject<MultimapSubject, Multimap<?, ?>> {
    */
   @SuppressWarnings("unchecked") // safe because we only read, not write
   public IterableSubject valuesForKey(@Nullable Object key) {
-    return check()
-        .about(valuesForKeyFactory(key))
-        .that(((Multimap<Object, Object>) actual()).get(key));
+    return check("valuesForKey(%s)", key).that(((Multimap<Object, Object>) actual()).get(key));
   }
 
   @Override
@@ -286,35 +287,6 @@ public class MultimapSubject extends Subject<MultimapSubject, Multimap<?, ?>> {
       expectedMultimap.put(rest[i], rest[i + 1]);
     }
     return expectedMultimap;
-  }
-
-  private Factory<IterableSubject, Iterable<?>> valuesForKeyFactory(final Object key) {
-    return new Factory<IterableSubject, Iterable<?>>() {
-      @Override
-      public IterableSubject createSubject(FailureMetadata metadata, Iterable<?> actual) {
-        return new IterableValuesForKey(metadata, actualAsString(), key, actual);
-      }
-    };
-  }
-
-  private static class IterableValuesForKey extends IterableSubject {
-    @Nullable private final Object key;
-    private final String multimapStringRepresentation;
-
-    IterableValuesForKey(
-        FailureMetadata metadata,
-        String multimapStringRepresentation,
-        @Nullable Object key,
-        Iterable<?> actual) {
-      super(metadata, actual);
-      this.key = key;
-      this.multimapStringRepresentation = multimapStringRepresentation;
-    }
-
-    @Override
-    protected String actualCustomStringRepresentation() {
-      return "Values for key <" + key + "> (<" + actual() + ">) in " + multimapStringRepresentation;
-    }
   }
 
   private Factory<IterableSubject, Iterable<?>> iterableEntries() {

--- a/core/src/main/java/com/google/common/truth/SetMultimapSubject.java
+++ b/core/src/main/java/com/google/common/truth/SetMultimapSubject.java
@@ -26,8 +26,11 @@ import javax.annotation.Nullable;
  * @author Daniel Ploch
  */
 public final class SetMultimapSubject extends MultimapSubject {
-  SetMultimapSubject(FailureMetadata metadata, @Nullable SetMultimap<?, ?> multimap) {
-    super(metadata, multimap);
+  SetMultimapSubject(
+      FailureMetadata metadata,
+      @Nullable SetMultimap<?, ?> multimap,
+      @Nullable String typeDescription) {
+    super(metadata, multimap, typeDescription);
   }
 
   @Override

--- a/core/src/main/java/com/google/common/truth/StandardSubjectBuilder.java
+++ b/core/src/main/java/com/google/common/truth/StandardSubjectBuilder.java
@@ -88,7 +88,7 @@ public class StandardSubjectBuilder {
   }
 
   public final ThrowableSubject that(@Nullable Throwable actual) {
-    return new ThrowableSubject(metadata(), actual);
+    return new ThrowableSubject(metadata(), actual, "throwable");
   }
 
   public final LongSubject that(@Nullable Long actual) {
@@ -172,15 +172,15 @@ public class StandardSubjectBuilder {
   }
 
   public final MultimapSubject that(@Nullable Multimap<?, ?> actual) {
-    return new MultimapSubject(metadata(), actual);
+    return new MultimapSubject(metadata(), actual, "multimap");
   }
 
   public final ListMultimapSubject that(@Nullable ListMultimap<?, ?> actual) {
-    return new ListMultimapSubject(metadata(), actual);
+    return new ListMultimapSubject(metadata(), actual, "multimap");
   }
 
   public final SetMultimapSubject that(@Nullable SetMultimap<?, ?> actual) {
-    return new SetMultimapSubject(metadata(), actual);
+    return new SetMultimapSubject(metadata(), actual, "multimap");
   }
 
   public final MultisetSubject that(@Nullable Multiset<?> actual) {

--- a/core/src/main/java/com/google/common/truth/ThrowableSubject.java
+++ b/core/src/main/java/com/google/common/truth/ThrowableSubject.java
@@ -23,8 +23,9 @@ import javax.annotation.Nullable;
  * @author Kurt Alfred Kluever
  */
 public final class ThrowableSubject extends Subject<ThrowableSubject, Throwable> {
-  ThrowableSubject(FailureMetadata metadata, @Nullable Throwable throwable) {
-    super(metadata, throwable);
+  ThrowableSubject(
+      FailureMetadata metadata, @Nullable Throwable throwable, @Nullable String typeDescription) {
+    super(metadata, throwable, typeDescription);
   }
 
   /*
@@ -46,11 +47,7 @@ public final class ThrowableSubject extends Subject<ThrowableSubject, Throwable>
 
   /** Returns a {@code StringSubject} to make assertions about the throwable's message. */
   public StringSubject hasMessageThat() {
-    String name = actual().getClass().getName();
-    if (internalCustomName() != null) {
-      name = internalCustomName() + "(" + name + ")";
-    }
-    return check().withMessage("Unexpected message for %s", name).that(actual().getMessage());
+    return check("getMessage()").that(actual().getMessage());
   }
 
   /**
@@ -75,10 +72,6 @@ public final class ThrowableSubject extends Subject<ThrowableSubject, Throwable>
                 }
               });
     }
-    String name = actual().getClass().getName();
-    if (internalCustomName() != null) {
-      name = internalCustomName() + "(" + name + ")";
-    }
-    return check().withMessage("Unexpected cause for %s", name).that(actual().getCause());
+    return check("getCause()").that(actual().getCause());
   }
 }

--- a/core/src/main/java/com/google/common/truth/Truth.java
+++ b/core/src/main/java/com/google/common/truth/Truth.java
@@ -268,8 +268,10 @@ public final class Truth {
     /** Separate cause field, in case initCause() fails. */
     @Nullable private final Throwable cause;
 
-    private SimpleAssertionError(String message, @Nullable Throwable cause) {
-      super(message);
+    // TODO(cpovirk): Figure out if we ever pass a null message to this.
+    private SimpleAssertionError(
+        String message, @Nullable String suffix, @Nullable Throwable cause) {
+      super(appendSuffixIfNotNull(message, suffix));
       this.cause = cause;
 
       try {
@@ -282,12 +284,13 @@ public final class Truth {
       }
     }
 
-    static SimpleAssertionError create(String message, Throwable cause) {
-      return new SimpleAssertionError(message, cause);
+    static SimpleAssertionError create(
+        String message, @Nullable String suffix, @Nullable Throwable cause) {
+      return new SimpleAssertionError(message, suffix, cause);
     }
 
-    static SimpleAssertionError createWithNoStack(String message, Throwable cause) {
-      SimpleAssertionError error = new SimpleAssertionError(message, cause);
+    static SimpleAssertionError createWithNoStack(String message, @Nullable Throwable cause) {
+      SimpleAssertionError error = new SimpleAssertionError(message, /* suffix= */ null, cause);
       error.setStackTrace(new StackTraceElement[0]);
       return error;
     }
@@ -306,5 +309,13 @@ public final class Truth {
     public String toString() {
       return getLocalizedMessage();
     }
+  }
+
+  @Nullable
+  static String appendSuffixIfNotNull(String message, String suffix) {
+    if (suffix != null) {
+      message += ": " + suffix;
+    }
+    return message;
   }
 }

--- a/core/src/test/java/com/google/common/truth/ChainingTest.java
+++ b/core/src/test/java/com/google/common/truth/ChainingTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.truth;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assert_;
+
+import com.google.common.base.Objects;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for chained subjects (produced with {@link Subject#check()}, etc.). */
+@RunWith(JUnit4.class)
+public final class ChainingTest extends BaseSubjectTestCase {
+  private static final Throwable throwable = new Throwable("root");
+
+  @Test
+  public void noChaining() {
+    expectFailureWhenTestingThat("root").isThePresentKingOfFrance();
+    assertNoCause("message");
+  }
+
+  @Test
+  public void oneLevel() {
+    expectFailureWhenTestingThat("root").delegatingTo("child").isThePresentKingOfFrance();
+    assertNoCause("message");
+  }
+
+  @Test
+  public void twoLevels() {
+    expectFailureWhenTestingThat("root")
+        .delegatingTo("child")
+        .delegatingTo("grandchild")
+        .isThePresentKingOfFrance();
+    assertNoCause("message");
+  }
+
+  @Test
+  public void noChainingRootThrowable() {
+    expectFailureWhenTestingThat(throwable).isThePresentKingOfFrance();
+    assertHasCause("message");
+  }
+
+  @Test
+  public void oneLevelRootThrowable() {
+    expectFailureWhenTestingThat(throwable).delegatingTo("child").isThePresentKingOfFrance();
+    assertHasCause("message");
+  }
+
+  @Test
+  public void twoLevelsRootThrowable() {
+    expectFailureWhenTestingThat(throwable)
+        .delegatingTo("child")
+        .delegatingTo("grandchild")
+        .isThePresentKingOfFrance();
+    assertHasCause("message");
+  }
+
+  // e.g., future.failureCause()
+  @Test
+  public void oneLevelDerivedThrowable() {
+    expectFailureWhenTestingThat("root").delegatingTo(throwable).isThePresentKingOfFrance();
+    assertHasCause("message");
+  }
+
+  @Test
+  public void twoLevelsDerivedThrowableMiddle() {
+    expectFailureWhenTestingThat("root")
+        .delegatingTo(throwable)
+        .delegatingTo("grandchild")
+        .isThePresentKingOfFrance();
+    assertHasCause("message");
+  }
+
+  @Test
+  public void twoLevelsDerivedThrowableLast() {
+    expectFailureWhenTestingThat("root")
+        .delegatingTo("child")
+        .delegatingTo(throwable)
+        .isThePresentKingOfFrance();
+    assertHasCause("message");
+  }
+
+  @Test
+  public void oneLevelNamed() {
+    expectFailureWhenTestingThat("root")
+        .delegatingToNamed("child", "child")
+        .isThePresentKingOfFrance();
+    assertNoCause("value of: myObject.child: message: myObject was: <root>");
+  }
+
+  @Test
+  public void twoLevelsNamed() {
+    expectFailureWhenTestingThat("root")
+        .delegatingToNamed("child", "child")
+        .delegatingToNamed("grandchild", "grandchild")
+        .isThePresentKingOfFrance();
+    assertNoCause("value of: myObject.child.grandchild: message: myObject was: <root>");
+  }
+
+  @Test
+  public void twoLevelsOnlyFirstNamed() {
+    expectFailureWhenTestingThat("root")
+        .delegatingToNamed("child", "child")
+        .delegatingTo("grandchild")
+        .isThePresentKingOfFrance();
+    assertNoCause("message: myObject was: <root>");
+  }
+
+  @Test
+  public void twoLevelsOnlySecondNamed() {
+    expectFailureWhenTestingThat("root")
+        .delegatingTo("child")
+        .delegatingToNamed("grandchild", "grandchild")
+        .isThePresentKingOfFrance();
+    assertNoCause("value of: myObject.grandchild: message: myObject was: <root>");
+  }
+
+  @Test
+  public void namedAndComparisonFailure() {
+    expectFailureWhenTestingThat("root").delegatingToNamed("child", "child").isEqualToString("z");
+    assertNoCause(
+        "value of: myObject.child: message expected:<[child]> but was:<[z]>: myObject was: <root>");
+  }
+
+  @Test
+  public void namedAndMessage() {
+    expectFailure
+        .whenTesting()
+        .withMessage("prefix")
+        .about(myObjects())
+        .that("root")
+        .delegatingToNamed("child", "child")
+        .isThePresentKingOfFrance();
+    assertNoCause("prefix: value of: myObject.child: message: myObject was: <root>");
+  }
+
+  @Test
+  public void checkFail() {
+    expectFailureWhenTestingThat("root").doCheckFail();
+    assertNoCause("message");
+  }
+
+  @Test
+  public void checkFailWithName() {
+    expectFailureWhenTestingThat("root").doCheckFail("child");
+    assertNoCause("value of: myObject.child: message: myObject was: <root>");
+  }
+
+  @Test
+  public void badFormat() {
+    try {
+      Object unused = assertThat("root").check("%s %s", 1, 2, 3);
+      assert_().fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
+  /*
+   * TODO(cpovirk): It would be nice to have multiple Subject subclasses so that we know we're
+   * pulling the type from the right link in the chain. But we get some coverage of that from other
+   * tests like MultimapSubjectTest.
+   */
+
+  private static final class MyObjectSubject extends Subject<MyObjectSubject, Object> {
+    static final Factory<MyObjectSubject, Object> FACTORY =
+        new Factory<MyObjectSubject, Object>() {
+          @Override
+          public MyObjectSubject createSubject(FailureMetadata metadata, Object actual) {
+            return new MyObjectSubject(metadata, actual);
+          }
+        };
+
+    private MyObjectSubject(FailureMetadata metadata, Object actual) {
+      super(metadata, actual);
+    }
+
+    /** Runs a check that always fails with the generic message "message." */
+    void isThePresentKingOfFrance() {
+      failWithRawMessage("message");
+    }
+
+    /**
+     * Checks that the value is equal to the given string, failing with the generic message
+     * "message" and a {@link org.junit.ComparisonFailure} if not.
+     */
+    void isEqualToString(String expected) {
+      if (!Objects.equal(actual(), expected)) {
+        failComparing("message", String.valueOf(actual()), expected);
+      }
+    }
+
+    void doCheckFail() {
+      check().fail("message");
+    }
+
+    void doCheckFail(String name) {
+      check(name).fail("message");
+    }
+
+    /**
+     * Returns a new {@code MyObjectSubject} for the given actual value, chaining it to the current
+     * subject with {@link Subject#check}.
+     */
+    MyObjectSubject delegatingTo(Object actual) {
+      return check().about(myObjects()).that(actual);
+    }
+
+    /**
+     * Returns a new {@code MyObjectSubject} for the given actual value, chaining it to the current
+     * subject with {@link Subject#check}.
+     */
+    MyObjectSubject delegatingToNamed(Object actual, String name) {
+      return check(name).about(myObjects()).that(actual);
+    }
+  }
+
+  private static Subject.Factory<MyObjectSubject, Object> myObjects() {
+    return MyObjectSubject.FACTORY;
+  }
+
+  private MyObjectSubject expectFailureWhenTestingThat(Object actual) {
+    return expectFailure.whenTesting().about(myObjects()).that(actual);
+  }
+
+  private void assertNoCause(String message) {
+    assertThatFailure().hasMessageThat().isEqualTo(message);
+    assertThatFailure().hasCauseThat().isNull();
+  }
+
+  private void assertHasCause(String message) {
+    assertThatFailure().hasMessageThat().isEqualTo(message);
+    assertThatFailure().hasCauseThat().isEqualTo(throwable);
+  }
+
+  private ThrowableSubject assertThatFailure() {
+    return assertThat(expectFailure.getFailure());
+  }
+}

--- a/core/src/test/java/com/google/common/truth/CustomFailureMessageTest.java
+++ b/core/src/test/java/com/google/common/truth/CustomFailureMessageTest.java
@@ -119,19 +119,19 @@ public class CustomFailureMessageTest {
 
   @Test
   public void countPlaceholders() {
-    assertThat(FailureMetadata.countPlaceholders(null)).isEqualTo(0);
-    assertThat(FailureMetadata.countPlaceholders("")).isEqualTo(0);
-    assertThat(FailureMetadata.countPlaceholders("%s")).isEqualTo(1);
-    assertThat(FailureMetadata.countPlaceholders("%s%s")).isEqualTo(2);
-    assertThat(FailureMetadata.countPlaceholders("%s%%s")).isEqualTo(2);
-    assertThat(FailureMetadata.countPlaceholders("hello")).isEqualTo(0);
-    assertThat(FailureMetadata.countPlaceholders("%shello")).isEqualTo(1);
-    assertThat(FailureMetadata.countPlaceholders("hello%s")).isEqualTo(1);
-    assertThat(FailureMetadata.countPlaceholders("hel%slo")).isEqualTo(1);
-    assertThat(FailureMetadata.countPlaceholders("hel%%slo")).isEqualTo(1);
-    assertThat(FailureMetadata.countPlaceholders("hel%s%slo")).isEqualTo(2);
-    assertThat(FailureMetadata.countPlaceholders("%shel%s%slo")).isEqualTo(3);
-    assertThat(FailureMetadata.countPlaceholders("hel%s%slo%s")).isEqualTo(3);
+    assertThat(LazyMessage.countPlaceholders(null)).isEqualTo(0);
+    assertThat(LazyMessage.countPlaceholders("")).isEqualTo(0);
+    assertThat(LazyMessage.countPlaceholders("%s")).isEqualTo(1);
+    assertThat(LazyMessage.countPlaceholders("%s%s")).isEqualTo(2);
+    assertThat(LazyMessage.countPlaceholders("%s%%s")).isEqualTo(2);
+    assertThat(LazyMessage.countPlaceholders("hello")).isEqualTo(0);
+    assertThat(LazyMessage.countPlaceholders("%shello")).isEqualTo(1);
+    assertThat(LazyMessage.countPlaceholders("hello%s")).isEqualTo(1);
+    assertThat(LazyMessage.countPlaceholders("hel%slo")).isEqualTo(1);
+    assertThat(LazyMessage.countPlaceholders("hel%%slo")).isEqualTo(1);
+    assertThat(LazyMessage.countPlaceholders("hel%s%slo")).isEqualTo(2);
+    assertThat(LazyMessage.countPlaceholders("%shel%s%slo")).isEqualTo(3);
+    assertThat(LazyMessage.countPlaceholders("hel%s%slo%s")).isEqualTo(3);
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/MultimapSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/MultimapSubjectTest.java
@@ -166,12 +166,22 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   public void multimapNamedValuesForKey() {
     ImmutableMultimap<Integer, Integer> multimap = ImmutableMultimap.of(1, 5);
     expectFailure.whenTesting().that(multimap).named("multymap").valuesForKey(1).containsExactly(4);
+    /*
+     * TODO(cpovirk): It's silly that we display "multymap" twice in the failure, once for "value
+     * of" and once for "root." The problem is that we need to include it in "value of" in case it's
+     * a Throwable (since we don't include a "root" for Throwables), but it also comes along
+     * automatically with "root" because we call actualAsString(). We'll probably fix this
+     * incidentally as part of reducing the number of ways to set string representations, possibly
+     * including eliminating named() itself. Or we could just special-case our logic to skip the
+     * name for non-throwables. For now, I'm not too worried about this.
+     */
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that "
-                + "<Values for key <1> (<[5]>) in multymap (<{1=[5]}>)> contains exactly <[4]>. "
-                + "It is missing <[4]> and has unexpected items <[5]>");
+            "value of: multymap.valuesForKey(1): "
+                + "Not true that <[5]> contains exactly <[4]>. "
+                + "It is missing <[4]> and has unexpected items <[5]>: "
+                + "multimap was: multymap (<{1=[5]}>)");
   }
 
   @Test
@@ -181,9 +191,10 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that "
-                + "valuez (<Values for key <1> (<[5]>) in <{1=[5]}>>) contains exactly <[4]>. "
-                + "It is missing <[4]> and has unexpected items <[5]>");
+            "value of: multimap.valuesForKey(1): "
+                + "Not true that valuez (<[5]>) contains exactly <[4]>. "
+                + "It is missing <[4]> and has unexpected items <[5]>: "
+                + "multimap was: <{1=[5]}>");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/ThrowableSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/ThrowableSubjectTest.java
@@ -54,9 +54,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
     NullPointerException actual = new NullPointerException("message");
     expectFailure.whenTesting().that(actual).hasMessageThat().isEqualTo("foobar");
     assertThat(expectFailure.getFailure().getMessage())
-        .isEqualTo(
-            "Unexpected message for java.lang.NullPointerException: "
-                + "expected:<[foobar]> but was:<[message]>");
+        .isEqualTo("value of: throwable.getMessage(): expected:<[foobar]> but was:<[message]>");
     assertErrorHasActualAsCause(actual, expectFailure.getFailure());
   }
 
@@ -64,9 +62,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
   public void hasMessageThat_MessageHasNullMessage_failure() {
     expectFailure.whenTesting().that(new NullPointerException("message")).hasMessageThat().isNull();
     assertThat(expectFailure.getFailure().getMessage())
-        .isEqualTo(
-            "Unexpected message for java.lang.NullPointerException: "
-                + "Not true that <\"message\"> is null");
+        .isEqualTo("value of: throwable.getMessage(): Not true that <\"message\"> is null");
   }
 
   @Test
@@ -74,9 +70,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
     NullPointerException npe = new NullPointerException("message");
     expectFailure.whenTesting().that(npe).named("NPE").hasMessageThat().isEqualTo("foobar");
     assertThat(expectFailure.getFailure().getMessage())
-        .isEqualTo(
-            "Unexpected message for NPE(java.lang.NullPointerException): "
-                + "expected:<[foobar]> but was:<[message]>");
+        .isEqualTo("value of: NPE.getMessage(): expected:<[foobar]> but was:<[message]>");
   }
 
   @Test
@@ -85,8 +79,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(npe).hasMessageThat().isEqualTo("message");
     assertThat(expectFailure.getFailure().getMessage())
         .isEqualTo(
-            "Unexpected message for java.lang.NullPointerException: "
-                + "Not true that <null> is equal to <\"message\">");
+            "value of: throwable.getMessage(): Not true that <null> is equal to <\"message\">");
   }
 
   @Test
@@ -115,8 +108,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(actual).hasCauseThat().hasMessageThat().isEqualTo("message");
     assertThat(expectFailure.getFailure().getMessage())
         .isEqualTo(
-            "Unexpected cause for java.lang.Exception: Unexpected message for "
-                + "java.io.IOException: expected:<[message]> but was:<[barfoo]>");
+            "value of: throwable.getCause().getMessage(): expected:<[message]> but was:<[barfoo]>");
     assertErrorHasActualAsCause(actual, expectFailure.getFailure());
   }
 
@@ -126,7 +118,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(actual).hasCauseThat().isInstanceOf(RuntimeException.class);
     assertThat(expectFailure.getFailure().getMessage())
         .isEqualTo(
-            "Unexpected cause for java.lang.Exception: Not true that <java.io.IOException: "
+            "value of: throwable.getCause(): Not true that <java.io.IOException: "
                 + "barfoo> is an instance of <java.lang.RuntimeException>. "
                 + "It is an instance of <java.io.IOException>");
     assertErrorHasActualAsCause(actual, expectFailure.getFailure());
@@ -136,9 +128,14 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
   public void hasCauseThat_tooDeep_failure() {
     Exception actual = new Exception("foobar");
     expectFailure.whenTesting().that(actual).hasCauseThat().hasCauseThat().isNull();
+    /*
+     * TODO(cpovirk): This message might suggest that actual.getCause() is the part that's failing.
+     * But that part is fine. It's only when we try to call getCause() again (on the null result of
+     * the previous call) that we have a problem.
+     */
     assertThat(expectFailure.getFailure().getMessage())
         .isEqualTo(
-            "Unexpected cause for java.lang.Exception: "
+            "value of: throwable.getCause(): "
                 + "Causal chain is not deep enough - add a .isNotNull() check?");
     assertErrorHasActualAsCause(actual, expectFailure.getFailure());
   }
@@ -156,8 +153,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
         .isEqualTo("message");
     assertThat(expectFailure.getFailure().getMessage())
         .isEqualTo(
-            "Unexpected cause for java.lang.Exception: Unexpected cause for "
-                + "java.lang.RuntimeException: Unexpected message for java.io.IOException: "
+            "value of: throwable.getCause().getCause().getMessage(): "
                 + "expected:<[message]> but was:<[buzz]>");
     assertErrorHasActualAsCause(actual, expectFailure.getFailure());
   }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add check(String template, Object... args), and use it to provide context like...

- "value of: throwable.getCause().getMessage()"
- "multimap was: <{1=[5]}>"

This covers:
- "high-level approach" issues A, A1, E
- "Subject.check()" issues A, B, C

This CL stops short of letting the existing no-arg check() contribute to a chain, thanks to outstanding questions around the right behavior in some edge cases. Any call to no-arg check() will throw away any "value of" string we've computed so far, and it won't trigger the inclusion of a "root." (Calls to check(String, Object...) elsewhere in the chain may still cause us to include one or both of "value of" and "root.")

This CL also doesn't introduce any newlines into failure messages.

Internally, the main parts of this are:
- Make our custom ComparisonFailure accept a suffix (for use with "value of"). We need this because ComparisonFailure puts the user-specified message *before* the "expected: ...; but was: ..." text, and we want to put part of ours after. I've also added suffix support to our custom AssertionError. This might be avoidable, but it seems reasonable enough for the two classes to have similar APIs, especially because our GWT method for "give me a ComparisonFailure" actually returns a plain AssertionError.
- In FailureMetadata, track the calls to check() alongside the calls to Subject constructors.
- Make FailureMetadata.Message (currently used by withMessage()) available for use from check().
- Change MultimapSubject and ThrowableSubject to use the new API.

If it would help, I could split these into different CLs. It's just that they aren't easily to realistically test in isolation from one another :\

RELNOTES=Added `check(String template, Object... args)`. Most users of `check()` should migrate. If the new method doesn't suit your needs, please [file a bug](https://github.com/google/truth/issues/new).

2f9b7af9e1ebe08316c03e8bf6cd631e81a70a8d