### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/AssertionErrorWithFields.java
+++ b/core/src/main/java/com/google/common/truth/AssertionErrorWithFields.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2011 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.common.truth;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.truth.Field.makeMessage;
+
+import com.google.common.collect.ImmutableList;
+import javax.annotation.Nullable;
+
+/**
+ * An {@link AssertionError} composed of structured {@link Field} instances and other string
+ * messages.
+ */
+final class AssertionErrorWithFields extends AssertionError {
+  static AssertionErrorWithFields create(
+      ImmutableList<String> messages, ImmutableList<Field> fields, @Nullable Throwable cause) {
+    return new AssertionErrorWithFields(messages, fields, cause);
+  }
+
+  final ImmutableList<Field> fields;
+
+  /** Separate cause field, in case initCause() fails. */
+  @Nullable private final Throwable cause;
+
+  private AssertionErrorWithFields(
+      ImmutableList<String> messages, ImmutableList<Field> fields, @Nullable Throwable cause) {
+    super(makeMessage(messages, fields));
+    this.fields = checkNotNull(fields);
+
+    this.cause = cause;
+    try {
+      initCause(cause);
+    } catch (IllegalStateException alreadyInitializedBecauseOfHarmonyBug) {
+      // See Truth.SimpleAssertionError.
+    }
+  }
+
+  @Override
+  @SuppressWarnings("UnsynchronizedOverridesSynchronized")
+  public Throwable getCause() {
+    return cause;
+  }
+
+  @Override
+  public String toString() {
+    return getLocalizedMessage();
+  }
+}

--- a/core/src/main/java/com/google/common/truth/ComparisonFailureWithFields.java
+++ b/core/src/main/java/com/google/common/truth/ComparisonFailureWithFields.java
@@ -16,13 +16,148 @@
 
 package com.google.common.truth;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.commonPrefix;
+import static com.google.common.base.Strings.commonSuffix;
+import static com.google.common.truth.Field.field;
+import static com.google.common.truth.Field.makeMessage;
 import static com.google.common.truth.Platform.ComparisonFailureMessageStrategy.OMIT_COMPARISON_FAILURE_GENERATED_MESSAGE;
+import static java.lang.Character.isHighSurrogate;
+import static java.lang.Character.isLowSurrogate;
+import static java.lang.Math.max;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.truth.Platform.PlatformComparisonFailure;
+import javax.annotation.Nullable;
 
+/**
+ * An {@link AssertionError} (usually a JUnit {@code ComparisonFailure}, but not under GWT) composed
+ * of structured {@link Field} instances and other string messages.
+ *
+ * <p>This class includes logic to format expected and actual values for easier reading.
+ */
 final class ComparisonFailureWithFields extends PlatformComparisonFailure {
-  ComparisonFailureWithFields(
-      String message, String expected, String actual, String suffix, Throwable cause) {
-    super(message, expected, actual, suffix, cause, OMIT_COMPARISON_FAILURE_GENERATED_MESSAGE);
+  static ComparisonFailureWithFields create(
+      ImmutableList<String> messages,
+      ImmutableList<Field> headFields,
+      ImmutableList<Field> tailFields,
+      String expected,
+      String actual,
+      @Nullable Throwable cause) {
+    ImmutableList<Field> fields = makeFields(headFields, tailFields, expected, actual);
+    return new ComparisonFailureWithFields(messages, fields, expected, actual, cause);
+  }
+
+  final ImmutableList<Field> fields;
+
+  private ComparisonFailureWithFields(
+      ImmutableList<String> messages,
+      ImmutableList<Field> fields,
+      String expected,
+      String actual,
+      @Nullable Throwable cause) {
+    super(
+        makeMessage(messages, fields),
+        checkNotNull(expected),
+        checkNotNull(actual),
+        /* suffix= */ null,
+        cause,
+        OMIT_COMPARISON_FAILURE_GENERATED_MESSAGE);
+    this.fields = checkNotNull(fields);
+  }
+
+  private static ImmutableList<Field> makeFields(
+      ImmutableList<Field> headFields,
+      ImmutableList<Field> tailFields,
+      String expected,
+      String actual) {
+    return new ImmutableList.Builder<Field>()
+        .addAll(headFields)
+        .addAll(formatExpectedAndActual(expected, actual))
+        .addAll(tailFields)
+        .build();
+  }
+
+  /**
+   * Returns one or more fields describing the difference between the given expected and actual
+   * values.
+   *
+   * <p>Currently, this method always returns 2 fields, one each for expected and actual. Someday,
+   * it may return a single diff-style field.
+   *
+   * <p>The 2 fields contain either the full expected and actual values or, if the values have a
+   * long prefix or suffix in common, abbreviated values with "..." at the beginning or end.
+   */
+  @VisibleForTesting
+  static ImmutableList<Field> formatExpectedAndActual(String expected, String actual) {
+    ImmutableList<Field> result;
+
+    result = removeCommonPrefixAndSuffix(expected, actual);
+    if (result != null) {
+      return result;
+    }
+
+    /*
+     * TODO(cpovirk): Add other strategies, like diff-style output, possibly preferring it over
+     * removeCommonPrefixAndSuffix when the values contain a newline.
+     *
+     * (For GWT, we probably won't offer diff-style: We'd need to make the diff library work there,
+     * and even once we do, I think we'd lose the newlines. Hopefully no one under GWT has long,
+     * nearly identical messages. In any case, they've always been stuck like this.
+     */
+
+    return ImmutableList.of(field("expected", expected), field("but was", actual));
+  }
+
+  @Nullable
+  private static ImmutableList<Field> removeCommonPrefixAndSuffix(String expected, String actual) {
+    // TODO(cpovirk): Use something like BreakIterator where available.
+    int prefix = commonPrefix(expected, actual).length();
+    prefix = max(0, prefix - CONTEXT);
+    while (prefix > 0 && validSurrogatePairAt(expected, prefix - 1)) {
+      prefix--;
+    }
+    if (prefix <= 3) {
+      // If the common prefix is short, then we might as well just show it.
+      prefix = 0;
+    }
+
+    int suffix = commonSuffix(expected, actual).length();
+    suffix = max(0, suffix - CONTEXT);
+    while (suffix > 0 && validSurrogatePairAt(expected, expected.length() - suffix - 1)) {
+      suffix--;
+    }
+    if (suffix <= 3) {
+      // If the common suffix is short, then we might as well just show it.
+      suffix = 0;
+    }
+
+    if (prefix + suffix < WORTH_HIDING) {
+      return null;
+    }
+
+    return ImmutableList.of(
+        field("expected", hidePrefixAndSuffix(expected, prefix, suffix)),
+        field("but was", hidePrefixAndSuffix(actual, prefix, suffix)));
+  }
+
+  private static final int CONTEXT = 5;
+  private static final int WORTH_HIDING = 60;
+
+  private static String hidePrefixAndSuffix(String s, int prefix, int suffix) {
+    return maybeDots(prefix) + s.substring(prefix, s.length() - suffix) + maybeDots(suffix);
+  }
+
+  private static String maybeDots(int prefixOrSuffix) {
+    return prefixOrSuffix > 0 ? "…" : "";
+  }
+
+  // From c.g.c.base.Strings.
+  private static boolean validSurrogatePairAt(CharSequence string, int index) {
+    return index >= 0
+        && index <= (string.length() - 2)
+        && isHighSurrogate(string.charAt(index))
+        && isLowSurrogate(string.charAt(index + 1));
   }
 }

--- a/core/src/main/java/com/google/common/truth/Field.java
+++ b/core/src/main/java/com/google/common/truth/Field.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.truth;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.padEnd;
+import static java.lang.Math.max;
+
+import com.google.common.collect.ImmutableList;
+
+/** A string key-value pair in a failure message, such as "expected: abc" or "but was: xyz." */
+final class Field {
+  static Field field(String key, Object value) {
+    return new Field(key, String.valueOf(value));
+  }
+
+  final String key;
+  final String value;
+
+  private Field(String key, String value) {
+    this.key = checkNotNull(key);
+    this.value = checkNotNull(value);
+  }
+
+  /**
+   * Returns a simple string representation for the field. While this is used by the old-style
+   * messages, we're moving away from it and onto {@link #makeMessage}, which aligns fields
+   * horizontally and indents multiline values.
+   */
+  @Override
+  public String toString() {
+    return key + ": " + value;
+  }
+
+  /**
+   * Formats the given messages and fields into a string for use as the message of a test failure.
+   * In particular, this method horizontally aligns the beginning of field values.
+   */
+  static String makeMessage(ImmutableList<String> messages, ImmutableList<Field> fields) {
+    int longestKeyLength = 0;
+    boolean seenNewlineInValue = false;
+    for (Field field : fields) {
+      longestKeyLength = max(longestKeyLength, field.key.length());
+      // TODO(cpovirk): Look for other kinds of newlines.
+      seenNewlineInValue |= field.value.contains("\n");
+    }
+
+    StringBuilder builder = new StringBuilder();
+    for (String message : messages) {
+      builder.append(message);
+      builder.append('\n');
+    }
+
+    /*
+     * *Usually* the first field is printed at the beginning of a new line. However, when this
+     * exception is the cause of another exception, that exception will print it starting after
+     * "Caused by: " on the same line. The other exception sometimes also reuses this message as its
+     * own message. In both of those scenarios, the first line doesn't start at column 0, so the
+     * horizontal alignment is thrown off.
+     *
+     * There's not much we can do about this, short of always starting with a newline (which would
+     * leave a blank line at the beginning of the message in the normal case).
+     */
+    for (Field field : fields) {
+      if (seenNewlineInValue) {
+        builder.append(field.key);
+        builder.append(":\n");
+        builder.append(indent(field.value));
+      } else {
+        builder.append(padEnd(field.key, longestKeyLength, ' '));
+        builder.append(": ");
+        builder.append(field.value);
+      }
+      builder.append('\n');
+    }
+    builder.setLength(builder.length() - 1); // remove trailing \n
+    return builder.toString();
+  }
+
+  private static String indent(String value) {
+    // We don't want to indent with \t because the text would align exactly with the stack trace.
+    // We don't want to indent with \t\t because it would be very far for people with 8-space tabs.
+    // Let's compromise and indent by 4 spaces, which is different than both 2- and 8-space tabs.
+    return "    " + value.replaceAll("\n", "\n    ");
+  }
+}

--- a/core/src/test/java/com/google/common/truth/ComparisonFailureWithFieldsTest.java
+++ b/core/src/test/java/com/google/common/truth/ComparisonFailureWithFieldsTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.truth;
+
+import static com.google.common.base.Strings.repeat;
+import static com.google.common.truth.ComparisonFailureWithFields.formatExpectedAndActual;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Test for {@link ComparisonFailureWithFields}. */
+@RunWith(JUnit4.class)
+public class ComparisonFailureWithFieldsTest {
+  @Test
+  public void formatAllDifferent() {
+    runFormatTest(
+        "foo", "bar",
+        "foo", "bar");
+  }
+
+  @Test
+  public void formatShortOverlap() {
+    runFormatTest(
+        "bar", "baz",
+        "bar", "baz");
+  }
+
+  @Test
+  public void formatLongOverlapStart() {
+    runFormatTest(repeat("b", 100) + "aa", repeat("b", 100) + "oo", "…bbbbbaa", "…bbbbboo");
+  }
+
+  @Test
+  public void formatLongOverlapEnd() {
+    runFormatTest("ba" + repeat("r", 100), "fu" + repeat("r", 100), "barrrrr…", "furrrrr…");
+  }
+
+  @Test
+  public void formatLongOverlapStartAlsoSmallAtEnd() {
+    runFormatTest(
+        repeat("b", 100) + "aa" + repeat("t", 7),
+        repeat("b", 100) + "oo" + repeat("t", 7),
+        "…bbbbbaattttttt",
+        "…bbbbboottttttt");
+  }
+
+  @Test
+  public void formatLongOverlapEndAlsoSmallAtStart() {
+    runFormatTest(
+        repeat("a", 7) + "ba" + repeat("r", 100),
+        repeat("a", 7) + "fu" + repeat("r", 100),
+        "aaaaaaabarrrrr…",
+        "aaaaaaafurrrrr…");
+  }
+
+  @Test
+  public void formatLongOverlapBoth() {
+    runFormatTest(
+        repeat("r", 40) + "a" + repeat("g", 40),
+        repeat("r", 40) + "u" + repeat("g", 40),
+        "…rrrrraggggg…",
+        "…rrrrruggggg…");
+  }
+
+  @Test
+  public void formatNoSplitSurrogateStart() {
+    runFormatTest(
+        repeat("b", 100) + "\uD8AB\uDCABbbbbaa",
+        repeat("b", 100) + "\uD8AB\uDCABbbbboo",
+        "…\uD8AB\uDCABbbbbaa",
+        "…\uD8AB\uDCABbbbboo");
+  }
+
+  @Test
+  public void formatNoSplitSurrogateEnd() {
+    runFormatTest(
+        "barrrr\uD8AB\uDCAB" + repeat("r", 100),
+        "furrrr\uD8AB\uDCAB" + repeat("r", 100),
+        "barrrr\uD8AB\uDCAB…",
+        "furrrr\uD8AB\uDCAB…");
+  }
+
+  private static void runFormatTest(
+      String expected, String actual, String expectedExpected, String expectedActual) {
+    ImmutableList<Field> fields = formatExpectedAndActual(expected, actual);
+    assertThat(fields).hasSize(2);
+    assertThat(fields.get(0).key).isEqualTo("expected");
+    assertThat(fields.get(1).key).isEqualTo("but was");
+    assertThat(fields.get(0).value).isEqualTo(expectedExpected);
+    assertThat(fields.get(1).value).isEqualTo(expectedActual);
+  }
+}

--- a/core/src/test/java/com/google/common/truth/FieldTest.java
+++ b/core/src/test/java/com/google/common/truth/FieldTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.truth;
+
+import static com.google.common.truth.Field.field;
+import static com.google.common.truth.Field.makeMessage;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link Field}. */
+@RunWith(JUnit4.class)
+public class FieldTest {
+  @Test
+  public void string() {
+    assertThat(field("foo", "bar").toString()).isEqualTo("foo: bar");
+  }
+
+  @Test
+  public void oneFields() {
+    assertThat(makeMessage(ImmutableList.<String>of(), ImmutableList.of(field("foo", "bar"))))
+        .isEqualTo("foo: bar");
+  }
+
+  @Test
+  public void twoFields() {
+    assertThat(
+            makeMessage(
+                ImmutableList.<String>of(),
+                ImmutableList.of(field("foo", "bar"), field("longer name", "other value"))))
+        .isEqualTo("foo        : bar\nlonger name: other value");
+  }
+
+  @Test
+  public void newline() {
+    assertThat(makeMessage(ImmutableList.<String>of(), ImmutableList.of(field("foo", "bar\nbaz"))))
+        .isEqualTo("foo:\n    bar\n    baz");
+  }
+
+  @Test
+  public void withMessage() {
+    assertThat(
+            makeMessage(ImmutableList.<String>of("hello"), ImmutableList.of(field("foo", "bar"))))
+        .isEqualTo("hello\nfoo: bar");
+  }
+}

--- a/core/src/test/java/com/google/common/truth/IterableSubjectCorrespondenceTest.java
+++ b/core/src/test/java/com/google/common/truth/IterableSubjectCorrespondenceTest.java
@@ -323,10 +323,10 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
         .isEqualTo(
             "Not true that <[1/100, 2/211, 4/400, none/999]> contains exactly one element that has "
                 + "the same id as and a score is within 10 of each element of "
-                + "<[1/100, 2/200, 3/300, none/900]>. It is missing an element that has the same "
-                + "id as and a score is within 10 of each of <[2/200, 3/300, none/900]> and has "
-                + "unexpected elements <[2/211, 4/400, none/999]>");
-    // TODO(b/32960783): Update expected message to show the diff between the records with key=2.
+                + "<[1/100, 2/200, 3/300, none/900]>. It is missing an element that corresponds to "
+                + "<2/200> and has unexpected elements <[2/211 (diff: score:11)]> with key 2, and "
+                + "is missing an element that corresponds to each of <[3/300, none/900]> and has "
+                + "unexpected elements <[4/400, none/999]> without matching keys");
   }
 
   @Test
@@ -350,10 +350,10 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
             "Not true that <[1/100, 2/211, 4/400, none/999]> contains exactly one element that "
                 + "parses to a record that has the same id as and a score is within 10 of each "
                 + "element of <[1/100, 2/200, 3/300, none/900]>. It is missing an element that "
-                + "parses to a record that has the same id as and a score is within 10 of each of "
-                + "<[2/200, 3/300, none/900]> and has unexpected elements "
-                + "<[2/211, 4/400, none/999]>");
-    // TODO(b/32960783): Update expected message to show the diff between the records with key=2.
+                + "corresponds to <2/200> and has unexpected elements <[2/211 (diff: score:11)]> "
+                + "with key 2, and is missing an element that corresponds to each of "
+                + "<[3/300, none/900]> and has unexpected elements <[4/400, none/999]> without "
+                + "matching keys");
   }
 
   @Test
@@ -401,8 +401,9 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
                 + "the same id as and a score is within 10 of each element of "
                 + "<[1/100, 2/200, 3/300, 3/301, none/900]>. It is missing an element that has the "
                 + "same id as and a score is within 10 of each of <[2/200, 3/300, 3/301, none/900]>"
-                + " and has unexpected elements <[2/211, 4/400, none/999]>");
-    // TODO(b/32960783): Update expected message to show the warning about non-uniqueness.
+                + " and has unexpected elements <[2/211, 4/400, none/999]>. (N.B. A key function "
+                + "which does not uniquely key the expected elements was provided and has "
+                + "consequently been ignored.)");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/StringSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/StringSubjectTest.java
@@ -144,6 +144,7 @@ public class StringSubjectTest extends BaseSubjectTestCase {
   public void stringEqualityFail() {
     try {
       assertThat("abc").isEqualTo("abd");
+      fail();
     } catch (ComparisonFailure expected) {
       assertThat(expected).hasMessageThat().isEqualTo("expected:<ab[d]> but was:<ab[c]>");
       // truth used to create a synthetic cause, make sure that isn't happening anymore.
@@ -153,9 +154,21 @@ public class StringSubjectTest extends BaseSubjectTestCase {
 
   @Test
   @GwtIncompatible("ComparisonFailure")
+  public void stringEqualityCompleteFail() {
+    try {
+      assertThat("abc").isEqualTo("xyz");
+      fail();
+    } catch (ComparisonFailure expected) {
+      assertThat(expected).hasMessageThat().isEqualTo("expected:<[xyz]> but was:<[abc]>");
+    }
+  }
+
+  @Test
+  @GwtIncompatible("ComparisonFailure")
   public void stringNamedEqualityFail() {
     try {
       assertThat("abc").named("foo").isEqualTo("abd");
+      fail();
     } catch (ComparisonFailure expected) {
       assertThat(expected).hasMessageThat().isEqualTo("\"foo\": expected:<ab[d]> but was:<ab[c]>");
     }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add a test for when the actual and expected strings don't match at all.
Add a bunch of missing fail() calls.

004812430e2d5b648ae0a1b5a9d5890c077ae617

-------

<p> Introduce a Field class and a method to format fields into a failure message.

This lays some groundwork for the coming changes to failure messages, in which Subject and FailureMetadata will pass a list of fields to construct their failure exceptions.

Also, start using Field in a trivial way in FailureMetadata: Instead of returning @Nullable String, return Optional<Field>, and convert it to a String as needed. This sets up for using the Field directly in future commit. (Eventually, the old-style failure messages will go away, and we can eliminate the String methods entirely.)

expected: abc
but was : xyz

181244d68d2c348b526b9745bc5d978a0b468c69

-------

<p> Make IterableSubject.UsingCorrespondence.displayingDiffsPairedBy() work for containsExactly and containsExactlyElementsIn, and make it public.

This follows the precedent set in ef55cb75d588f8af387f69b39e6aac0259215b42 for containsNoneOf/In and says "corresponds to" instead of repeating the correspondence.toString() when in a loop. (I actually vaguely think that we should switch to always saying "corresponds to" on the second and subsequent occurrences. That would be possible, but it would create churn in several existing messages, so I'm not doing it here. At least, though, we should make sure we never repeat correspondence.toString() a number of times that scales with the size of the input.)

Also adds a TODO in fuzzy.md to remind me to update it in due course. (My plan is to do that when the feature is more-or-less complete, and to put something in the RELNOTES for that commit which can direct folks to the docs for more info.)

0c5b2eb313173b686bad185434a9d978f4b7f9e7

-------

<p> Introduce versions of AssertionError and ComparisonFailure that use Field (but don't use them yet).

In the case of ComparisonFailure, I've also included logic similar to JUnit's to "compact" long expected and actual values.

6da55150f3308e0c4fba2fe315edbd2aecf80713