### PR TITLE
Moe Sync

### DIFF
--- a/fuzzy.md
+++ b/fuzzy.md
@@ -78,6 +78,8 @@ assertThat(actual)
     .containsEntry("def", 789);
 ```
 
+<!-- TODO(b/32960783): Document pairing & diffing support. -->
+
 
 [protocol buffers]: https://developers.google.com/protocol-buffers/
 [correspondence-tostring]: http://google.github.io/truth/api/latest/com/google/common/truth/Correspondence.html#toString()

--- a/known_types.md
+++ b/known_types.md
@@ -27,7 +27,7 @@ Truth has built in support for the following types:
     *   [`long[]`][LongArray]
     *   [`short[]`][ShortArray]
 
-*   Java 8 types (see go/truth/faq#java8)
+*   [Java 8 types]
 
     *   [`Optional`] - and `OptionalInt`, `OptionalLong`, and `OptionalDouble`
     *   [`Stream`] - and `IntStream`, `LongStream` (and maybe someday,
@@ -88,3 +88,5 @@ Truth has built in support for the following types:
 [`String`]: http://google.github.io/truth/api/latest/com/google/common/truth/StringSubject
 [`Table`]: http://google.github.io/truth/api/latest/com/google/common/truth/TableSubject
 [`Throwable`]: http://google.github.io/truth/api/latest/com/google/common/truth/ThrowableSubject
+[Java 8 types]: https://google.github.io/truth/faq#java8
+


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Replace broken link

e5c6cc75de5aa7778049db1dcc093948cc19370b

-------

<p> Make IterableSubject.UsingCorrespondence.displayingDiffsPairedBy() work for containsExactly and containsExactlyElementsIn, and make it public.

This follows the precedent set in ef55cb75d588f8af387f69b39e6aac0259215b42 for containsNoneOf/In and says "corresponds to" instead of repeating the correspondence.toString() when in a loop. (I actually vaguely think that we should switch to always saying "corresponds to" on the second and subsequent occurrences. That would be possible, but it would create churn in several existing messages, so I'm not doing it here. At least, though, we should make sure we never repeat correspondence.toString() a number of times that scales with the size of the input.)

Also adds a TODO in fuzzy.md to remind me to update it in due course. (My plan is to do that when the feature is more-or-less complete, and to put something in the RELNOTES for that commit which can direct folks to the docs for more info.)

44029a2cb59ef59f078c4123e045ca0ea490367c