### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/AbstractArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/AbstractArraySubject.java
@@ -26,8 +26,9 @@ import javax.annotation.Nullable;
  * @author Christian Gruber (cgruber@israfil.net)
  */
 abstract class AbstractArraySubject<S extends AbstractArraySubject<S, T>, T> extends Subject<S, T> {
-  AbstractArraySubject(FailureMetadata metadata, @Nullable T actual) {
-    super(metadata, actual);
+  AbstractArraySubject(
+      FailureMetadata metadata, @Nullable T actual, @Nullable String typeDescription) {
+    super(metadata, actual, typeDescription);
   }
 
   /** Fails if the array is not empty (i.e. {@code array.length != 0}). */

--- a/core/src/main/java/com/google/common/truth/ObjectArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/ObjectArraySubject.java
@@ -42,8 +42,8 @@ public final class ObjectArraySubject<T> extends AbstractArraySubject<ObjectArra
   private final String typeName;
   private final int numberOfDimensions;
 
-  ObjectArraySubject(FailureMetadata metadata, @Nullable T[] o) {
-    super(metadata, o);
+  ObjectArraySubject(FailureMetadata metadata, @Nullable T[] o, @Nullable String typeDescription) {
+    super(metadata, o, typeDescription);
     typeName = typeNameFromInstance(o);
     numberOfDimensions = numberOfDimensions(o);
   }

--- a/core/src/main/java/com/google/common/truth/PrimitiveBooleanArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveBooleanArraySubject.java
@@ -27,8 +27,9 @@ import javax.annotation.Nullable;
  */
 public final class PrimitiveBooleanArraySubject
     extends AbstractArraySubject<PrimitiveBooleanArraySubject, boolean[]> {
-  PrimitiveBooleanArraySubject(FailureMetadata metadata, @Nullable boolean[] o) {
-    super(metadata, o);
+  PrimitiveBooleanArraySubject(
+      FailureMetadata metadata, @Nullable boolean[] o, @Nullable String typeDescription) {
+    super(metadata, o, typeDescription);
   }
 
   @Override

--- a/core/src/main/java/com/google/common/truth/PrimitiveByteArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveByteArraySubject.java
@@ -27,8 +27,9 @@ import javax.annotation.Nullable;
  */
 public final class PrimitiveByteArraySubject
     extends AbstractArraySubject<PrimitiveByteArraySubject, byte[]> {
-  PrimitiveByteArraySubject(FailureMetadata metadata, @Nullable byte[] o) {
-    super(metadata, o);
+  PrimitiveByteArraySubject(
+      FailureMetadata metadata, @Nullable byte[] o, @Nullable String typeDescription) {
+    super(metadata, o, typeDescription);
   }
 
   @Override

--- a/core/src/main/java/com/google/common/truth/PrimitiveCharArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveCharArraySubject.java
@@ -27,8 +27,9 @@ import javax.annotation.Nullable;
  */
 public final class PrimitiveCharArraySubject
     extends AbstractArraySubject<PrimitiveCharArraySubject, char[]> {
-  PrimitiveCharArraySubject(FailureMetadata metadata, @Nullable char[] o) {
-    super(metadata, o);
+  PrimitiveCharArraySubject(
+      FailureMetadata metadata, @Nullable char[] o, @Nullable String typeDescription) {
+    super(metadata, o, typeDescription);
   }
 
   @Override

--- a/core/src/main/java/com/google/common/truth/PrimitiveDoubleArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveDoubleArraySubject.java
@@ -39,8 +39,9 @@ import javax.annotation.Nullable;
  */
 public final class PrimitiveDoubleArraySubject
     extends AbstractArraySubject<PrimitiveDoubleArraySubject, double[]> {
-  PrimitiveDoubleArraySubject(FailureMetadata metadata, @Nullable double[] o) {
-    super(metadata, o);
+  PrimitiveDoubleArraySubject(
+      FailureMetadata metadata, @Nullable double[] o, @Nullable String typeDescription) {
+    super(metadata, o, typeDescription);
   }
 
   @Override

--- a/core/src/main/java/com/google/common/truth/PrimitiveFloatArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveFloatArraySubject.java
@@ -39,8 +39,9 @@ import javax.annotation.Nullable;
  */
 public final class PrimitiveFloatArraySubject
     extends AbstractArraySubject<PrimitiveFloatArraySubject, float[]> {
-  PrimitiveFloatArraySubject(FailureMetadata metadata, @Nullable float[] o) {
-    super(metadata, o);
+  PrimitiveFloatArraySubject(
+      FailureMetadata metadata, @Nullable float[] o, @Nullable String typeDescription) {
+    super(metadata, o, typeDescription);
   }
 
   @Override

--- a/core/src/main/java/com/google/common/truth/PrimitiveIntArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveIntArraySubject.java
@@ -27,8 +27,9 @@ import javax.annotation.Nullable;
  */
 public final class PrimitiveIntArraySubject
     extends AbstractArraySubject<PrimitiveIntArraySubject, int[]> {
-  PrimitiveIntArraySubject(FailureMetadata metadata, @Nullable int[] o) {
-    super(metadata, o);
+  PrimitiveIntArraySubject(
+      FailureMetadata metadata, @Nullable int[] o, @Nullable String typeDescription) {
+    super(metadata, o, typeDescription);
   }
 
   @Override

--- a/core/src/main/java/com/google/common/truth/PrimitiveLongArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveLongArraySubject.java
@@ -27,8 +27,9 @@ import javax.annotation.Nullable;
  */
 public final class PrimitiveLongArraySubject
     extends AbstractArraySubject<PrimitiveLongArraySubject, long[]> {
-  PrimitiveLongArraySubject(FailureMetadata metadata, @Nullable long[] o) {
-    super(metadata, o);
+  PrimitiveLongArraySubject(
+      FailureMetadata metadata, @Nullable long[] o, @Nullable String typeDescription) {
+    super(metadata, o, typeDescription);
   }
 
   @Override

--- a/core/src/main/java/com/google/common/truth/PrimitiveShortArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveShortArraySubject.java
@@ -27,8 +27,9 @@ import javax.annotation.Nullable;
  */
 public final class PrimitiveShortArraySubject
     extends AbstractArraySubject<PrimitiveShortArraySubject, short[]> {
-  PrimitiveShortArraySubject(FailureMetadata metadata, @Nullable short[] o) {
-    super(metadata, o);
+  PrimitiveShortArraySubject(
+      FailureMetadata metadata, @Nullable short[] o, @Nullable String typeDescription) {
+    super(metadata, o, typeDescription);
   }
 
   @Override

--- a/core/src/main/java/com/google/common/truth/StandardSubjectBuilder.java
+++ b/core/src/main/java/com/google/common/truth/StandardSubjectBuilder.java
@@ -124,39 +124,39 @@ public class StandardSubjectBuilder {
   }
 
   public final <T> ObjectArraySubject<T> that(@Nullable T[] actual) {
-    return new ObjectArraySubject<>(metadata(), actual);
+    return new ObjectArraySubject<>(metadata(), actual, "array");
   }
 
   public final PrimitiveBooleanArraySubject that(@Nullable boolean[] actual) {
-    return new PrimitiveBooleanArraySubject(metadata(), actual);
+    return new PrimitiveBooleanArraySubject(metadata(), actual, "array");
   }
 
   public final PrimitiveShortArraySubject that(@Nullable short[] actual) {
-    return new PrimitiveShortArraySubject(metadata(), actual);
+    return new PrimitiveShortArraySubject(metadata(), actual, "array");
   }
 
   public final PrimitiveIntArraySubject that(@Nullable int[] actual) {
-    return new PrimitiveIntArraySubject(metadata(), actual);
+    return new PrimitiveIntArraySubject(metadata(), actual, "array");
   }
 
   public final PrimitiveLongArraySubject that(@Nullable long[] actual) {
-    return new PrimitiveLongArraySubject(metadata(), actual);
+    return new PrimitiveLongArraySubject(metadata(), actual, "array");
   }
 
   public final PrimitiveCharArraySubject that(@Nullable char[] actual) {
-    return new PrimitiveCharArraySubject(metadata(), actual);
+    return new PrimitiveCharArraySubject(metadata(), actual, "array");
   }
 
   public final PrimitiveByteArraySubject that(@Nullable byte[] actual) {
-    return new PrimitiveByteArraySubject(metadata(), actual);
+    return new PrimitiveByteArraySubject(metadata(), actual, "array");
   }
 
   public final PrimitiveFloatArraySubject that(@Nullable float[] actual) {
-    return new PrimitiveFloatArraySubject(metadata(), actual);
+    return new PrimitiveFloatArraySubject(metadata(), actual, "array");
   }
 
   public final PrimitiveDoubleArraySubject that(@Nullable double[] actual) {
-    return new PrimitiveDoubleArraySubject(metadata(), actual);
+    return new PrimitiveDoubleArraySubject(metadata(), actual, "array");
   }
 
   public final GuavaOptionalSubject that(@Nullable Optional<?> actual) {

--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -172,14 +172,19 @@ public class Subject<S extends Subject<S, T>, T> {
   }
 
   private boolean actualEquals(@Nullable Object expected) {
-    if (isIntegralBoxedPrimitive(actual()) && isIntegralBoxedPrimitive(expected)) {
-      return Objects.equal(integralValue(actual()), integralValue(expected));
+    // TODO(cpovirk): Move array handling from subclasses into this method.
+    if (actual() == null && expected == null) {
+      return true;
+    } else if (actual() == null || expected == null) {
+      return false;
+    } else if (isIntegralBoxedPrimitive(actual()) && isIntegralBoxedPrimitive(expected)) {
+      return integralValue(actual()) == integralValue(expected);
     } else if (actual() instanceof Double && expected instanceof Double) {
       return Double.compare((Double) actual(), (Double) expected) == 0;
     } else if (actual() instanceof Float && expected instanceof Float) {
       return Float.compare((Float) actual(), (Float) expected) == 0;
     } else {
-      return Objects.equal(actual(), expected);
+      return actual() == expected || actual().equals(expected);
     }
   }
 
@@ -191,7 +196,7 @@ public class Subject<S extends Subject<S, T>, T> {
         || o instanceof Long;
   }
 
-  private static Long integralValue(Object o) {
+  private static long integralValue(Object o) {
     if (o instanceof Character) {
       return (long) ((Character) o).charValue();
     } else if (o instanceof Number) {

--- a/core/src/test/java/com/google/common/truth/StringSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/StringSubjectTest.java
@@ -75,6 +75,15 @@ public class StringSubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
+  public void stringIsEmptyFailNull() {
+    String s = null;
+    expectFailure.whenTesting().that(s).isEmpty();
+    assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .isEqualTo("Not true that null reference is empty");
+  }
+
+  @Test
   public void stringIsNotEmpty() {
     assertThat("abc").isNotEmpty();
   }
@@ -85,6 +94,15 @@ public class StringSubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <\"\"> is not empty");
+  }
+
+  @Test
+  public void stringIsNotEmptyFailNull() {
+    String s = null;
+    expectFailure.whenTesting().that(s).isNotEmpty();
+    assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .isEqualTo("Not true that null reference is not empty");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/StringSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/StringSubjectTest.java
@@ -182,6 +182,15 @@ public class StringSubjectTest extends BaseSubjectTestCase {
         .isEqualTo("Not true that foo (<null>) is equal to <\"abd\">");
   }
 
+  @GwtIncompatible // ComparisonFailure-style message
+  @Test
+  public void stringEqualityFailMultiline() {
+    expectFailure.whenTesting().that("abc\ndef\nxyz").isEqualTo("aaa\nqqq\nzzz");
+    assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .isEqualTo("expected:<a[aa\nqqq\nzz]z> but was:<a[bc\ndef\nxy]z>");
+  }
+
   @Test
   public void stringStartsWith() {
     assertThat("abc").startsWith("ab");

--- a/core/src/test/java/com/google/common/truth/SubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/SubjectTest.java
@@ -15,6 +15,7 @@
  */
 package com.google.common.truth;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.TestPlatform.isGwt;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
@@ -334,6 +335,11 @@ public class SubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
+  public void isNullBadEqualsImplementation() {
+    expectFailure.whenTesting().that(new ThrowsOnEqualsNull()).isNull();
+  }
+
+  @Test
   public void isNotNull() {
     Object o = new Object();
     assertThat(o).isNotNull();
@@ -346,6 +352,11 @@ public class SubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that the subject is a non-null reference");
+  }
+
+  @Test
+  public void isNotNullBadEqualsImplementation() {
+    assertThat(new ThrowsOnEqualsNull()).isNotNull();
   }
 
   @Test
@@ -846,5 +857,13 @@ public class SubjectTest extends BaseSubjectTestCase {
         .isEqualTo(
             "Not true that <[1, 2, 3]> is equal to <[1, 2, 3]> "
                 + "(although their toString() representations are the same)");
+  }
+
+  private static final class ThrowsOnEqualsNull {
+    @Override
+    public boolean equals(Object obj) {
+      checkNotNull(obj); // buggy implementation but one that we're working around, at least for now
+      return super.equals(obj);
+    }
   }
 }

--- a/core/src/test/java/com/google/common/truth/SubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/SubjectTest.java
@@ -454,6 +454,18 @@ public class SubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
+  public void isEqualToNullBadEqualsImplementation() {
+    expectFailure.whenTesting().that(new ThrowsOnEqualsNull()).isEqualTo(null);
+  }
+
+  @SuppressWarnings("TruthSelfEquals")
+  @Test
+  public void isEqualToSameInstanceBadEqualsImplementation() {
+    Object o = new ThrowsOnEquals();
+    assertThat(o).isEqualTo(o);
+  }
+
+  @Test
   public void isNotEqualToWithNulls() {
     Object o = null;
     assertThat(o).isNotEqualTo("a");
@@ -516,6 +528,18 @@ public class SubjectTest extends BaseSubjectTestCase {
     Object a = "true";
     Object b = true;
     assertThat(a).isNotEqualTo(b);
+  }
+
+  @Test
+  public void isNotEqualToNullBadEqualsImplementation() {
+    assertThat(new ThrowsOnEqualsNull()).isNotEqualTo(null);
+  }
+
+  @SuppressWarnings("TruthSelfEquals")
+  @Test
+  public void isNotEqualToSameInstanceBadEqualsImplementation() {
+    Object o = new ThrowsOnEquals();
+    expectFailure.whenTesting().that(o).isNotEqualTo(o);
   }
 
   @Test
@@ -864,6 +888,14 @@ public class SubjectTest extends BaseSubjectTestCase {
     public boolean equals(Object obj) {
       checkNotNull(obj); // buggy implementation but one that we're working around, at least for now
       return super.equals(obj);
+    }
+  }
+
+  private static final class ThrowsOnEquals {
+    @Override
+    public boolean equals(Object obj) {
+      throw new UnsupportedOperationException();
+      // buggy implementation but one that we're working around, at least for now
     }
   }
 }

--- a/extensions/java8/src/main/java/com/google/common/truth/OptionalDoubleSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/OptionalDoubleSubject.java
@@ -25,8 +25,11 @@ import javax.annotation.Nullable;
  */
 public final class OptionalDoubleSubject extends Subject<OptionalDoubleSubject, OptionalDouble> {
 
-  OptionalDoubleSubject(FailureMetadata failureMetadata, @Nullable OptionalDouble subject) {
-    super(failureMetadata, subject);
+  OptionalDoubleSubject(
+      FailureMetadata failureMetadata,
+      @Nullable OptionalDouble subject,
+      @Nullable String typeDescription) {
+    super(failureMetadata, subject, typeDescription);
   }
 
   /** Fails if the {@link OptionalDouble} is empty or the subject is null. */
@@ -76,6 +79,6 @@ public final class OptionalDoubleSubject extends Subject<OptionalDoubleSubject, 
   }
 
   public static Subject.Factory<OptionalDoubleSubject, OptionalDouble> optionalDoubles() {
-    return OptionalDoubleSubject::new;
+    return (metadata, subject) -> new OptionalDoubleSubject(metadata, subject, "optionalDouble");
   }
 }

--- a/extensions/java8/src/main/java/com/google/common/truth/OptionalIntSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/OptionalIntSubject.java
@@ -24,8 +24,11 @@ import javax.annotation.Nullable;
  * @author Ben Douglass
  */
 public final class OptionalIntSubject extends Subject<OptionalIntSubject, OptionalInt> {
-  OptionalIntSubject(FailureMetadata failureMetadata, @Nullable OptionalInt subject) {
-    super(failureMetadata, subject);
+  OptionalIntSubject(
+      FailureMetadata failureMetadata,
+      @Nullable OptionalInt subject,
+      @Nullable String typeDescription) {
+    super(failureMetadata, subject, typeDescription);
   }
 
   /** Fails if the {@link OptionalInt} is empty or the subject is null. */
@@ -71,6 +74,6 @@ public final class OptionalIntSubject extends Subject<OptionalIntSubject, Option
   }
 
   public static Subject.Factory<OptionalIntSubject, OptionalInt> optionalInts() {
-    return OptionalIntSubject::new;
+    return (metadata, subject) -> new OptionalIntSubject(metadata, subject, "optionalInt");
   }
 }

--- a/extensions/java8/src/main/java/com/google/common/truth/OptionalLongSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/OptionalLongSubject.java
@@ -24,8 +24,11 @@ import javax.annotation.Nullable;
  * @author Ben Douglass
  */
 public final class OptionalLongSubject extends Subject<OptionalLongSubject, OptionalLong> {
-  OptionalLongSubject(FailureMetadata failureMetadata, @Nullable OptionalLong subject) {
-    super(failureMetadata, subject);
+  OptionalLongSubject(
+      FailureMetadata failureMetadata,
+      @Nullable OptionalLong subject,
+      @Nullable String typeDescription) {
+    super(failureMetadata, subject, typeDescription);
   }
 
   /** Fails if the {@link OptionalLong} is empty or the subject is null. */
@@ -71,6 +74,6 @@ public final class OptionalLongSubject extends Subject<OptionalLongSubject, Opti
   }
 
   public static Subject.Factory<OptionalLongSubject, OptionalLong> optionalLongs() {
-    return OptionalLongSubject::new;
+    return (metadata, subject) -> new OptionalLongSubject(metadata, subject, "optionalLong");
   }
 }

--- a/extensions/java8/src/main/java/com/google/common/truth/OptionalSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/OptionalSubject.java
@@ -24,8 +24,11 @@ import javax.annotation.Nullable;
  * @author Christian Gruber
  */
 public final class OptionalSubject extends Subject<OptionalSubject, Optional<?>> {
-  OptionalSubject(FailureMetadata failureMetadata, @Nullable Optional<?> subject) {
-    super(failureMetadata, subject);
+  OptionalSubject(
+      FailureMetadata failureMetadata,
+      @Nullable Optional<?> subject,
+      @Nullable String typeDescription) {
+    super(failureMetadata, subject, typeDescription);
   }
 
   /** Fails if the {@link Optional}{@code <T>} is empty or the subject is null. */
@@ -73,6 +76,6 @@ public final class OptionalSubject extends Subject<OptionalSubject, Optional<?>>
   }
 
   public static Subject.Factory<OptionalSubject, Optional<?>> optionals() {
-    return (metadata, subject) -> new OptionalSubject(metadata, subject);
+    return (metadata, subject) -> new OptionalSubject(metadata, subject, "optional");
   }
 }

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosFluentAssertion.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosFluentAssertion.java
@@ -15,6 +15,8 @@
  */
 package com.google.common.truth.extensions.proto;
 
+import com.google.common.base.Function;
+import com.google.common.truth.IterableSubject;
 import com.google.common.truth.Ordered;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Descriptors.FieldDescriptor;
@@ -218,6 +220,40 @@ public interface IterableOfProtosFluentAssertion<M extends Message> {
    * <p>This a purely cosmetic setting, and it has no effect on the behavior of the test.
    */
   IterableOfProtosFluentAssertion<M> reportingMismatchesOnly();
+
+  /**
+   * Specifies a way to pair up unexpected and missing elements in the message when an assertion
+   * fails. For example:
+   *
+   * <pre>{@code
+   * assertThat(actualFoos)
+   *     .ignoringRepeatedFieldOrder()
+   *     .ignoringFields(Foo.BAR_FIELD_NUMBER)
+   *     .displayingDiffsPairedBy(Foo::getId)
+   *     .containsExactlyElementsIn(expectedFoos);
+   * }</pre>
+   *
+   * <p>On assertions where it makes sense to do so, the elements are paired as follows: they are
+   * keyed by {@code keyFunction}, and if an unexpected element and a missing element have the same
+   * non-null key then the they are paired up. (Elements with null keys are not paired.) The failure
+   * message will show paired elements together, and a diff will be shown.
+   *
+   * <p>The expected elements given in the assertion should be uniquely keyed by {@link
+   * keyFunction}. If multiple missing elements have the same key then the pairing will be skipped.
+   *
+   * <p>Useful key functions will have the property that key equality is less strict than the
+   * already specified equality rules; i.e. given {@code actual} and {@code expected} values with
+   * keys {@code actualKey} and {@code expectedKey}, if {@code actual} and {@code expected} compare
+   * equal given the rest of the directives such as {@code ignoringRepeatedFieldOrder} and {@code
+   * ignoringFields}, then it is guaranteed that {@code actualKey} is equal to {@code expectedKey},
+   * but there are cases where {@code actualKey} is equal to {@code expectedKey} but the direct
+   * comparison fails.
+   *
+   * <p>Note that calling this method makes no difference to whether a test passes or fails, it just
+   * improves the message if it fails.
+   */
+  IterableSubject.UsingCorrespondence<M, M> displayingDiffsPairedBy(
+      Function<? super M, ?> keyFunction);
 
   /**
    * Checks that the subject contains at least one element that corresponds to the given expected

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/IterableOfProtosSubjectTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/IterableOfProtosSubjectTest.java
@@ -16,6 +16,7 @@
 
 package com.google.common.truth.extensions.proto;
 
+import com.google.common.base.Function;
 import com.google.protobuf.Message;
 import java.util.Collection;
 import java.util.Comparator;
@@ -469,6 +470,29 @@ public class IterableOfProtosSubjectTest extends ProtoSubjectTestBase {
                 + "deleted: r_string[1]: \"qux\"\n"
                 + "\n"
                 + "Full diff report:\n");
+  }
+
+  @Test
+  public void testDisplayingDiffsPairedBy() {
+    Message actualInt3 = parse("o_int: 3 r_string: 'foo'");
+    Message actualInt4 = parse("o_int: 4 r_string: 'bar'");
+    Message expectedInt3 = parse("o_int: 3 r_string: 'baz'");
+    Message expectedInt4 = parse("o_int: 4 r_string: 'qux'");
+
+    Function<Message, Integer> getInt =
+        new Function<Message, Integer>() {
+          @Override
+          public Integer apply(Message message) {
+            return (Integer) message.getField(getFieldDescriptor("o_int"));
+          }
+        };
+
+    expectFailureWhenTesting()
+        .that(listOf(actualInt3, actualInt4))
+        .displayingDiffsPairedBy(getInt)
+        .containsExactly(expectedInt3, expectedInt4);
+    expectThatFailure().hasMessageThat().contains("modified: r_string[0]: \"baz\" -> \"foo\"");
+    expectThatFailure().hasMessageThat().contains("modified: r_string[0]: \"qux\" -> \"bar\"");
   }
 
   @Test


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add displayingDiffsPairedBy to IterableOfProtosSubject.

This includes the one-arg version only, because ProtoTruth correspondences are all for the same type, so there is no practical need for a two-arg method.

RELNOTES=Add `displayingDiffsPairedBy` to `IterableOfProtosSubject`.

826a5d065b938ae938bd47979c9c45e00d2f455d

-------

<p> Override the type description for array subjects and for Java 8 optional subjects.

The array-subject changes are necessary to change, e.g.,...

value of: primitiveBooleanArray.asList()

...to...

value of: array.asList()

...or at least they will be once we start printing that line.

The optional changes won't change anything except someday under j2cl/GWT if people are running with class metadata off / obfuscation on. (Those modes mess with class names, so all Truth would be able to infer is "value of: object.get()." We override that back to "optional.get()," etc.)
z

632dd9fed3aa6787c5ef90101ad4c8fd7dc2aed3

-------

<p> Add a test for multiline strings.

This test looks at the whole ComparisonFailure message, not just the actual and expected values -- mainly to give an idea of how we need to improve things :)

8b47927df798c72143bb6f68202ec709ca19069e

-------

<p> Test that isNull() and isNotNull() work even on types whose equals() implementations throw NPE when given null.

I don't really "want" to support this, but tests in the depot currently rely on isNull() and isNotNull() to work with broken equals() implementations, and my upcoming changes would causes their tests to fail. It would be nice to clean them up, but accommodating them (starting with this commit to verify that we've done so) is a more expedient way forward.

9e84af1ceb446aeab22b8f2b9727a24046f58849

-------

<p> Put explicit null handling in our equality checking.

By getting the null checks out of the way early, we make it easier to insert tests for array equality later (https://github.com/google/truth/issues/335).

As part of this, we need to continue to explicitly check actual()==expected to avoid breaking various tests that fail if we actually invoke equals().
Furthermore: The usual way to do this would be the check actual()==expected at the top of the method. However, this seems to cause j2cl to consider 0 to be == to 0.0. For whatever reason, I'm able to avoid it by moving the == check down.

(Also, make a tiny simplification by changing integralValue() to return a primitive long rather than a Long. That lets us use == instead of equals().)

f5e58f319d1107908dc979bb77a4a2b00fd68b9d

-------

<p> Test that isNull() and isNotNull() work even when isEqualTo() and isNotEqualTo() don't.

Some people are overriding isEqualTo() and isNotEqualTo() to throw, telling their users to use some other methods instead. I'm not entirely sure what I think about this, so again, let's just push forward, adding tests for it to Truth itself so that it's easier to see why I'll be working around this in my coming CL.

f049a2b7209ce5edaaf05119778fa511832d29c9

-------

<p> Test isEmpty() and isNotEmpty() with null inputs.

a396d1d38843cc74e404d46c04e48feb6cf7244b