### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/FailureMetadata.java
+++ b/core/src/main/java/com/google/common/truth/FailureMetadata.java
@@ -308,15 +308,15 @@ public final class FailureMetadata {
       }
     }
     /*
-     * TODO(cpovirk): Maybe say "root foo: ..." instead of just "foo: ..." if there's more than one
-     * foo in the chain, if the description string doesn't start with "foo," and/or if the name we
-     * have is just "object?"
+     * TODO(cpovirk): Maybe say "root foo was: ..." instead of just "foo was: ..." if there's more
+     * than one foo in the chain, if the description string doesn't start with "foo," and/or if the
+     * name we have is just "object?"
      */
     return seenDerivation
         ? Optional.of(
             field(
                 rootSubject.subject.typeDescription() + " was",
-                rootSubject.subject.actualAsString()))
+                rootSubject.subject.actualAsStringNoBrackets()))
         : Optional.<Field>absent();
   }
 

--- a/core/src/main/java/com/google/common/truth/GuavaOptionalSubject.java
+++ b/core/src/main/java/com/google/common/truth/GuavaOptionalSubject.java
@@ -27,8 +27,9 @@ import javax.annotation.Nullable;
  * @author Christian Gruber
  */
 public final class GuavaOptionalSubject extends Subject<GuavaOptionalSubject, Optional<?>> {
-  GuavaOptionalSubject(FailureMetadata metadata, @Nullable Optional<?> actual) {
-    super(metadata, actual);
+  GuavaOptionalSubject(
+      FailureMetadata metadata, @Nullable Optional<?> actual, @Nullable String typeDescription) {
+    super(metadata, actual, typeDescription);
   }
 
   /** Fails if the {@link Optional}{@code <T>} is absent or the subject is null. */

--- a/core/src/main/java/com/google/common/truth/IterableSubject.java
+++ b/core/src/main/java/com/google/common/truth/IterableSubject.java
@@ -996,10 +996,7 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
               + ". (N.B. A key function which does not uniquely key the expected elements was "
               + "provided and has consequently been ignored.)";
         }
-      } else if (missing.size() == 1 && extra.size() == 1) {
-        // TODO(b/32960783): Consider changing the extra.size() == 1 check to >= 1. This is what was
-        // agreed in the API review, but the 'one missing, any number extra' variant was left as
-        // 'to be considered', and with this implementation it's trivial to do it if we want.
+      } else if (missing.size() == 1 && extra.size() >= 1) {
         return describeSingleMissingWithExtras(correspondence.toString(), missing.get(0), extra);
       } else {
         return describeMissingOrExtraWithoutPairing(correspondence.toString(), missing, extra);

--- a/core/src/main/java/com/google/common/truth/StandardSubjectBuilder.java
+++ b/core/src/main/java/com/google/common/truth/StandardSubjectBuilder.java
@@ -160,7 +160,7 @@ public class StandardSubjectBuilder {
   }
 
   public final GuavaOptionalSubject that(@Nullable Optional<?> actual) {
-    return new GuavaOptionalSubject(metadata(), actual);
+    return new GuavaOptionalSubject(metadata(), actual, "optional");
   }
 
   public final MapSubject that(@Nullable Map<?, ?> actual) {

--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -304,13 +304,11 @@ public class Subject<S extends Subject<S, T>, T> {
    * value or a prefixed "name" along with the string representation.
    */
   /*
-   * TODO(cpovirk): Consider whether this API pulls its weight. If users want to format the actual
-   * value, maybe they should do so themselves? Of course, they won't have a chance to use a custom
-   * format for inherited implementations like isEqualTo(). But if they want to format the actual
-   * value specially, then it seems likely that they'll want to format the expected value specially,
-   * too. And that applies just as well to APIs like isIn(). Maybe we'll want an API that supports
-   * formatting those values, too? See also the related b/70930431. But note that we are likely to
-   * use this from FailureMetadata, at least in the short term, for better or for worse.
+   * TODO(cpovirk): If we delete named(), this method will be a thin wrapper around
+   * actualCustomStringRepresentation(), one that merely adds angle brackets (which we might not
+   * want it to do). But if we delete actualCustomStringRepresentation() in favor of a "format
+   * actual or expected" method, as described in a comment on that method, then it becomes useful
+   * again (though there's still a question of what to do with the angle brackets).
    */
   protected final String actualAsString() {
     String formatted = actualCustomStringRepresentation();
@@ -327,6 +325,16 @@ public class Subject<S extends Subject<S, T>, T> {
     }
   }
 
+  /** Like {@link #actualAsString()} but without angle brackets around the value. */
+  final String actualAsStringNoBrackets() {
+    String formatted = actualCustomStringRepresentation();
+    if (customName != null) {
+      return customName + (formatted.isEmpty() ? "" : " (" + formatted + ")");
+    } else {
+      return formatted;
+    }
+  }
+
   /**
    * Supplies the direct string representation of the actual value to other methods which may prefix
    * or otherwise position it in an error message. This should only be overridden to provide an
@@ -336,6 +344,15 @@ public class Subject<S extends Subject<S, T>, T> {
    * <p>Subjects should override this with care.
    *
    * <p>By default, this returns {@code String.ValueOf(getActualValue())}.
+   */
+  /*
+   * TODO(cpovirk): Consider whether this API pulls its weight. If users want to format the actual
+   * value, maybe they should do so themselves? Of course, they won't have a chance to use a custom
+   * format for inherited implementations like isEqualTo(). But if they want to format the actual
+   * value specially, then it seems likely that they'll want to format the expected value specially,
+   * too. And that applies just as well to APIs like isIn(). Maybe we'll want an API that supports
+   * formatting those values, too? See also the related b/70930431. But note that we are likely to
+   * use this from FailureMetadata, at least in the short term, for better or for worse.
    */
   @ForOverride
   protected String actualCustomStringRepresentation() {

--- a/core/src/test/java/com/google/common/truth/ChainingTest.java
+++ b/core/src/test/java/com/google/common/truth/ChainingTest.java
@@ -101,7 +101,7 @@ public final class ChainingTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat("root")
         .delegatingToNamed("child", "child")
         .isThePresentKingOfFrance();
-    assertNoCause("value of: myObject.child: message: myObject was: <root>");
+    assertNoCause("value of: myObject.child: message: myObject was: root");
   }
 
   @Test
@@ -110,7 +110,7 @@ public final class ChainingTest extends BaseSubjectTestCase {
         .delegatingToNamed("child", "child")
         .delegatingToNamed("grandchild", "grandchild")
         .isThePresentKingOfFrance();
-    assertNoCause("value of: myObject.child.grandchild: message: myObject was: <root>");
+    assertNoCause("value of: myObject.child.grandchild: message: myObject was: root");
   }
 
   @Test
@@ -119,7 +119,7 @@ public final class ChainingTest extends BaseSubjectTestCase {
         .delegatingToNamed("child", "child")
         .delegatingTo("grandchild")
         .isThePresentKingOfFrance();
-    assertNoCause("message: myObject was: <root>");
+    assertNoCause("message: myObject was: root");
   }
 
   @Test
@@ -128,14 +128,14 @@ public final class ChainingTest extends BaseSubjectTestCase {
         .delegatingTo("child")
         .delegatingToNamed("grandchild", "grandchild")
         .isThePresentKingOfFrance();
-    assertNoCause("value of: myObject.grandchild: message: myObject was: <root>");
+    assertNoCause("value of: myObject.grandchild: message: myObject was: root");
   }
 
   @Test
   public void namedAndComparisonFailure() {
     expectFailureWhenTestingThat("root").delegatingToNamed("child", "child").isEqualToString("z");
     assertNoCause(
-        "value of: myObject.child: message expected:<[child]> but was:<[z]>: myObject was: <root>");
+        "value of: myObject.child: message expected:<[child]> but was:<[z]>: myObject was: root");
   }
 
   @Test
@@ -147,7 +147,7 @@ public final class ChainingTest extends BaseSubjectTestCase {
         .that("root")
         .delegatingToNamed("child", "child")
         .isThePresentKingOfFrance();
-    assertNoCause("prefix: value of: myObject.child: message: myObject was: <root>");
+    assertNoCause("prefix: value of: myObject.child: message: myObject was: root");
   }
 
   @Test
@@ -159,7 +159,7 @@ public final class ChainingTest extends BaseSubjectTestCase {
   @Test
   public void checkFailWithName() {
     expectFailureWhenTestingThat("root").doCheckFail("child");
-    assertNoCause("value of: myObject.child: message: myObject was: <root>");
+    assertNoCause("value of: myObject.child: message: myObject was: root");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/FieldTest.java
+++ b/core/src/test/java/com/google/common/truth/FieldTest.java
@@ -17,6 +17,7 @@
 package com.google.common.truth;
 
 import static com.google.common.truth.Field.field;
+import static com.google.common.truth.Field.fieldWithoutValue;
 import static com.google.common.truth.Field.makeMessage;
 import static com.google.common.truth.Truth.assertThat;
 
@@ -31,6 +32,11 @@ public class FieldTest {
   @Test
   public void string() {
     assertThat(field("foo", "bar").toString()).isEqualTo("foo: bar");
+  }
+
+  @Test
+  public void stringWithoutValue() {
+    assertThat(fieldWithoutValue("foo").toString()).isEqualTo("foo");
   }
 
   @Test
@@ -49,9 +55,33 @@ public class FieldTest {
   }
 
   @Test
+  public void oneFieldWithoutValue() {
+    assertThat(makeMessage(ImmutableList.<String>of(), ImmutableList.of(fieldWithoutValue("foo"))))
+        .isEqualTo("foo");
+  }
+
+  @Test
+  public void twoFieldsOneWithoutValue() {
+    assertThat(
+            makeMessage(
+                ImmutableList.<String>of(),
+                ImmutableList.of(field("foo", "bar"), fieldWithoutValue("hello"))))
+        .isEqualTo("foo: bar\nhello");
+  }
+
+  @Test
   public void newline() {
     assertThat(makeMessage(ImmutableList.<String>of(), ImmutableList.of(field("foo", "bar\nbaz"))))
         .isEqualTo("foo:\n    bar\n    baz");
+  }
+
+  @Test
+  public void newlineWithoutValue() {
+    assertThat(
+            makeMessage(
+                ImmutableList.<String>of(),
+                ImmutableList.of(field("foo", "bar\nbaz"), fieldWithoutValue("xyz"))))
+        .isEqualTo("foo:\n    bar\n    baz\nxyz");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/GuavaOptionalSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/GuavaOptionalSubjectTest.java
@@ -42,15 +42,6 @@ public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
-  public void failOnNullSubject() {
-      Optional<String> nullOptional = null;
-    expectFailure.whenTesting().that(nullOptional).isAbsent();
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <null> is absent");
-  }
-
-  @Test
   public void isPresent() {
     assertThat(Optional.of("foo")).isPresent();
   }
@@ -72,6 +63,14 @@ public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
+  public void isPresentFailingNull() {
+    expectFailure.whenTesting().that((Optional<?>) null).isPresent();
+    assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .isEqualTo("Not true that the subject is present");
+  }
+
+  @Test
   public void isAbsent() {
     assertThat(Optional.absent()).isAbsent();
   }
@@ -82,6 +81,15 @@ public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <Optional.of(foo)> is absent");
+  }
+
+  @Test
+  public void isAbsentFailingNull() {
+    Optional<String> nullOptional = null;
+    expectFailure.whenTesting().that(nullOptional).isAbsent();
+    assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .isEqualTo("Not true that <null> is absent");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/IterableSubjectCorrespondenceTest.java
+++ b/core/src/test/java/com/google/common/truth/IterableSubjectCorrespondenceTest.java
@@ -282,9 +282,9 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
   }
 
   @Test
-  public void comparingElementsUsing_containsExactlyElementsIn_diffOneMissingAndExtraCandidate() {
+  public void comparingElementsUsing_containsExactlyElementsIn_diffOneMissingSomeExtraCandidate() {
     ImmutableList<Integer> expected = ImmutableList.of(30, 60, 90);
-    ImmutableList<Integer> actual = ImmutableList.of(101, 65, 35);
+    ImmutableList<Integer> actual = ImmutableList.of(101, 65, 35, 190);
     expectFailure
         .whenTesting()
         .that(actual)
@@ -293,9 +293,9 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "Not true that <[101, 65, 35]> contains exactly one element that is within 10 of "
+            "Not true that <[101, 65, 35, 190]> contains exactly one element that is within 10 of "
                 + "each element of <[30, 60, 90]>. It is missing an element that is within 10 of "
-                + "<90> and has unexpected elements <[101 (diff: 11)]>");
+                + "<90> and has unexpected elements <[101 (diff: 11), 190 (diff: 100)]>");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/IterableSubjectCorrespondenceTest.java
+++ b/core/src/test/java/com/google/common/truth/IterableSubjectCorrespondenceTest.java
@@ -68,6 +68,31 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
   }
 
   @Test
+  public void comparingElementsUsing_displayingDiffsPairedBy_1arg_contains() {
+    Record expected = Record.create(2, 200);
+    ImmutableList<Record> actual =
+        ImmutableList.of(
+            Record.create(1, 100),
+            Record.create(2, 211),
+            Record.create(4, 400),
+            Record.create(2, 189),
+            Record.createWithoutId(999));
+    expectFailure
+        .whenTesting()
+        .that(actual)
+        .comparingElementsUsing(RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10)
+        .displayingDiffsPairedBy(RECORD_ID)
+        .contains(expected);
+    assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .isEqualTo(
+            "Not true that <[1/100, 2/211, 4/400, 2/189, none/999]> contains exactly one element "
+                + "that has the same id as and a score is within 10 of <2/200>. It did contain the "
+                + "following elements with the correct key: "
+                + "<[2/211 (diff: score:11), 2/189 (diff: score:-11)]>");
+  }
+
+  @Test
   public void comparingElementsUsing_contains_null() {
     List<String> actual = Arrays.asList("+123", null, "+789");
     assertThat(actual)

--- a/core/src/test/java/com/google/common/truth/MultimapSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/MultimapSubjectTest.java
@@ -181,7 +181,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
             "value of: multymap.valuesForKey(1): "
                 + "Not true that <[5]> contains exactly <[4]>. "
                 + "It is missing <[4]> and has unexpected items <[5]>: "
-                + "multimap was: multymap (<{1=[5]}>)");
+                + "multimap was: multymap ({1=[5]})");
   }
 
   @Test
@@ -194,7 +194,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
             "value of: multimap.valuesForKey(1): "
                 + "Not true that valuez (<[5]>) contains exactly <[4]>. "
                 + "It is missing <[4]> and has unexpected items <[5]>: "
-                + "multimap was: <{1=[5]}>");
+                + "multimap was: {1=[5]}");
   }
 
   @Test

--- a/extensions/java8/src/test/java/com/google/common/truth/OptionalSubjectTest.java
+++ b/extensions/java8/src/test/java/com/google/common/truth/OptionalSubjectTest.java
@@ -43,12 +43,6 @@ public class OptionalSubjectTest {
   }
 
   @Test
-  public void failOnNullSubject() {
-    AssertionError expected = expectFailure(whenTesting -> whenTesting.that(null).isEmpty());
-    assertThat(expected).hasMessageThat().isEqualTo("Not true that <null> is empty");
-  }
-
-  @Test
   public void isPresent() {
     assertThat(Optional.of("foo")).isPresent();
   }
@@ -68,6 +62,12 @@ public class OptionalSubjectTest {
   }
 
   @Test
+  public void isPresentFailingNull() {
+    AssertionError expected = expectFailure(whenTesting -> whenTesting.that(null).isPresent());
+    assertThat(expected).hasMessageThat().isEqualTo("Not true that the subject is present");
+  }
+
+  @Test
   public void isEmpty() {
     assertThat(Optional.empty()).isEmpty();
   }
@@ -77,6 +77,12 @@ public class OptionalSubjectTest {
     AssertionError expected =
         expectFailure(whenTesting -> whenTesting.that(Optional.of("foo")).isEmpty());
     assertThat(expected).hasMessageThat().isEqualTo("Not true that <Optional[foo]> is empty");
+  }
+
+  @Test
+  public void isEmptyFailingNull() {
+    AssertionError expected = expectFailure(whenTesting -> whenTesting.that(null).isEmpty());
+    assertThat(expected).hasMessageThat().isEqualTo("Not true that <null> is empty");
   }
 
   @Test

--- a/util/generate-latest-docs.sh
+++ b/util/generate-latest-docs.sh
@@ -34,7 +34,7 @@ if [[ -n "${RELEASE_VERSION:-}" ||
     # Travis
     version_subdir=api/latest
     github_url="https://${GH_TOKEN}@github.com/${EXPECTED_REPO_SLUG}"
-    commit_message="Lastest javadoc on successful travis build $TRAVIS_BUILD_NUMBER auto-pushed to gh-pages."
+    commit_message="Latest javadoc on successful travis build $TRAVIS_BUILD_NUMBER auto-pushed to gh-pages."
   fi
 
   mvn javadoc:aggregate


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Make Smart Diffs for Fuzzy Truth for Iterables without displayingDiffsPairedBy trigger for exactly one missing and at least one unexpected, rather than exactly one missing and exactly one unexpected.

924f650c81cf27aaf2ac0d306b29b061cd846e9b

-------

<p> Add tests for assertThat(nullOptional).isPresent().

Move existing tests for assertThat(nullOptional).isAbsent()/isEmpty() to be parallel to the new tests.

e0e72d54aea871bbeb2b6ea1c39de1d2e4bd5280

-------

<p> Remove angle brackets from description of root object.

For example:

multimap was: <{1=[5]}>
=>
multimap was: {1=[5]}

Also, improve some comments:
- Add a missing "was" to a comment in FailureMetadata
- Move a TODO from Subject.actualAsString to actualCustomStringRepresentation, the method I meant to put it on.
- Add a new TODO to actualAsString about the future of *that* method.

056f9b4957fdd26c4a173d17a0bc5f80488f5a69

-------

<p> Add support for fields with no values.

My plan is to use this for cases like OptionalSubject.isPresent(), when there's no value to print, just the message "expected to be present."

7564b40af2a7bb4c9999520c242a1ba4e61cb607

-------

<p> Typo: "Lastest" -> "Latest"

e303fc83a22cc77a3c3d22e70762b0098d2ea110

-------

<p> Override the type description for GuavaOptionalSubject.

In a later CL, I'm going to start using check("get()") for tests of the Optional's value, and Truth would otherwise generate:

value of: guavaOptional.get()

This CL makes it:

value of: optional.get()

cafa949e1d8526ccd93a71d2e17c74da3322b1c1

-------

<p> Make IterableSubject.UsingCorrespondence.displayingDiffsPairedBy() work for contains().

516cae0715cbadac79ea144820a16ec0f0e60b94