### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/AssertionErrorWithFields.java
+++ b/core/src/main/java/com/google/common/truth/AssertionErrorWithFields.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
  * An {@link AssertionError} composed of structured {@link Field} instances and other string
  * messages.
  */
-final class AssertionErrorWithFields extends AssertionError {
+final class AssertionErrorWithFields extends AssertionError implements ErrorWithFields {
   static AssertionErrorWithFields create(
       ImmutableList<String> messages, ImmutableList<Field> fields, @Nullable Throwable cause) {
     return new AssertionErrorWithFields(messages, fields, cause);
@@ -58,5 +58,10 @@ final class AssertionErrorWithFields extends AssertionError {
   @Override
   public String toString() {
     return getLocalizedMessage();
+  }
+
+  @Override
+  public ImmutableList<Field> fields() {
+    return fields;
   }
 }

--- a/core/src/main/java/com/google/common/truth/ComparisonFailureWithFields.java
+++ b/core/src/main/java/com/google/common/truth/ComparisonFailureWithFields.java
@@ -38,7 +38,8 @@ import javax.annotation.Nullable;
  *
  * <p>This class includes logic to format expected and actual values for easier reading.
  */
-final class ComparisonFailureWithFields extends PlatformComparisonFailure {
+final class ComparisonFailureWithFields extends PlatformComparisonFailure
+    implements ErrorWithFields {
   static ComparisonFailureWithFields create(
       ImmutableList<String> messages,
       ImmutableList<Field> headFields,
@@ -66,6 +67,11 @@ final class ComparisonFailureWithFields extends PlatformComparisonFailure {
         cause,
         OMIT_COMPARISON_FAILURE_GENERATED_MESSAGE);
     this.fields = checkNotNull(fields);
+  }
+
+  @Override
+  public ImmutableList<Field> fields() {
+    return fields;
   }
 
   private static ImmutableList<Field> makeFields(

--- a/core/src/main/java/com/google/common/truth/ErrorWithFields.java
+++ b/core/src/main/java/com/google/common/truth/ErrorWithFields.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.truth;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Supertype of Truth's {@link AssertionError} subclasses that are created from a list of {@link
+ * Field} instances.
+ */
+interface ErrorWithFields {
+  ImmutableList<Field> fields();
+}

--- a/core/src/main/java/com/google/common/truth/super/com/google/common/truth/Platform.java
+++ b/core/src/main/java/com/google/common/truth/super/com/google/common/truth/Platform.java
@@ -191,7 +191,7 @@ final class Platform {
           + "other exception before the failure would have happened. Under GWT, such an exception "
           + "is hidden by this message. The non-GWT tests do not have this problem, so you may "
           + "wish to debug them first. If you're still having this problem, consider temporarily "
-          + "modifying the GWT copy of BaseSubjectTestCase to remove the call to "
+          + "modifying the GWT copy of PlatformBaseSubjectTestCase to remove the call to "
           + "ensureFailureCaught(). Removing that call will let any other exception fall through. "
           + "(But of course it will also prevent the test from verifying that the expected failure "
           + "occurred.)";

--- a/core/src/test/java/com/google/common/truth/AtomicLongMapSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/AtomicLongMapSubjectTest.java
@@ -36,7 +36,7 @@ public final class AtomicLongMapSubjectTest extends BaseSubjectTestCase {
     AtomicLongMap<String> alm1 = AtomicLongMap.create();
     AtomicLongMap<String> alm2 = AtomicLongMap.create();
 
-    expectFailure.whenTesting().that(alm1).isEqualTo(alm2);
+    expectFailureWhenTestingThat(alm1).isEqualTo(alm2);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -55,7 +55,7 @@ public final class AtomicLongMapSubjectTest extends BaseSubjectTestCase {
     AtomicLongMap<String> actual = AtomicLongMap.create();
     actual.getAndIncrement("foo");
 
-    expectFailure.whenTesting().that(actual).isEmpty();
+    expectFailureWhenTestingThat(actual).isEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{foo=1}> is empty");
@@ -71,7 +71,7 @@ public final class AtomicLongMapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void isNotEmptyWithFailure() {
     AtomicLongMap<String> actual = AtomicLongMap.create();
-    expectFailure.whenTesting().that(actual).isNotEmpty();
+    expectFailureWhenTestingThat(actual).isNotEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{}> is not empty");
@@ -102,7 +102,7 @@ public final class AtomicLongMapSubjectTest extends BaseSubjectTestCase {
   public void hasSizeFails() {
     AtomicLongMap<String> actual = AtomicLongMap.create();
     actual.getAndIncrement("kurt");
-    expectFailure.whenTesting().that(actual).hasSize(2);
+    expectFailureWhenTestingThat(actual).hasSize(2);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{kurt=1}> has a size of <2>. It is <1>");
@@ -132,7 +132,7 @@ public final class AtomicLongMapSubjectTest extends BaseSubjectTestCase {
   public void hasSumFails() {
     AtomicLongMap<String> actual = AtomicLongMap.create();
     actual.getAndIncrement("kurt");
-    expectFailure.whenTesting().that(actual).hasSum(2);
+    expectFailureWhenTestingThat(actual).hasSum(2);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{kurt=1}> has a sum of <2>. It is <1>");
@@ -149,7 +149,7 @@ public final class AtomicLongMapSubjectTest extends BaseSubjectTestCase {
   public void containsKeyFailure() {
     AtomicLongMap<String> actual = AtomicLongMap.create();
     actual.getAndIncrement("kurt");
-    expectFailure.whenTesting().that(actual).containsKey("greg");
+    expectFailureWhenTestingThat(actual).containsKey("greg");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{kurt=1}> contains key <greg>");
@@ -166,7 +166,7 @@ public final class AtomicLongMapSubjectTest extends BaseSubjectTestCase {
   public void doesNotContainKeyFailure() {
     AtomicLongMap<String> actual = AtomicLongMap.create();
     actual.getAndIncrement("kurt");
-    expectFailure.whenTesting().that(actual).doesNotContainKey("kurt");
+    expectFailureWhenTestingThat(actual).doesNotContainKey("kurt");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{kurt=1}> does not contain key <kurt>");
@@ -194,7 +194,7 @@ public final class AtomicLongMapSubjectTest extends BaseSubjectTestCase {
   public void containsEntryFailure() {
     AtomicLongMap<String> actual = AtomicLongMap.create();
     actual.getAndIncrement("kurt");
-    expectFailure.whenTesting().that(actual).containsEntry("greg", 2);
+    expectFailureWhenTestingThat(actual).containsEntry("greg", 2);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{kurt=1}> contains entry <greg=2>");
@@ -212,7 +212,7 @@ public final class AtomicLongMapSubjectTest extends BaseSubjectTestCase {
   public void doesNotContainEntryFailure() {
     AtomicLongMap<String> actual = AtomicLongMap.create();
     actual.getAndIncrement("kurt");
-    expectFailure.whenTesting().that(actual).doesNotContainEntry("kurt", 1);
+    expectFailureWhenTestingThat(actual).doesNotContainEntry("kurt", 1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{kurt=1}> does not contain entry <kurt=1>");
@@ -222,7 +222,7 @@ public final class AtomicLongMapSubjectTest extends BaseSubjectTestCase {
   public void failMapContainsKey() {
     AtomicLongMap<String> actual = AtomicLongMap.create();
     actual.getAndIncrement("kurt");
-    expectFailure.whenTesting().that(actual).containsKey("greg");
+    expectFailureWhenTestingThat(actual).containsKey("greg");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{kurt=1}> contains key <greg>");
@@ -232,7 +232,7 @@ public final class AtomicLongMapSubjectTest extends BaseSubjectTestCase {
   public void failMapLacksKey() {
     AtomicLongMap<String> actual = AtomicLongMap.create();
     actual.getAndIncrement("kurt");
-    expectFailure.whenTesting().that(actual).doesNotContainKey("kurt");
+    expectFailureWhenTestingThat(actual).doesNotContainKey("kurt");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{kurt=1}> does not contain key <kurt>");
@@ -249,9 +249,13 @@ public final class AtomicLongMapSubjectTest extends BaseSubjectTestCase {
   public void failMapContainsKeyWithValue() {
     AtomicLongMap<String> actual = AtomicLongMap.create();
     actual.getAndIncrement("kurt");
-    expectFailure.whenTesting().that(actual).containsEntry("kurt", 2);
+    expectFailureWhenTestingThat(actual).containsEntry("kurt", 2);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{kurt=1}> contains entry <kurt=2>");
+  }
+
+  private AtomicLongMapSubject expectFailureWhenTestingThat(AtomicLongMap<?> actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/BigDecimalSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/BigDecimalSubjectTest.java
@@ -47,7 +47,7 @@ public class BigDecimalSubjectTest extends BaseSubjectTestCase {
   public void isEqualToIgnoringScale_bigDecimal() {
     assertThat(TEN).isEqualToIgnoringScale(TEN);
     assertThat(TEN).isEqualToIgnoringScale(new BigDecimal(10));
-    expectFailure.whenTesting().that(TEN).isEqualToIgnoringScale(new BigDecimal(3));
+    expectFailureWhenTestingThat(TEN).isEqualToIgnoringScale(new BigDecimal(3));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("<10> should have had the same value as <3> (scale is ignored)");
@@ -56,7 +56,7 @@ public class BigDecimalSubjectTest extends BaseSubjectTestCase {
   @Test
   public void isEqualToIgnoringScale_int() {
     assertThat(TEN).isEqualToIgnoringScale(10);
-    expectFailure.whenTesting().that(TEN).isEqualToIgnoringScale(3);
+    expectFailureWhenTestingThat(TEN).isEqualToIgnoringScale(3);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("<10> should have had the same value as <3> (scale is ignored)");
@@ -65,7 +65,7 @@ public class BigDecimalSubjectTest extends BaseSubjectTestCase {
   @Test
   public void isEqualToIgnoringScale_long() {
     assertThat(TEN).isEqualToIgnoringScale(10L);
-    expectFailure.whenTesting().that(TEN).isEqualToIgnoringScale(3L);
+    expectFailureWhenTestingThat(TEN).isEqualToIgnoringScale(3L);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("<10> should have had the same value as <3> (scale is ignored)");
@@ -77,9 +77,13 @@ public class BigDecimalSubjectTest extends BaseSubjectTestCase {
     assertThat(TEN).isEqualToIgnoringScale("10.");
     assertThat(TEN).isEqualToIgnoringScale("10.0");
     assertThat(TEN).isEqualToIgnoringScale("10.00");
-    expectFailure.whenTesting().that(TEN).isEqualToIgnoringScale("3");
+    expectFailureWhenTestingThat(TEN).isEqualToIgnoringScale("3");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("<10> should have had the same value as <3> (scale is ignored)");
+  }
+
+  private BigDecimalSubject expectFailureWhenTestingThat(BigDecimal actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/BooleanSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/BooleanSubjectTest.java
@@ -36,8 +36,7 @@ public class BooleanSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void nullIsTrueFailing() {
-    Boolean nullBoolean = null;
-    expectFailure.whenTesting().that(nullBoolean).isTrue();
+    expectFailureWhenTestingThat(null).isTrue();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("The subject was expected to be true, but was null");
@@ -45,8 +44,7 @@ public class BooleanSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void nullIsFalseFailing() {
-    Boolean nullBoolean = null;
-    expectFailure.whenTesting().that(nullBoolean).isFalse();
+    expectFailureWhenTestingThat(null).isFalse();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("The subject was expected to be false, but was null");
@@ -54,7 +52,7 @@ public class BooleanSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isTrueFailing() {
-    expectFailure.whenTesting().that(false).isTrue();
+    expectFailureWhenTestingThat(false).isTrue();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("The subject was expected to be true, but was false");
@@ -67,9 +65,13 @@ public class BooleanSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isFalseFailing() {
-    expectFailure.whenTesting().that(true).isFalse();
+    expectFailureWhenTestingThat(true).isFalse();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("The subject was expected to be false, but was true");
+  }
+
+  private BooleanSubject expectFailureWhenTestingThat(Boolean actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/ClassSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/ClassSubjectTest.java
@@ -44,7 +44,7 @@ public class ClassSubjectTest {
 
   @Test
   public void testIsAssignableTo_reversed() {
-    expectFailure.whenTesting().that(Object.class).isAssignableTo(String.class);
+    expectFailureWhenTestingThat(Object.class).isAssignableTo(String.class);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -54,11 +54,15 @@ public class ClassSubjectTest {
 
   @Test
   public void testIsAssignableTo_reversedDifferentTypes() {
-    expectFailure.whenTesting().that(String.class).isAssignableTo(Exception.class);
+    expectFailureWhenTestingThat(String.class).isAssignableTo(Exception.class);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
             "Not true that <class java.lang.String> "
                 + "is assignable to <class java.lang.Exception>");
+  }
+
+  private ClassSubject expectFailureWhenTestingThat(Class<?> actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/DoubleSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/DoubleSubjectTest.java
@@ -74,7 +74,7 @@ public class DoubleSubjectTest extends BaseSubjectTestCase {
     // "although their toString() representations are the same"
     assertThatIsEqualToFails(-0.0, 0.0);
     // Under GWT, 1.23f.toString() is different than 1.23d.toString(), so the message omits types.
-    expectFailure.whenTesting().that(1.23).isEqualTo(1.23f);
+    expectFailureWhenTestingThat(1.23).isEqualTo(1.23f);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -558,5 +558,9 @@ public class DoubleSubjectTest extends BaseSubjectTestCase {
           }
         };
     expectFailureWithMessage(callback, "testValue (<" + value + ">) should not have been NaN");
+  }
+
+  private DoubleSubject expectFailureWhenTestingThat(Double actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/FloatSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/FloatSubjectTest.java
@@ -74,7 +74,7 @@ public class FloatSubjectTest extends BaseSubjectTestCase {
     // "although their toString() representations are the same"
     assertThatIsEqualToFails(-0.0f, 0.0f);
     // Under GWT, 1.23f.toString() is different than 1.23d.toString(), so the message omits types.
-    expectFailure.whenTesting().that(1.23f).isEqualTo(1.23);
+    expectFailureWhenTestingThat(1.23f).isEqualTo(1.23);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -558,5 +558,9 @@ public class FloatSubjectTest extends BaseSubjectTestCase {
           }
         };
     expectFailureWithMessage(callback, "testValue (<" + value + ">) should not have been NaN");
+  }
+
+  private FloatSubject expectFailureWhenTestingThat(Float actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/GuavaOptionalSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/GuavaOptionalSubjectTest.java
@@ -38,7 +38,7 @@ public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isPresentFailing() {
-    expectFailure.whenTesting().that(Optional.absent()).isPresent();
+    expectFailureWhenTestingThat(Optional.absent()).isPresent();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that the subject is present");
@@ -46,7 +46,7 @@ public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isPresentFailing_named() {
-    expectFailure.whenTesting().that(Optional.absent()).named("name").isPresent();
+    expectFailureWhenTestingThat(Optional.absent()).named("name").isPresent();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that \"name\" is present");
@@ -54,7 +54,7 @@ public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isPresentFailingNull() {
-    expectFailure.whenTesting().that((Optional<?>) null).isPresent();
+    expectFailureWhenTestingThat(null).isPresent();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that the subject is present");
@@ -67,7 +67,7 @@ public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isAbsentFailing() {
-    expectFailure.whenTesting().that(Optional.of("foo")).isAbsent();
+    expectFailureWhenTestingThat(Optional.of("foo")).isAbsent();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <Optional.of(foo)> is absent");
@@ -75,8 +75,7 @@ public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isAbsentFailingNull() {
-    Optional<String> nullOptional = null;
-    expectFailure.whenTesting().that(nullOptional).isAbsent();
+    expectFailureWhenTestingThat(null).isAbsent();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <null> is absent");
@@ -89,7 +88,7 @@ public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValue_failingWithAbsent() {
-    expectFailure.whenTesting().that(Optional.absent()).hasValue("foo");
+    expectFailureWhenTestingThat(Optional.absent()).hasValue("foo");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <Optional.absent()> has value <foo>");
@@ -108,7 +107,7 @@ public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValue_failingWithWrongValueForString() {
-    expectFailure.whenTesting().that(Optional.of("foo")).hasValue("boo");
+    expectFailureWhenTestingThat(Optional.of("foo")).hasValue("boo");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <Optional.of(foo)> has value <boo>");
@@ -116,7 +115,7 @@ public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValue_failingWithWrongValueForString_named() {
-    expectFailure.whenTesting().that(Optional.of("foo")).named("bar").hasValue("boo");
+    expectFailureWhenTestingThat(Optional.of("foo")).named("bar").hasValue("boo");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that bar (<Optional.of(foo)>) has value <boo>");
@@ -124,7 +123,7 @@ public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValue_failingWithWrongValueForOther() {
-    expectFailure.whenTesting().that(Optional.of(5)).hasValue(10);
+    expectFailureWhenTestingThat(Optional.of(5)).hasValue(10);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <Optional.of(5)> has value <10>");
@@ -132,7 +131,7 @@ public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValue_failingWithSameToStrings() {
-    expectFailure.whenTesting().that(Optional.of(10)).hasValue("10");
+    expectFailureWhenTestingThat(Optional.of(10)).hasValue("10");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -142,11 +141,15 @@ public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValue_failingWithSameToStrings_named() {
-    expectFailure.whenTesting().that(Optional.of(10)).named("bar").hasValue("10");
+    expectFailureWhenTestingThat(Optional.of(10)).named("bar").hasValue("10");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
             "Not true that bar (<Optional.of(10)>) (class java.lang.Integer) "
                 + "has value <10> (class java.lang.String)");
+  }
+
+  private GuavaOptionalSubject expectFailureWhenTestingThat(Optional<?> optional) {
+    return expectFailure.whenTesting().that(optional);
   }
 }

--- a/core/src/test/java/com/google/common/truth/GuavaOptionalSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/GuavaOptionalSubjectTest.java
@@ -95,14 +95,13 @@ public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
-  public void hasValue_errorWithNullParameter() {
+  public void hasValue_npeWithNullParameter() {
     try {
       assertThat(Optional.of("foo")).hasValue(null);
+      fail("Expected NPE");
     } catch (NullPointerException expected) {
       assertThat(expected).hasMessageThat().contains("Optional");
-      return;
     }
-    fail("Should have thrown");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/GuavaOptionalSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/GuavaOptionalSubjectTest.java
@@ -149,7 +149,7 @@ public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
                 + "has value <10> (class java.lang.String)");
   }
 
-  private GuavaOptionalSubject expectFailureWhenTestingThat(Optional<?> optional) {
-    return expectFailure.whenTesting().that(optional);
+  private GuavaOptionalSubject expectFailureWhenTestingThat(Optional<?> actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/GuavaOptionalSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/GuavaOptionalSubjectTest.java
@@ -32,16 +32,6 @@ import org.junit.runners.JUnit4;
 public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
 
   @Test
-  public void namedOptional() {
-    Optional<String> optional = Optional.of("actual");
-
-    expectFailure.whenTesting().that(optional).named("name").hasValue("expected");
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that name (<Optional.of(actual)>) has value <expected>");
-  }
-
-  @Test
   public void isPresent() {
     assertThat(Optional.of("foo")).isPresent();
   }
@@ -55,7 +45,7 @@ public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
-  public void isPresentFailingWithNamed() {
+  public void isPresentFailing_named() {
     expectFailure.whenTesting().that(Optional.absent()).named("name").isPresent();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -98,7 +88,7 @@ public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
-  public void hasValue_FailingWithAbsent() {
+  public void hasValue_failingWithAbsent() {
     expectFailure.whenTesting().that(Optional.absent()).hasValue("foo");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -106,7 +96,7 @@ public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
-  public void hasValue_ErrorWithNullParameter() {
+  public void hasValue_errorWithNullParameter() {
     try {
       assertThat(Optional.of("foo")).hasValue(null);
     } catch (NullPointerException expected) {
@@ -117,7 +107,7 @@ public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
-  public void hasValue_FailingWithWrongValueForString() {
+  public void hasValue_failingWithWrongValueForString() {
     expectFailure.whenTesting().that(Optional.of("foo")).hasValue("boo");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -125,7 +115,15 @@ public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
-  public void hasValue_FailingWithWrongValueForOther() {
+  public void hasValue_failingWithWrongValueForString_named() {
+    expectFailure.whenTesting().that(Optional.of("foo")).named("bar").hasValue("boo");
+    assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .isEqualTo("Not true that bar (<Optional.of(foo)>) has value <boo>");
+  }
+
+  @Test
+  public void hasValue_failingWithWrongValueForOther() {
     expectFailure.whenTesting().that(Optional.of(5)).hasValue(10);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -133,7 +131,7 @@ public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
-  public void hasValue_FailingWithSameToStrings() {
+  public void hasValue_failingWithSameToStrings() {
     expectFailure.whenTesting().that(Optional.of(10)).hasValue("10");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -143,15 +141,7 @@ public class GuavaOptionalSubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
-  public void hasValue_Named_Failing() {
-    expectFailure.whenTesting().that(Optional.of("foo")).named("bar").hasValue("boo");
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that bar (<Optional.of(foo)>) has value <boo>");
-  }
-
-  @Test
-  public void hasValue_Named_FailingWithSameToStrings() {
+  public void hasValue_failingWithSameToStrings_named() {
     expectFailure.whenTesting().that(Optional.of(10)).named("bar").hasValue("10");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()

--- a/core/src/test/java/com/google/common/truth/IntegerSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/IntegerSubjectTest.java
@@ -16,10 +16,8 @@
 package com.google.common.truth;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableSet;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -36,219 +34,72 @@ public class IntegerSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void simpleEquality() {
-    assertThat(2 + 2).isEqualTo(4);
+    assertThat(4).isEqualTo(4);
+  }
+
+  @Test
+  public void simpleInequality() {
+    assertThat(4).isNotEqualTo(5);
   }
 
   @Test
   public void equalityWithLongs() {
-    int x = 0;
-    assertThat(x).isEqualTo(0L);
-    expectFailure.whenTesting().that(x).isNotEqualTo(0L);
+    assertThat(0).isEqualTo(0L);
+    expectFailureWhenTestingThat(0).isNotEqualTo(0L);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <0> is not equal to <0>");
   }
 
   @Test
-  public void intIsInt() {
-    assertThat(4).isEqualTo(4);
-  }
-
-  @Test
-  public void simpleInequality() {
-    assertThat(2 + 2).isNotEqualTo(5);
-  }
-
-  @Test
   public void equalityFail() {
-    expectFailure.whenTesting().that(2 + 2).isEqualTo(5);
+    expectFailureWhenTestingThat(4).isEqualTo(5);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .contains("Not true that <4> is equal to <5>");
+        .isEqualTo("Not true that <4> is equal to <5>");
   }
 
   @Test
   public void inequalityFail() {
-    expectFailure.whenTesting().that(2 + 2).isNotEqualTo(4);
+    expectFailureWhenTestingThat(4).isNotEqualTo(4);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .contains("Not true that <4> is not equal to <4>");
+        .isEqualTo("Not true that <4> is not equal to <4>");
   }
 
   @Test
-  public void assertThatIntegerNullIsEqualToNull() {
-    assertThat((Integer) null).isEqualTo((Integer) null);
-    assertThat((Integer) null).isEqualTo((Long) null);
-    assertThat((Integer) null).isEqualTo((Object) null);
+  public void equalityOfNulls() {
+    assertThat((Integer) null).isEqualTo(null);
   }
 
   @Test
-  public void assertThatLongNullIsEqualToNull() {
-    assertThat((Long) null).isEqualTo((Integer) null);
-    assertThat((Long) null).isEqualTo((Long) null);
-    assertThat((Long) null).isEqualTo((Object) null);
-  }
-
-  @Test
-  public void equalityOfNullsFail_actualNull() {
-    expectFailure.whenTesting().that((Long) null).isEqualTo(5);
+  public void equalityOfNullsFail_nullActual() {
+    expectFailureWhenTestingThat(null).isEqualTo(5);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .contains("Not true that <null> is equal to <5>");
+        .isEqualTo("Not true that <null> is equal to <5>");
   }
 
   @Test
-  public void equalityOfNullsFail_expectNull() {
-    expectFailure.whenTesting().that(5).isEqualTo((Integer) null);
+  public void equalityOfNullsFail_nullExpected() {
+    expectFailureWhenTestingThat(5).isEqualTo(null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .contains("Not true that <5> is equal to <null>");
+        .isEqualTo("Not true that <5> is equal to <null>");
   }
 
   @Test
-  public void assertThatIntegerIsNotEqualToNull() {
-    assertThat(4).isNotEqualTo((Long) null);
-    assertThat(4).isNotEqualTo((Integer) null);
-    assertThat(4).isNotEqualTo((Object) null);
-  }
-
-  @Test
-  public void assertThatLongIsNotEqualToNull() {
-    assertThat(4L).isNotEqualTo((Long) null);
-    assertThat(4L).isNotEqualTo((Integer) null);
-    assertThat(4L).isNotEqualTo((Object) null);
-  }
-
-  @Test
-  public void assertThatLongNullIsNotEqualTo() {
-    assertThat((Long) null).isNotEqualTo(4);
-    assertThat((Long) null).isNotEqualTo(4L);
-  }
-
-  @Test
-  public void assertThatIntegerNullIsNotEqualTo() {
+  public void inequalityOfNulls() {
+    assertThat(4).isNotEqualTo(null);
     assertThat((Integer) null).isNotEqualTo(4);
-    assertThat((Integer) null).isNotEqualTo(4L);
   }
 
   @Test
-  public void assertThatIntegerIsEqualToLong() {
-    assertThat(4).isEqualTo(new Long(4L));
-    assertThat(new Integer(4)).isEqualTo(new Long(4L));
-    assertThat(new Integer(4)).isEqualTo(4L);
-  }
-
-  @Test
-  public void assertThatLongIsEqualToInteger() {
-    assertThat(4L).isEqualTo(new Integer(4));
-    assertThat(new Long(4L)).isEqualTo(new Integer(4));
-    assertThat(new Long(4L)).isEqualTo(4);
-  }
-
-  @Test
-  public void assertThatIntegerNullIsNotEqualToIntegerNull_shouldFail() {
-    expectFailure.whenTesting().that((Integer) null).isNotEqualTo((Integer) null);
+  public void inequalityOfNullsFail() {
+    expectFailureWhenTestingThat(null).isNotEqualTo(null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <null> is not equal to <null>");
-  }
-
-  @Test
-  public void assertThatIntegerNullIsNotEqualToLongNull_shouldFail() {
-    expectFailure.whenTesting().that((Integer) null).isNotEqualTo((Long) null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <null> is not equal to <null>");
-  }
-
-  @Test
-  public void assertThatIntegerNullIsNotEqualToObjectNull_shouldFail() {
-    expectFailure.whenTesting().that((Integer) null).isNotEqualTo((Object) null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <null> is not equal to <null>");
-  }
-
-  @Test
-  public void assertThatLongNullIsNotEqualToIntegerNull_shouldFail() {
-    expectFailure.whenTesting().that((Long) null).isNotEqualTo((Integer) null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .contains("Not true that <null> is not equal to <null>");
-  }
-
-  @Test
-  public void assertThatLongNullIsNotEqualToLongNull_shouldFail() {
-    expectFailure.whenTesting().that((Long) null).isNotEqualTo((Long) null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <null> is not equal to <null>");
-  }
-
-  @Test
-  public void assertThatLongNullIsNotEqualToObjectNull_shouldFail() {
-    expectFailure.whenTesting().that((Long) null).isNotEqualTo((Object) null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <null> is not equal to <null>");
-  }
-
-  @Test
-  public void primitives() {
-    Assert.assertEquals(4, 4L);
-    Assert.assertEquals(4L, 4);
-    assertThat(4L).isEqualTo(4);
-    assertThat(new Long(4L)).isEqualTo(4);
-  }
-
-  @SuppressWarnings("EqualsIncompatibleType")
-  @Test
-  public void boxedPrimitives() {
-    // Java says boxed primitives are not .equals().
-    // Check the boolean expression with JUnit and Truth:
-    Assert.assertFalse(new Integer(4).equals(new Long(4L)));
-    Assert.assertFalse(new Long(4L).equals(new Integer(4)));
-    assertThat(new Integer(4).equals(new Long(4L))).isFalse();
-    assertThat(new Long(4L).equals(new Integer(4))).isFalse();
-
-    // JUnit says boxed primitives are not .equals()
-    try {
-      Assert.assertEquals(new Integer(4), new Long(4L)); // this throws!
-      fail("Should have thrown");
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("expected: java.lang.Integer<4> but was: java.lang.Long<4>");
-    }
-    try {
-      Assert.assertEquals(new Long(4L), new Integer(4)); // this throws!
-      fail("Should have thrown");
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("expected: java.lang.Long<4> but was: java.lang.Integer<4>");
-    }
-  }
-
-  @SuppressWarnings("EqualsIncompatibleType")
-  @Test
-  public void mixedBoxedAndUnboxedPrimitives() {
-    // Java says boxed primitives are not .equals() to primitives.
-    Assert.assertFalse(new Integer(4).equals(4L));
-    Assert.assertFalse(new Integer(4).equals(new Long(4L)));
-    Assert.assertFalse(new Long(4L).equals(4));
-    Assert.assertFalse(new Long(4L).equals(new Integer(4)));
-    assertThat(new Integer(4).equals(4L)).isFalse();
-    assertThat(new Long(4L).equals(4)).isFalse();
-
-    // JUnit won't even let you do this comparison (compile error!)
-    // "reference to assertEquals is ambiguous"
-    // Assert.assertEquals(new Integer(4), 4L);
-    // Assert.assertEquals(4L, new Integer(4));
-    // Assert.assertEquals(new Long(4L), 4);
-    // Assert.assertEquals(4, new Long(4L));
-    // Assert.assertEquals(4, new Integer(4));
-    // Assert.assertEquals(new Long(4L), 4L);
   }
 
   @Test
@@ -265,7 +116,7 @@ public class IntegerSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void overflowOnPrimitives_shouldBeEqualAfterCast_min() {
-    expectFailure.whenTesting().that(Integer.MIN_VALUE).isNotEqualTo((long) Integer.MIN_VALUE);
+    expectFailureWhenTestingThat(Integer.MIN_VALUE).isNotEqualTo((long) Integer.MIN_VALUE);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <-2147483648> is not equal to <-2147483648>");
@@ -273,7 +124,7 @@ public class IntegerSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void overflowOnPrimitives_shouldBeEqualAfterCast_max() {
-    expectFailure.whenTesting().that(Integer.MAX_VALUE).isNotEqualTo((long) Integer.MAX_VALUE);
+    expectFailureWhenTestingThat(Integer.MAX_VALUE).isNotEqualTo((long) Integer.MAX_VALUE);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <2147483647> is not equal to <2147483647>");
@@ -281,7 +132,7 @@ public class IntegerSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void overflowBetweenIntegerAndLong_shouldBeDifferent_min() {
-    expectFailure.whenTesting().that(Integer.MIN_VALUE).isEqualTo(Long.MIN_VALUE);
+    expectFailureWhenTestingThat(Integer.MIN_VALUE).isEqualTo(Long.MIN_VALUE);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <-2147483648> is equal to <-9223372036854775808>");
@@ -289,7 +140,7 @@ public class IntegerSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void overflowBetweenIntegerAndLong_shouldBeDifferent_max() {
-    expectFailure.whenTesting().that(Integer.MAX_VALUE).isEqualTo(Long.MAX_VALUE);
+    expectFailureWhenTestingThat(Integer.MAX_VALUE).isEqualTo(Long.MAX_VALUE);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <2147483647> is equal to <9223372036854775807>");
@@ -358,63 +209,7 @@ public class IntegerSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void testNumericTypeWithSameValue_shouldBeEqual_int_long() {
-    expectFailure.whenTesting().that(42).isNotEqualTo(42L);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <42> is not equal to <42>");
-  }
-
-  @Test
-  public void testNumericTypeWithSameValue_shouldBeEqual_int_Long() {
-    expectFailure.whenTesting().that(42).isNotEqualTo(new Long(42L));
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <42> is not equal to <42>");
-  }
-
-  @Test
-  public void testNumericTypeWithSameValue_shouldBeEqual_Integer_long() {
-    expectFailure.whenTesting().that(new Integer(42)).isNotEqualTo(42L);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <42> is not equal to <42>");
-  }
-
-  @Test
-  public void testNumericTypeWithSameValue_shouldBeEqual_Integer_Long() {
-    expectFailure.whenTesting().that(new Integer(42)).isNotEqualTo(new Long(42L));
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <42> is not equal to <42>");
-  }
-
-  @Test
-  public void testNumericTypeWithSameValue_shouldBeEqual_long_int() {
-    expectFailure.whenTesting().that(42L).isNotEqualTo(42);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <42> is not equal to <42>");
-  }
-
-  @Test
-  public void testNumericTypeWithSameValue_shouldBeEqual_long_Integer() {
-    expectFailure.whenTesting().that(42L).isNotEqualTo(new Integer(42));
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <42> is not equal to <42>");
-  }
-
-  @Test
-  public void testNumericTypeWithSameValue_shouldBeEqual_Long_int() {
-    expectFailure.whenTesting().that(new Long(42L)).isNotEqualTo(42);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <42> is not equal to <42>");
-  }
-
-  @Test
-  public void testNumericTypeWithSameValue_shouldBeEqual_Long_Integer() {
-    expectFailure.whenTesting().that(new Long(42L)).isNotEqualTo(new Integer(42));
+    expectFailureWhenTestingThat(42).isNotEqualTo(42L);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <42> is not equal to <42>");
@@ -422,63 +217,7 @@ public class IntegerSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void testNumericTypeWithSameValue_shouldBeEqual_int_int() {
-    expectFailure.whenTesting().that(42).isNotEqualTo(42);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <42> is not equal to <42>");
-  }
-
-  @Test
-  public void testNumericTypeWithSameValue_shouldBeEqual_int_Integer() {
-    expectFailure.whenTesting().that(42).isNotEqualTo(new Integer(42));
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <42> is not equal to <42>");
-  }
-
-  @Test
-  public void testNumericTypeWithSameValue_shouldBeEqual_Integer_int() {
-    expectFailure.whenTesting().that(new Integer(42)).isNotEqualTo(42);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <42> is not equal to <42>");
-  }
-
-  @Test
-  public void testNumericTypeWithSameValue_shouldBeEqual_Integer_Integer() {
-    expectFailure.whenTesting().that(new Integer(42)).isNotEqualTo(new Integer(42));
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <42> is not equal to <42>");
-  }
-
-  @Test
-  public void testNumericTypeWithSameValue_shouldBeEqual_long_long() {
-    expectFailure.whenTesting().that(42L).isNotEqualTo(42L);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <42> is not equal to <42>");
-  }
-
-  @Test
-  public void testNumericTypeWithSameValue_shouldBeEqual_long_Long() {
-    expectFailure.whenTesting().that(42L).isNotEqualTo(new Long(42L));
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <42> is not equal to <42>");
-  }
-
-  @Test
-  public void testNumericTypeWithSameValue_shouldBeEqual_Long_long() {
-    expectFailure.whenTesting().that(new Long(42L)).isNotEqualTo(42L);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <42> is not equal to <42>");
-  }
-
-  @Test
-  public void testNumericTypeWithSameValue_shouldBeEqual_Long_Long() {
-    expectFailure.whenTesting().that(new Long(42L)).isNotEqualTo(new Long(42L));
+    expectFailureWhenTestingThat(42).isNotEqualTo(42);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <42> is not equal to <42>");
@@ -486,7 +225,7 @@ public class IntegerSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void testNumericPrimitiveTypes_isNotEqual_shouldFail_intToChar() {
-    expectFailure.whenTesting().that(42).isNotEqualTo((char) 42);
+    expectFailureWhenTestingThat(42).isNotEqualTo((char) 42);
     // 42 in ASCII is '*'
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -495,6 +234,7 @@ public class IntegerSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void testNumericPrimitiveTypes_isNotEqual_shouldFail_charToInt() {
+    // Uses Object overload rather than Integer.
     expectFailure.whenTesting().that((char) 42).isNotEqualTo(42);
     // 42 in ASCII is '*'
     assertThat(expectFailure.getFailure())
@@ -571,5 +311,9 @@ public class IntegerSubjectTest extends BaseSubjectTestCase {
         assertThat(expected).isNotEqualTo(actual);
       }
     }
+  }
+
+  private IntegerSubject expectFailureWhenTestingThat(Integer actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/IterableSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/IterableSubjectTest.java
@@ -51,7 +51,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasSizeFails() {
-    expectFailure.whenTesting().that(ImmutableList.of(1, 2, 3)).hasSize(4);
+    expectFailureWhenTestingThat(ImmutableList.of(1, 2, 3)).hasSize(4);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[1, 2, 3]> has a size of <4>. It is <3>");
@@ -78,7 +78,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsFailsWithSameToString() {
-    expectFailure.whenTesting().that(asList(1L, 2L, 3L, 2L)).contains(2);
+    expectFailureWhenTestingThat(asList(1L, 2L, 3L, 2L)).contains(2);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -88,7 +88,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsFailsWithSameToStringAndNull() {
-    expectFailure.whenTesting().that(asList(1, "null")).contains(null);
+    expectFailureWhenTestingThat(asList(1, "null")).contains(null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -98,7 +98,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsFailure() {
-    expectFailure.whenTesting().that(asList(1, 2, 3)).contains(5);
+    expectFailureWhenTestingThat(asList(1, 2, 3)).contains(5);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("<[1, 2, 3]> should have contained <5>");
@@ -106,7 +106,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void namedIterableContainsFailure() {
-    expectFailure.whenTesting().that(asList(1, 2, 3)).named("numbers").contains(5);
+    expectFailureWhenTestingThat(asList(1, 2, 3)).named("numbers").contains(5);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("numbers (<[1, 2, 3]>) should have contained <5>");
@@ -132,7 +132,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableDoesNotContainFailure() {
-    expectFailure.whenTesting().that(asList(1, 2, 3)).doesNotContain(2);
+    expectFailureWhenTestingThat(asList(1, 2, 3)).doesNotContain(2);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("<[1, 2, 3]> should not have contained <2>");
@@ -150,7 +150,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void doesNotContainDuplicatesFailure() {
-    expectFailure.whenTesting().that(asList(1, 2, 2, 3)).containsNoDuplicates();
+    expectFailureWhenTestingThat(asList(1, 2, 2, 3)).containsNoDuplicates();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("<[1, 2, 2, 3]> has the following duplicates: <[2 x 2]>");
@@ -173,7 +173,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAnyOfFailure() {
-    expectFailure.whenTesting().that(asList(1, 2, 3)).containsAnyOf(5, 6, 0);
+    expectFailureWhenTestingThat(asList(1, 2, 3)).containsAnyOf(5, 6, 0);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[1, 2, 3]> contains any of <[5, 6, 0]>");
@@ -181,7 +181,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAnyOfFailsWithSameToStringAndHomogeneousList() {
-    expectFailure.whenTesting().that(asList(1L, 2L, 3L)).containsAnyOf(2, 3);
+    expectFailureWhenTestingThat(asList(1L, 2L, 3L)).containsAnyOf(2, 3);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -191,7 +191,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAnyOfFailsWithSameToStringAndHomogeneousListWithDuplicates() {
-    expectFailure.whenTesting().that(asList(3L, 3L)).containsAnyOf(2, 3, 3);
+    expectFailureWhenTestingThat(asList(3L, 3L)).containsAnyOf(2, 3, 3);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -201,7 +201,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAnyOfFailsWithSameToStringAndNullInSubject() {
-    expectFailure.whenTesting().that(asList(null, "abc")).containsAnyOf("def", "null");
+    expectFailureWhenTestingThat(asList(null, "abc")).containsAnyOf("def", "null");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -211,7 +211,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAnyOfFailsWithSameToStringAndNullInExpectation() {
-    expectFailure.whenTesting().that(asList("null", "abc")).containsAnyOf("def", null);
+    expectFailureWhenTestingThat(asList("null", "abc")).containsAnyOf("def", null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -238,7 +238,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
   public void iterableContainsAnyInIterable() {
     assertThat(asList(1, 2, 3)).containsAnyIn(asList(1, 10, 100));
 
-    expectFailure.whenTesting().that(asList(1, 2, 3)).containsAnyIn(asList(5, 6, 0));
+    expectFailureWhenTestingThat(asList(1, 2, 3)).containsAnyIn(asList(5, 6, 0));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[1, 2, 3]> contains any element in <[5, 6, 0]>");
@@ -248,7 +248,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
   public void iterableContainsAnyInArray() {
     assertThat(asList(1, 2, 3)).containsAnyIn(new Integer[] {1, 10, 100});
 
-    expectFailure.whenTesting().that(asList(1, 2, 3)).containsAnyIn(new Integer[] {5, 6, 0});
+    expectFailureWhenTestingThat(asList(1, 2, 3)).containsAnyIn(new Integer[] {5, 6, 0});
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[1, 2, 3]> contains any element in <[5, 6, 0]>");
@@ -276,7 +276,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAllOfFailure() {
-    expectFailure.whenTesting().that(asList(1, 2, 3)).containsAllOf(1, 2, 4);
+    expectFailureWhenTestingThat(asList(1, 2, 3)).containsAllOf(1, 2, 4);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[1, 2, 3]> contains all of <[1, 2, 4]>. It is missing <[4]>");
@@ -284,7 +284,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAllOfWithExtras() {
-    expectFailure.whenTesting().that(asList("y", "x")).containsAllOf("x", "y", "z");
+    expectFailureWhenTestingThat(asList("y", "x")).containsAllOf("x", "y", "z");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[y, x]> contains all of <[x, y, z]>. It is missing <[z]>");
@@ -292,7 +292,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAllOfWithExtraCopiesOfOutOfOrder() {
-    expectFailure.whenTesting().that(asList("y", "x")).containsAllOf("x", "y", "y");
+    expectFailureWhenTestingThat(asList("y", "x")).containsAllOf("x", "y", "y");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[y, x]> contains all of <[x, y, y]>. It is missing <[y]>");
@@ -300,7 +300,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAllOfWithDuplicatesFailure() {
-    expectFailure.whenTesting().that(asList(1, 2, 3)).containsAllOf(1, 2, 2, 2, 3, 4);
+    expectFailureWhenTestingThat(asList(1, 2, 3)).containsAllOf(1, 2, 2, 2, 3, 4);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -314,7 +314,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
    */
   @Test
   public void iterableContainsAllOfWithDuplicateMissingElements() {
-    expectFailure.whenTesting().that(asList(1, 2)).containsAllOf(4, 4, 4);
+    expectFailureWhenTestingThat(asList(1, 2)).containsAllOf(4, 4, 4);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -323,7 +323,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAllOfWithNullFailure() {
-    expectFailure.whenTesting().that(asList(1, null, 3)).containsAllOf(1, null, null, 3);
+    expectFailureWhenTestingThat(asList(1, null, 3)).containsAllOf(1, null, null, 3);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -333,7 +333,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAllOfFailsWithSameToStringAndHomogeneousList() {
-    expectFailure.whenTesting().that(asList(1L, 2L)).containsAllOf(1, 2);
+    expectFailureWhenTestingThat(asList(1L, 2L)).containsAllOf(1, 2);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -344,7 +344,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAllOfFailsWithSameToStringAndHomogeneousListWithDuplicates() {
-    expectFailure.whenTesting().that(asList(1L, 2L, 2L)).containsAllOf(1, 1, 2);
+    expectFailureWhenTestingThat(asList(1L, 2L, 2L)).containsAllOf(1, 1, 2);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -355,7 +355,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAllOfFailsWithSameToStringAndHomogeneousListWithNull() {
-    expectFailure.whenTesting().that(asList("null", "abc")).containsAllOf("abc", null);
+    expectFailureWhenTestingThat(asList("null", "abc")).containsAllOf("abc", null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -365,7 +365,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAllOfFailsWithSameToStringAndHeterogeneousListWithDuplicates() {
-    expectFailure.whenTesting().that(asList(1, 2, 2L, 3L, 3L)).containsAllOf(2L, 2L, 3, 3);
+    expectFailureWhenTestingThat(asList(1, 2, 2L, 3L, 3L)).containsAllOf(2L, 2L, 3, 3);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -376,7 +376,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAllOfFailsWithEmptyString() {
-    expectFailure.whenTesting().that(asList("a", null)).containsAllOf("", null);
+    expectFailureWhenTestingThat(asList("a", null)).containsAllOf("", null);
 
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -409,7 +409,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAllOfInOrderWithFailure() {
-    expectFailure.whenTesting().that(asList(1, null, 3)).containsAllOf(null, 1, 3).inOrder();
+    expectFailureWhenTestingThat(asList(1, null, 3)).containsAllOf(null, 1, 3).inOrder();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[1, null, 3]> contains all elements in order <[null, 1, 3]>");
@@ -451,7 +451,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
           }
         };
 
-    expectFailure.whenTesting().that(iterable).containsAllOf(1, 3, (Object) null).inOrder();
+    expectFailureWhenTestingThat(iterable).containsAllOf(1, 3, (Object) null).inOrder();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <BadIterable> contains all elements in order <[1, 3, null]>");
@@ -461,7 +461,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
   public void iterableContainsAllInIterable() {
     assertThat(asList(1, 2, 3)).containsAllIn(asList(1, 2));
 
-    expectFailure.whenTesting().that(asList(1, 2, 3)).containsAllIn(asList(1, 2, 4));
+    expectFailureWhenTestingThat(asList(1, 2, 3)).containsAllIn(asList(1, 2, 4));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -472,7 +472,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
   public void iterableContainsAllInArray() {
     assertThat(asList(1, 2, 3)).containsAllIn(new Integer[] {1, 2});
 
-    expectFailure.whenTesting().that(asList(1, 2, 3)).containsAllIn(new Integer[] {1, 2, 4});
+    expectFailureWhenTestingThat(asList(1, 2, 3)).containsAllIn(new Integer[] {1, 2, 4});
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -486,7 +486,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsNoneOfFailure() {
-    expectFailure.whenTesting().that(asList(1, 2, 3)).containsNoneOf(1, 2, 4);
+    expectFailureWhenTestingThat(asList(1, 2, 3)).containsNoneOf(1, 2, 4);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[1, 2, 3]> contains none of <[1, 2, 4]>. It contains <[1, 2]>");
@@ -494,7 +494,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsNoneOfFailureWithDuplicateInSubject() {
-    expectFailure.whenTesting().that(asList(1, 2, 2, 3)).containsNoneOf(1, 2, 4);
+    expectFailureWhenTestingThat(asList(1, 2, 2, 3)).containsNoneOf(1, 2, 4);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -503,7 +503,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsNoneOfFailureWithDuplicateInExpected() {
-    expectFailure.whenTesting().that(asList(1, 2, 3)).containsNoneOf(1, 2, 2, 4);
+    expectFailureWhenTestingThat(asList(1, 2, 3)).containsNoneOf(1, 2, 2, 4);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -512,7 +512,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsNoneOfFailureWithEmptyString() {
-    expectFailure.whenTesting().that(asList("")).containsNoneOf("", null);
+    expectFailureWhenTestingThat(asList("")).containsNoneOf("", null);
 
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -524,7 +524,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void iterableContainsNoneInIterable() {
     assertThat(asList(1, 2, 3)).containsNoneIn(asList(4, 5, 6));
-    expectFailure.whenTesting().that(asList(1, 2, 3)).containsNoneIn(asList(1, 2, 4));
+    expectFailureWhenTestingThat(asList(1, 2, 3)).containsNoneIn(asList(1, 2, 4));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -534,7 +534,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void iterableContainsNoneInArray() {
     assertThat(asList(1, 2, 3)).containsNoneIn(new Integer[] {4, 5, 6});
-    expectFailure.whenTesting().that(asList(1, 2, 3)).containsNoneIn(new Integer[] {1, 2, 4});
+    expectFailureWhenTestingThat(asList(1, 2, 3)).containsNoneIn(new Integer[] {1, 2, 4});
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -611,7 +611,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsExactlyWithEmptyString() {
-    expectFailure.whenTesting().that(asList()).containsExactly("");
+    expectFailureWhenTestingThat(asList()).containsExactly("");
 
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -622,7 +622,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsExactlyWithEmptyStringAndUnexpectedItem() {
-    expectFailure.whenTesting().that(asList("a", null)).containsExactly("");
+    expectFailureWhenTestingThat(asList("a", null)).containsExactly("");
 
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -633,7 +633,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsExactlyWithEmptyStringAndMissingItem() {
-    expectFailure.whenTesting().that(asList("")).containsExactly("a", null);
+    expectFailureWhenTestingThat(asList("")).containsExactly("a", null);
 
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -652,7 +652,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
     assertThat(asList(one, two)).containsExactlyElementsIn(asList(two, one));
     assertThat(asList(one, two)).containsExactlyElementsIn(asList(one, two)).inOrder();
 
-    expectFailure.whenTesting().that(asList(one, two)).containsExactly(one);
+    expectFailureWhenTestingThat(asList(one, two)).containsExactly(one);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -684,7 +684,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsExactlyElementsInWithEmptyExpected() {
-    expectFailure.whenTesting().that(asList("foo")).containsExactlyElementsIn(ImmutableList.of());
+    expectFailureWhenTestingThat(asList("foo")).containsExactlyElementsIn(ImmutableList.of());
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[foo]> is empty");
@@ -692,9 +692,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsExactlyElementsInErrorMessageIsOrdered() {
-    expectFailure
-        .whenTesting()
-        .that(asList("foo OR bar"))
+    expectFailureWhenTestingThat(asList("foo OR bar"))
         .containsExactlyElementsIn(asList("foo", "bar"));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -705,7 +703,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsExactlyMissingItemFailure() {
-    expectFailure.whenTesting().that(asList(1, 2)).containsExactly(1, 2, 4);
+    expectFailureWhenTestingThat(asList(1, 2)).containsExactly(1, 2, 4);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[1, 2]> contains exactly <[1, 2, 4]>. It is missing <[4]>");
@@ -713,7 +711,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsExactlyUnexpectedItemFailure() {
-    expectFailure.whenTesting().that(asList(1, 2, 3)).containsExactly(1, 2);
+    expectFailureWhenTestingThat(asList(1, 2, 3)).containsExactly(1, 2);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -722,7 +720,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsExactlyWithDuplicatesNotEnoughItemsFailure() {
-    expectFailure.whenTesting().that(asList(1, 2, 3)).containsExactly(1, 2, 2, 2, 3);
+    expectFailureWhenTestingThat(asList(1, 2, 3)).containsExactly(1, 2, 2, 2, 3);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -732,7 +730,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsExactlyWithDuplicatesMissingItemFailure() {
-    expectFailure.whenTesting().that(asList(1, 2, 3)).containsExactly(1, 2, 2, 2, 3, 4);
+    expectFailureWhenTestingThat(asList(1, 2, 3)).containsExactly(1, 2, 2, 2, 3, 4);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -742,7 +740,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsExactlyWithDuplicatesUnexpectedItemFailure() {
-    expectFailure.whenTesting().that(asList(1, 2, 2, 2, 2, 3)).containsExactly(1, 2, 2, 3);
+    expectFailureWhenTestingThat(asList(1, 2, 2, 2, 2, 3)).containsExactly(1, 2, 2, 3);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -756,7 +754,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
    */
   @Test
   public void iterableContainsExactlyWithDuplicateMissingElements() {
-    expectFailure.whenTesting().that(asList()).containsExactly(4, 4, 4);
+    expectFailureWhenTestingThat(asList()).containsExactly(4, 4, 4);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -765,7 +763,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsExactlyWithNullFailure() {
-    expectFailure.whenTesting().that(asList(1, null, 3)).containsExactly(1, null, null, 3);
+    expectFailureWhenTestingThat(asList(1, null, 3)).containsExactly(1, null, null, 3);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -775,7 +773,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsExactlyWithMissingAndExtraElements() {
-    expectFailure.whenTesting().that(asList(1, 2, 3)).containsExactly(1, 2, 4);
+    expectFailureWhenTestingThat(asList(1, 2, 3)).containsExactly(1, 2, 4);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -785,7 +783,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsExactlyWithDuplicateMissingAndExtraElements() {
-    expectFailure.whenTesting().that(asList(1, 2, 3, 3)).containsExactly(1, 2, 4, 4);
+    expectFailureWhenTestingThat(asList(1, 2, 3, 3)).containsExactly(1, 2, 4, 4);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -795,7 +793,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsExactlyFailsWithSameToStringAndHomogeneousList() {
-    expectFailure.whenTesting().that(asList(1L, 2L)).containsExactly(1, 2);
+    expectFailureWhenTestingThat(asList(1L, 2L)).containsExactly(1, 2);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -806,7 +804,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsExactlyFailsWithSameToStringAndListWithNull() {
-    expectFailure.whenTesting().that(asList(1L, 2L)).containsExactly(null, 1, 2);
+    expectFailureWhenTestingThat(asList(1L, 2L)).containsExactly(null, 1, 2);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -817,7 +815,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsExactlyFailsWithSameToStringAndHeterogeneousList() {
-    expectFailure.whenTesting().that(asList(1L, 2)).containsExactly(1, null, 2L);
+    expectFailureWhenTestingThat(asList(1L, 2)).containsExactly(1, null, 2L);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -828,7 +826,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsExactlyFailsWithSameToStringAndHomogeneousListWithDuplicates() {
-    expectFailure.whenTesting().that(asList(1L, 2L)).containsExactly(1, 2, 2);
+    expectFailureWhenTestingThat(asList(1L, 2L)).containsExactly(1, 2, 2);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -839,7 +837,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsExactlyFailsWithSameToStringAndHeterogeneousListWithDuplicates() {
-    expectFailure.whenTesting().that(asList(1L, 2)).containsExactly(1, null, null, 2L, 2L);
+    expectFailureWhenTestingThat(asList(1L, 2)).containsExactly(1, null, null, 2L, 2L);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -851,7 +849,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsExactlyWithOneIterableGivesWarning() {
-    expectFailure.whenTesting().that(asList(1, 2, 3, 4)).containsExactly(asList(1, 2, 3, 4));
+    expectFailureWhenTestingThat(asList(1, 2, 3, 4)).containsExactly(asList(1, 2, 3, 4));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -864,7 +862,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsExactlyElementsInWithOneIterableDoesNotGiveWarning() {
-    expectFailure.whenTesting().that(asList(1, 2, 3, 4)).containsExactlyElementsIn(asList(1, 2, 3));
+    expectFailureWhenTestingThat(asList(1, 2, 3, 4)).containsExactlyElementsIn(asList(1, 2, 3));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -874,10 +872,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsExactlyWithTwoIterableDoesNotGivesWarning() {
-    expectFailure
-        .whenTesting()
-        .that(asList(1, 2, 3, 4))
-        .containsExactly(asList(1, 2), asList(3, 4));
+    expectFailureWhenTestingThat(asList(1, 2, 3, 4)).containsExactly(asList(1, 2), asList(3, 4));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -887,7 +882,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsExactlyWithOneNonIterableDoesNotGiveWarning() {
-    expectFailure.whenTesting().that(asList(1, 2, 3, 4)).containsExactly(1);
+    expectFailureWhenTestingThat(asList(1, 2, 3, 4)).containsExactly(1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -907,7 +902,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsExactlyInOrderWithFailure() {
-    expectFailure.whenTesting().that(asList(1, null, 3)).containsExactly(null, 1, 3).inOrder();
+    expectFailureWhenTestingThat(asList(1, null, 3)).containsExactly(null, 1, 3).inOrder();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -944,7 +939,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
           }
         };
 
-    expectFailure.whenTesting().that(iterable).containsExactly(1, 3, null).inOrder();
+    expectFailureWhenTestingThat(iterable).containsExactly(1, 3, null).inOrder();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -962,7 +957,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
           }
         };
 
-    expectFailure.whenTesting().that(iterable).containsExactly(1, 2).inOrder();
+    expectFailureWhenTestingThat(iterable).containsExactly(1, 2).inOrder();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -973,7 +968,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
   public void iterableContainsExactlyElementsInIterable() {
     assertThat(asList(1, 2)).containsExactlyElementsIn(asList(1, 2));
 
-    expectFailure.whenTesting().that(asList(1, 2)).containsExactlyElementsIn(asList(1, 2, 4));
+    expectFailureWhenTestingThat(asList(1, 2)).containsExactlyElementsIn(asList(1, 2, 4));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[1, 2]> contains exactly <[1, 2, 4]>. It is missing <[4]>");
@@ -983,10 +978,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
   public void iterableContainsExactlyElementsInArray() {
     assertThat(asList(1, 2)).containsExactlyElementsIn(new Integer[] {1, 2});
 
-    expectFailure
-        .whenTesting()
-        .that(asList(1, 2))
-        .containsExactlyElementsIn(new Integer[] {1, 2, 4});
+    expectFailureWhenTestingThat(asList(1, 2)).containsExactlyElementsIn(new Integer[] {1, 2, 4});
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[1, 2]> contains exactly <[1, 2, 4]>. It is missing <[4]>");
@@ -999,7 +991,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableIsEmptyWithFailure() {
-    expectFailure.whenTesting().that(asList(1, null, 3)).isEmpty();
+    expectFailureWhenTestingThat(asList(1, null, 3)).isEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[1, null, 3]> is empty");
@@ -1012,7 +1004,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableIsNotEmptyWithFailure() {
-    expectFailure.whenTesting().that(asList()).isNotEmpty();
+    expectFailureWhenTestingThat(asList()).isNotEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[]> is not empty");
@@ -1027,7 +1019,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isStrictlyOrderedFailure() {
-    expectFailure.whenTesting().that(asList(1, 2, 2, 4)).isStrictlyOrdered();
+    expectFailureWhenTestingThat(asList(1, 2, 2, 4)).isStrictlyOrdered();
     assertThat(expectFailure.getFailure()).hasMessageThat().contains("is strictly ordered");
     assertThat(expectFailure.getFailure()).hasMessageThat().contains("<2> <2>");
   }
@@ -1050,7 +1042,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isOrderedFailure() {
-    expectFailure.whenTesting().that(asList(1, 3, 2, 4)).isOrdered();
+    expectFailureWhenTestingThat(asList(1, 3, 2, 4)).isOrdered();
     assertThat(expectFailure.getFailure()).hasMessageThat().contains("is ordered");
     assertThat(expectFailure.getFailure()).hasMessageThat().contains("<3> <2>");
   }
@@ -1075,10 +1067,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableIsStrictlyOrderedWithComparatorFailure() {
-    expectFailure
-        .whenTesting()
-        .that(asList("1", "2", "2", "10"))
-        .isStrictlyOrdered(COMPARE_AS_DECIMAL);
+    expectFailureWhenTestingThat(asList("1", "2", "2", "10")).isStrictlyOrdered(COMPARE_AS_DECIMAL);
     assertThat(expectFailure.getFailure()).hasMessageThat().contains("is strictly ordered");
     assertThat(expectFailure.getFailure()).hasMessageThat().contains("<2> <2>");
   }
@@ -1093,7 +1082,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableIsOrderedWithComparatorFailure() {
-    expectFailure.whenTesting().that(asList("1", "10", "2", "20")).isOrdered(COMPARE_AS_DECIMAL);
+    expectFailureWhenTestingThat(asList("1", "10", "2", "20")).isOrdered(COMPARE_AS_DECIMAL);
     assertThat(expectFailure.getFailure()).hasMessageThat().contains("is ordered");
     assertThat(expectFailure.getFailure()).hasMessageThat().contains("<10> <2>");
   }
@@ -1171,5 +1160,9 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
     ImmutableList<String> expectedC = ImmutableList.of("c");
 
     assertThat(actual).isNoneOf(expectedB, expectedC);
+  }
+
+  private IterableSubject expectFailureWhenTestingThat(Iterable<?> actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/LongSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/LongSubjectTest.java
@@ -33,26 +33,18 @@ public class LongSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void simpleEquality() {
-    assertThat(2L + 2).isEqualTo(4L);
-  }
-
-  @Test
-  public void longIsLong() {
     assertThat(4L).isEqualTo(4L);
   }
 
   @Test
   public void simpleInequality() {
-    assertThat(2L + 2).isNotEqualTo(5L);
+    assertThat(4L).isNotEqualTo(5L);
   }
 
   @Test
   public void equalityWithInts() {
-    long x = 0;
-
-    assertThat(x).isEqualTo(0);
-
-    expectFailure.whenTesting().that(x).isNotEqualTo(0);
+    assertThat(0L).isEqualTo(0);
+    expectFailureWhenTestingThat(0L).isNotEqualTo(0);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <0> is not equal to <0>");
@@ -60,7 +52,7 @@ public class LongSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void equalityFail() {
-    expectFailure.whenTesting().that(2L + 2).isEqualTo(5L);
+    expectFailureWhenTestingThat(4L).isEqualTo(5L);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <4> is equal to <5>");
@@ -68,7 +60,7 @@ public class LongSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void inequalityFail() {
-    expectFailure.whenTesting().that(2L + 2).isNotEqualTo(4L);
+    expectFailureWhenTestingThat(4L).isNotEqualTo(4L);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <4> is not equal to <4>");
@@ -76,12 +68,12 @@ public class LongSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void equalityOfNulls() {
-    assertThat((Long) null).isEqualTo((Long) null);
+    assertThat((Long) null).isEqualTo(null);
   }
 
   @Test
   public void equalityOfNullsFail_nullActual() {
-    expectFailure.whenTesting().that((Long) null).isEqualTo(5L);
+    expectFailureWhenTestingThat(null).isEqualTo(5L);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <null> is equal to <5>");
@@ -89,7 +81,7 @@ public class LongSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void equalityOfNullsFail_nullExpected() {
-    expectFailure.whenTesting().that(5L).isEqualTo((Long) null);
+    expectFailureWhenTestingThat(5L).isEqualTo(null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <5> is equal to <null>");
@@ -97,15 +89,35 @@ public class LongSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void inequalityOfNulls() {
-    assertThat((Long) null).isNotEqualTo(4L);
-    assertThat(4L).isNotEqualTo((Long) null);
+    assertThat(4L).isNotEqualTo(null);
+    assertThat((Integer) null).isNotEqualTo(4L);
   }
 
   @Test
   public void inequalityOfNullsFail() {
-    expectFailure.whenTesting().that((Long) null).isNotEqualTo((Long) null);
+    expectFailureWhenTestingThat(null).isNotEqualTo(null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <null> is not equal to <null>");
+  }
+
+  @Test
+  public void testNumericTypeWithSameValue_shouldBeEqual_long_long() {
+    expectFailureWhenTestingThat(42L).isNotEqualTo(42L);
+    assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .isEqualTo("Not true that <42> is not equal to <42>");
+  }
+
+  @Test
+  public void testNumericTypeWithSameValue_shouldBeEqual_long_int() {
+    expectFailureWhenTestingThat(42L).isNotEqualTo(42);
+    assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .isEqualTo("Not true that <42> is not equal to <42>");
+  }
+
+  private LongSubject expectFailureWhenTestingThat(Long actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/MapSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/MapSubjectTest.java
@@ -74,7 +74,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   public void containsExactlyEmpty_fails() {
     ImmutableMap<String, Integer> actual = ImmutableMap.of("jan", 1);
 
-    expectFailure.whenTesting().that(actual).containsExactly();
+    expectFailureWhenTestingThat(actual).containsExactly();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{jan=1}> is empty");
@@ -84,7 +84,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   public void containsExactlyEntriesInEmpty_fails() {
     ImmutableMap<String, Integer> actual = ImmutableMap.of("jan", 1);
 
-    expectFailure.whenTesting().that(actual).containsExactlyEntriesIn(ImmutableMap.of());
+    expectFailureWhenTestingThat(actual).containsExactlyEntriesIn(ImmutableMap.of());
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{jan=1}> is empty");
@@ -141,7 +141,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void containsExactlyExtraKey() {
     ImmutableMap<String, Integer> actual = ImmutableMap.of("jan", 1, "feb", 2, "march", 3);
-    expectFailure.whenTesting().that(actual).containsExactly("feb", 2, "jan", 1);
+    expectFailureWhenTestingThat(actual).containsExactly("feb", 2, "jan", 1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -152,7 +152,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void containsExactlyExtraKeyInOrder() {
     ImmutableMap<String, Integer> actual = ImmutableMap.of("jan", 1, "feb", 2, "march", 3);
-    expectFailure.whenTesting().that(actual).containsExactly("feb", 2, "jan", 1).inOrder();
+    expectFailureWhenTestingThat(actual).containsExactly("feb", 2, "jan", 1).inOrder();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -163,7 +163,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void namedMapContainsExactlyExtraKey() {
     ImmutableMap<String, Integer> actual = ImmutableMap.of("jan", 1, "feb", 2, "march", 3);
-    expectFailure.whenTesting().that(actual).named("foo").containsExactly("feb", 2, "jan", 1);
+    expectFailureWhenTestingThat(actual).named("foo").containsExactly("feb", 2, "jan", 1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -174,7 +174,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void containsExactlyMissingKey() {
     ImmutableMap<String, Integer> actual = ImmutableMap.of("jan", 1, "feb", 2);
-    expectFailure.whenTesting().that(actual).containsExactly("jan", 1, "march", 3, "feb", 2);
+    expectFailureWhenTestingThat(actual).containsExactly("jan", 1, "march", 3, "feb", 2);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -185,7 +185,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void containsExactlyWrongValue() {
     ImmutableMap<String, Integer> actual = ImmutableMap.of("jan", 1, "feb", 2, "march", 3);
-    expectFailure.whenTesting().that(actual).containsExactly("jan", 1, "march", 33, "feb", 2);
+    expectFailureWhenTestingThat(actual).containsExactly("jan", 1, "march", 33, "feb", 2);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -197,7 +197,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void containsExactlyExtraKeyAndMissingKey() {
     ImmutableMap<String, Integer> actual = ImmutableMap.of("jan", 1, "march", 3);
-    expectFailure.whenTesting().that(actual).containsExactly("jan", 1, "feb", 2);
+    expectFailureWhenTestingThat(actual).containsExactly("jan", 1, "feb", 2);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -209,7 +209,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void containsExactlyExtraKeyAndWrongValue() {
     ImmutableMap<String, Integer> actual = ImmutableMap.of("jan", 1, "feb", 2, "march", 3);
-    expectFailure.whenTesting().that(actual).containsExactly("jan", 1, "march", 33);
+    expectFailureWhenTestingThat(actual).containsExactly("jan", 1, "march", 33);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -222,7 +222,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void containsExactlyMissingKeyAndWrongValue() {
     ImmutableMap<String, Integer> actual = ImmutableMap.of("jan", 1, "march", 3);
-    expectFailure.whenTesting().that(actual).containsExactly("jan", 1, "march", 33, "feb", 2);
+    expectFailureWhenTestingThat(actual).containsExactly("jan", 1, "march", 33, "feb", 2);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -235,7 +235,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void containsExactlyExtraKeyAndMissingKeyAndWrongValue() {
     ImmutableMap<String, Integer> actual = ImmutableMap.of("jan", 1, "march", 3);
-    expectFailure.whenTesting().that(actual).containsExactly("march", 33, "feb", 2);
+    expectFailureWhenTestingThat(actual).containsExactly("march", 33, "feb", 2);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -253,11 +253,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
     assertThat(actual).containsExactlyEntriesIn(actual).inOrder();
 
     assertThat(actual).containsExactly("jan", 1, "march", 3, "feb", 2);
-    expectFailure
-        .whenTesting()
-        .that(actual)
-        .containsExactly("jan", 1, "march", 3, "feb", 2)
-        .inOrder();
+    expectFailureWhenTestingThat(actual).containsExactly("jan", 1, "march", 3, "feb", 2).inOrder();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -288,9 +284,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void containsExactlyWrongValue_sameToStringForValues() {
-    expectFailure
-        .whenTesting()
-        .that(ImmutableMap.of("jan", 1L, "feb", 2L))
+    expectFailureWhenTestingThat(ImmutableMap.of("jan", 1L, "feb", 2L))
         .containsExactly("jan", 1, "feb", 2);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -303,9 +297,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void containsExactlyWrongValue_sameToStringForKeys() {
-    expectFailure
-        .whenTesting()
-        .that(ImmutableMap.of(1L, "jan", 1, "feb"))
+    expectFailureWhenTestingThat(ImmutableMap.of(1L, "jan", 1, "feb"))
         .containsExactly(1, "jan", 1L, "feb");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -318,9 +310,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void containsExactlyExtraKeyAndMissingKey_failsWithSameToStringForKeys() {
-    expectFailure
-        .whenTesting()
-        .that(ImmutableMap.of(1L, "jan", 2, "feb"))
+    expectFailureWhenTestingThat(ImmutableMap.of(1L, "jan", 2, "feb"))
         .containsExactly(1, "jan", 2, "feb");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -343,7 +333,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
     ImmutableMap<String, Integer> actual = ImmutableMap.of("jan", 1, "feb", 2, "march", 3);
     ImmutableMap<String, Integer> expectedMap = ImmutableMap.of("jan", 1, "april", 4, "march", 5);
 
-    expectFailure.whenTesting().that(actual).isEqualTo(expectedMap);
+    expectFailureWhenTestingThat(actual).isEqualTo(expectedMap);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -359,7 +349,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
     ImmutableMap<String, Integer> actual = ImmutableMap.of("jan", 1, "feb", 2, "march", 3);
     ImmutableMap<String, Integer> expectedMap = ImmutableMap.of("jan", 1, "feb", 2, "march", 4);
 
-    expectFailure.whenTesting().that(actual).isEqualTo(expectedMap);
+    expectFailureWhenTestingThat(actual).isEqualTo(expectedMap);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -373,7 +363,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
     ImmutableMap<String, Integer> actual = ImmutableMap.of("jan", 1, "feb", 2, "march", 3);
     ImmutableMap<String, Integer> expectedMap = ImmutableMap.of("jan", 1, "feb", 2, "march", 4);
 
-    expectFailure.whenTesting().that(actual).named("foo").isEqualTo(expectedMap);
+    expectFailureWhenTestingThat(actual).named("foo").isEqualTo(expectedMap);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -387,7 +377,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
     ImmutableMap<String, Integer> actual = ImmutableMap.of("jan", 1, "feb", 2, "march", 3);
     ImmutableMap<String, Integer> expectedMap = ImmutableMap.of("jan", 1, "feb", 2);
 
-    expectFailure.whenTesting().that(actual).isEqualTo(expectedMap);
+    expectFailureWhenTestingThat(actual).isEqualTo(expectedMap);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -400,7 +390,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
     ImmutableMap<String, Integer> actual = ImmutableMap.of("jan", 1, "feb", 2);
     ImmutableMap<String, Integer> expectedMap = ImmutableMap.of("jan", 1, "feb", 2, "march", 3);
 
-    expectFailure.whenTesting().that(actual).isEqualTo(expectedMap);
+    expectFailureWhenTestingThat(actual).isEqualTo(expectedMap);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -413,7 +403,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
     ImmutableMap<String, Integer> actual = ImmutableMap.of("jan", 1, "feb", 2, "march", 3);
     ImmutableMap<String, Integer> expectedMap = ImmutableMap.of("jan", 1, "feb", 2, "mar", 3);
 
-    expectFailure.whenTesting().that(actual).isEqualTo(expectedMap);
+    expectFailureWhenTestingThat(actual).isEqualTo(expectedMap);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -428,7 +418,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
         ImmutableMap.<String, Number>of("jan", 1, "feb", 2, "march", 3L);
     ImmutableMap<String, Integer> expectedMap = ImmutableMap.of("jan", 1, "feb", 2, "march", 3);
 
-    expectFailure.whenTesting().that(actual).isEqualTo(expectedMap);
+    expectFailureWhenTestingThat(actual).isEqualTo(expectedMap);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -440,7 +430,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void isEqualToNonMap() {
     ImmutableMap<String, Integer> actual = ImmutableMap.of("jan", 1, "feb", 2, "march", 3);
-    expectFailure.whenTesting().that(actual).isEqualTo("something else");
+    expectFailureWhenTestingThat(actual).isEqualTo("something else");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{jan=1, feb=2, march=3}> is equal to <something else>");
@@ -495,7 +485,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
     // implementation that always returns false. So the isEqualTo assertion should fail.
     Map<String, Integer> map1 = BrokenMap.wrapWithAlwaysFalseEquals(ImmutableMap.of("jan", 1));
     Map<String, Integer> map1clone = BrokenMap.wrapWithAlwaysFalseEquals(ImmutableMap.of("jan", 1));
-    expectFailure.whenTesting().that(map1).isEqualTo(map1clone);
+    expectFailureWhenTestingThat(map1).isEqualTo(map1clone);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -508,7 +498,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
     ImmutableMap<String, Integer> actual = ImmutableMap.of("jan", 1, "feb", 2, "march", 3);
     ImmutableMap<String, Integer> unexpected = ImmutableMap.of("jan", 1, "feb", 2, "march", 3);
 
-    expectFailure.whenTesting().that(actual).isNotEqualTo(unexpected);
+    expectFailureWhenTestingThat(actual).isNotEqualTo(unexpected);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -524,7 +514,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void isEmptyWithFailure() {
     ImmutableMap<Integer, Integer> actual = ImmutableMap.of(1, 5);
-    expectFailure.whenTesting().that(actual).isEmpty();
+    expectFailureWhenTestingThat(actual).isEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{1=5}> is empty");
@@ -539,7 +529,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void isNotEmptyWithFailure() {
     ImmutableMap<Integer, Integer> actual = ImmutableMap.of();
-    expectFailure.whenTesting().that(actual).isNotEmpty();
+    expectFailureWhenTestingThat(actual).isNotEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{}> is not empty");
@@ -573,7 +563,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void containsKeyFailure() {
     ImmutableMap<String, String> actual = ImmutableMap.of("kurt", "kluever");
-    expectFailure.whenTesting().that(actual).containsKey("greg");
+    expectFailureWhenTestingThat(actual).containsKey("greg");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{kurt=kluever}> contains key <greg>");
@@ -582,7 +572,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void containsKeyNullFailure() {
     ImmutableMap<String, String> actual = ImmutableMap.of("kurt", "kluever");
-    expectFailure.whenTesting().that(actual).containsKey(null);
+    expectFailureWhenTestingThat(actual).containsKey(null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{kurt=kluever}> contains key <null>");
@@ -590,9 +580,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void containsKey_failsWithSameToString() {
-    expectFailure
-        .whenTesting()
-        .that(ImmutableMap.of(1L, "value1", 2L, "value2", "1", "value3"))
+    expectFailureWhenTestingThat(ImmutableMap.of(1L, "value1", 2L, "value2", "1", "value3"))
         .containsKey(1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -606,7 +594,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
     Map<String, String> actual = Maps.newHashMap();
     actual.put("null", "value1");
 
-    expectFailure.whenTesting().that(actual).containsKey(null);
+    expectFailureWhenTestingThat(actual).containsKey(null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -631,7 +619,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void doesNotContainKeyFailure() {
     ImmutableMap<String, String> actual = ImmutableMap.of("kurt", "kluever");
-    expectFailure.whenTesting().that(actual).doesNotContainKey("kurt");
+    expectFailureWhenTestingThat(actual).doesNotContainKey("kurt");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{kurt=kluever}> does not contain key <kurt>");
@@ -641,7 +629,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   public void doesNotContainNullKey() {
     Map<String, String> actual = Maps.newHashMap();
     actual.put(null, "null");
-    expectFailure.whenTesting().that(actual).doesNotContainKey(null);
+    expectFailureWhenTestingThat(actual).doesNotContainKey(null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{null=null}> does not contain key <null>");
@@ -656,7 +644,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void containsEntryFailure() {
     ImmutableMap<String, String> actual = ImmutableMap.of("kurt", "kluever");
-    expectFailure.whenTesting().that(actual).containsEntry("greg", "kick");
+    expectFailureWhenTestingThat(actual).containsEntry("greg", "kick");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{kurt=kluever}> contains entry <greg=kick>");
@@ -664,9 +652,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void containsEntry_failsWithSameToStringOfKey() {
-    expectFailure
-        .whenTesting()
-        .that(ImmutableMap.of(1L, "value1", 2L, "value2"))
+    expectFailureWhenTestingThat(ImmutableMap.of(1L, "value1", 2L, "value2"))
         .containsEntry(1, "value1");
     assertWithMessage("Full message: %s", expectFailure.getFailure().getMessage())
         .that(expectFailure.getFailure())
@@ -679,7 +665,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void containsEntry_failsWithSameToStringOfValue() {
-    expectFailure.whenTesting().that(ImmutableMap.of(1, "null")).containsEntry(1, null);
+    expectFailureWhenTestingThat(ImmutableMap.of(1, "null")).containsEntry(1, null);
     assertWithMessage("Full message: %s", expectFailure.getFailure().getMessage())
         .that(expectFailure.getFailure())
         .hasMessageThat()
@@ -692,7 +678,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void containsNullKeyAndValue() {
     ImmutableMap<String, String> actual = ImmutableMap.of("kurt", "kluever");
-    expectFailure.whenTesting().that(actual).containsEntry(null, null);
+    expectFailureWhenTestingThat(actual).containsEntry(null, null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{kurt=kluever}> contains entry <null=null>");
@@ -709,7 +695,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   public void containsNullEntryValue() {
     Map<String, String> actual = Maps.newHashMap();
     actual.put(null, null);
-    expectFailure.whenTesting().that(actual).containsEntry("kurt", null);
+    expectFailureWhenTestingThat(actual).containsEntry("kurt", null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -721,7 +707,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   public void containsNullEntryKey() {
     Map<String, String> actual = Maps.newHashMap();
     actual.put(null, null);
-    expectFailure.whenTesting().that(actual).containsEntry(null, "kluever");
+    expectFailureWhenTestingThat(actual).containsEntry(null, "kluever");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -741,7 +727,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void doesNotContainEntryFailure() {
     ImmutableMap<String, String> actual = ImmutableMap.of("kurt", "kluever");
-    expectFailure.whenTesting().that(actual).doesNotContainEntry("kurt", "kluever");
+    expectFailureWhenTestingThat(actual).doesNotContainEntry("kurt", "kluever");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{kurt=kluever}> does not contain entry <kurt=kluever>");
@@ -759,7 +745,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   public void doesNotContainNullEntryFailure() {
     Map<String, String> actual = Maps.newHashMap();
     actual.put(null, null);
-    expectFailure.whenTesting().that(actual).doesNotContainEntry(null, null);
+    expectFailureWhenTestingThat(actual).doesNotContainEntry(null, null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{null=null}> does not contain entry <null=null>");
@@ -768,7 +754,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void failMapContainsKey() {
     ImmutableMap<String, String> actual = ImmutableMap.of("a", "A");
-    expectFailure.whenTesting().that(actual).containsKey("b");
+    expectFailureWhenTestingThat(actual).containsKey("b");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{a=A}> contains key <b>");
@@ -777,7 +763,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void failMapContainsKeyWithNull() {
     ImmutableMap<String, String> actual = ImmutableMap.of("a", "A");
-    expectFailure.whenTesting().that(actual).containsKey(null);
+    expectFailureWhenTestingThat(actual).containsKey(null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{a=A}> contains key <null>");
@@ -786,7 +772,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void failMapLacksKey() {
     ImmutableMap<String, String> actual = ImmutableMap.of("a", "A");
-    expectFailure.whenTesting().that(actual).doesNotContainKey("a");
+    expectFailureWhenTestingThat(actual).doesNotContainKey("a");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{a=A}> does not contain key <a>");
@@ -808,7 +794,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void failMapContainsKeyWithValue() {
     ImmutableMap<String, String> actual = ImmutableMap.of("a", "A");
-    expectFailure.whenTesting().that(actual).containsEntry("a", "a");
+    expectFailureWhenTestingThat(actual).containsEntry("a", "a");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -820,7 +806,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   public void failMapContainsKeyWithNullValuePresentExpected() {
     Map<String, String> actual = Maps.newHashMap();
     actual.put("a", null);
-    expectFailure.whenTesting().that(actual).containsEntry("a", "A");
+    expectFailureWhenTestingThat(actual).containsEntry("a", "A");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -831,7 +817,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void failMapContainsKeyWithPresentValueNullExpected() {
     ImmutableMap<String, String> actual = ImmutableMap.of("a", "A");
-    expectFailure.whenTesting().that(actual).containsEntry("a", null);
+    expectFailureWhenTestingThat(actual).containsEntry("a", null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -850,9 +836,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void comparingValuesUsing_containsEntry_failsExpectedKeyHasWrongValue() {
     ImmutableMap<String, String> actual = ImmutableMap.of("abc", "+123", "def", "+456");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsEntry("def", 123);
     assertThat(expectFailure.getFailure())
@@ -866,9 +850,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void comparingValuesUsing_containsEntry_failsWrongKeyHasExpectedValue() {
     ImmutableMap<String, String> actual = ImmutableMap.of("abc", "+123", "def", "+456");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsEntry("xyz", 456);
     assertThat(expectFailure.getFailure())
@@ -882,9 +864,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void comparingValuesUsing_containsEntry_failsMissingExpectedKeyAndValue() {
     ImmutableMap<String, String> actual = ImmutableMap.of("abc", "+123", "def", "+456");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsEntry("xyz", 321);
     assertThat(expectFailure.getFailure())
@@ -897,9 +877,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void comparingValuesUsing_containsEntry_diffExpectedKeyHasWrongValue() {
     ImmutableMap<String, Integer> actual = ImmutableMap.of("abc", 35, "def", 71);
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(WITHIN_10_OF)
         .containsEntry("def", 60);
     assertThat(expectFailure.getFailure())
@@ -936,9 +914,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void comparingValuesUsing_doesNotContainEntry_failure() {
     ImmutableMap<String, String> actual = ImmutableMap.of("abc", "+123", "def", "+456");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .doesNotContainEntry("def", 456);
     assertThat(expectFailure.getFailure())
@@ -968,9 +944,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void comparingValuesUsing_containsExactly_failsExtraEntry() {
     ImmutableMap<String, String> actual = ImmutableMap.of("abc", "123", "def", "456");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactly("def", 456);
     assertThat(expectFailure.getFailure())
@@ -984,9 +958,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void comparingValuesUsing_containsExactly_failsMissingEntry() {
     ImmutableMap<String, String> actual = ImmutableMap.of("abc", "123", "def", "456");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactly("def", 456, "xyz", 999, "abc", 123);
     assertThat(expectFailure.getFailure())
@@ -1001,9 +973,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void comparingValuesUsing_containsExactly_failsWrongKey() {
     ImmutableMap<String, String> actual = ImmutableMap.of("abc", "123", "def", "456");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactly("def", 456, "cab", 123);
     assertThat(expectFailure.getFailure())
@@ -1018,9 +988,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void comparingValuesUsing_containsExactly_failsWrongValue() {
     ImmutableMap<String, String> actual = ImmutableMap.of("abc", "123", "def", "456");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactly("def", 456, "abc", 321);
     assertThat(expectFailure.getFailure())
@@ -1035,9 +1003,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void comparingValuesUsing_containsExactly_inOrder_failsOutOfOrder() {
     ImmutableMap<String, String> actual = ImmutableMap.of("abc", "123", "def", "456");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactly("def", 456, "abc", 123)
         .inOrder();
@@ -1096,9 +1062,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   public void comparingValuesUsing_containsExactlyEntriesIn_failsExtraEntry() {
     ImmutableMap<String, Integer> expected = ImmutableMap.of("def", 456);
     ImmutableMap<String, String> actual = ImmutableMap.of("abc", "123", "def", "456");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactlyEntriesIn(expected);
     assertThat(expectFailure.getFailure())
@@ -1113,9 +1077,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   public void comparingValuesUsing_containsExactlyEntriesIn_failsMissingEntry() {
     ImmutableMap<String, Integer> expected = ImmutableMap.of("def", 456, "xyz", 999, "abc", 123);
     ImmutableMap<String, String> actual = ImmutableMap.of("abc", "123", "def", "456");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactlyEntriesIn(expected);
     assertThat(expectFailure.getFailure())
@@ -1131,9 +1093,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   public void comparingValuesUsing_containsExactlyEntriesIn_failsWrongKey() {
     ImmutableMap<String, Integer> expected = ImmutableMap.of("def", 456, "cab", 123);
     ImmutableMap<String, String> actual = ImmutableMap.of("abc", "123", "def", "456");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactlyEntriesIn(expected);
     assertThat(expectFailure.getFailure())
@@ -1149,9 +1109,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   public void comparingValuesUsing_containsExactlyEntriesIn_failsWrongValue() {
     ImmutableMap<String, Integer> expected = ImmutableMap.of("def", 456, "abc", 321);
     ImmutableMap<String, String> actual = ImmutableMap.of("abc", "123", "def", "456");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactlyEntriesIn(expected);
     assertThat(expectFailure.getFailure())
@@ -1167,9 +1125,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   public void comparingValuesUsing_containsExactlyEntriesIn_diffMissingAndExtraAndWrongValue() {
     ImmutableMap<String, Integer> expected = ImmutableMap.of("abc", 30, "def", 60, "ghi", 90);
     ImmutableMap<String, Integer> actual = ImmutableMap.of("abc", 35, "fed", 60, "ghi", 101);
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(WITHIN_10_OF)
         .containsExactlyEntriesIn(expected);
     assertThat(expectFailure.getFailure())
@@ -1187,9 +1143,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   public void comparingValuesUsing_containsExactlyEntriesIn_inOrder_failsOutOfOrder() {
     ImmutableMap<String, Integer> expected = ImmutableMap.of("def", 456, "abc", 123);
     ImmutableMap<String, String> actual = ImmutableMap.of("abc", "123", "def", "456");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactlyEntriesIn(expected)
         .inOrder();
@@ -1214,9 +1168,7 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   public void comparingValuesUsing_containsExactlyEntriesIn_failsEmpty() {
     ImmutableMap<String, Integer> expected = ImmutableMap.of();
     ImmutableMap<String, String> actual = ImmutableMap.of("abc", "123");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactlyEntriesIn(expected);
     assertThat(expectFailure.getFailure())
@@ -1236,5 +1188,9 @@ public class MapSubjectTest extends BaseSubjectTestCase {
     } catch (ClassCastException e) {
       // expected
     }
+  }
+
+  private MapSubject expectFailureWhenTestingThat(Map<?, ?> actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/MultimapSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/MultimapSubjectTest.java
@@ -71,7 +71,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
 
     assertThat(multimapA.equals(multimapB)).isFalse();
 
-    expectFailure.whenTesting().that(multimapA).isEqualTo(multimapB);
+    expectFailureWhenTestingThat(multimapA).isEqualTo(multimapB);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -107,7 +107,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
 
     assertThat(multimapA.equals(multimapB)).isFalse();
 
-    expectFailure.whenTesting().that(multimapA).isEqualTo(multimapB);
+    expectFailureWhenTestingThat(multimapA).isEqualTo(multimapB);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -117,9 +117,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_failsWithSameToString() {
-    expectFailure
-        .whenTesting()
-        .that(ImmutableMultimap.of(1, "a", 1, "b", 2, "c"))
+    expectFailureWhenTestingThat(ImmutableMultimap.of(1, "a", 1, "b", 2, "c"))
         .isEqualTo(ImmutableMultimap.of(1L, "a", 1L, "b", 2L, "c"));
     AssertionError e = expectFailure.getFailure();
     assertWithMessage("Full message: %s", e.getMessage())
@@ -141,7 +139,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void multimapIsEmptyWithFailure() {
     ImmutableMultimap<Integer, Integer> multimap = ImmutableMultimap.of(1, 5);
-    expectFailure.whenTesting().that(multimap).isEmpty();
+    expectFailureWhenTestingThat(multimap).isEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{1=[5]}> is empty");
@@ -156,7 +154,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void multimapIsNotEmptyWithFailure() {
     ImmutableMultimap<Integer, Integer> multimap = ImmutableMultimap.of();
-    expectFailure.whenTesting().that(multimap).isNotEmpty();
+    expectFailureWhenTestingThat(multimap).isNotEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{}> is not empty");
@@ -165,7 +163,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void multimapNamedValuesForKey() {
     ImmutableMultimap<Integer, Integer> multimap = ImmutableMultimap.of(1, 5);
-    expectFailure.whenTesting().that(multimap).named("multymap").valuesForKey(1).containsExactly(4);
+    expectFailureWhenTestingThat(multimap).named("multymap").valuesForKey(1).containsExactly(4);
     /*
      * TODO(cpovirk): It's silly that we display "multymap" twice in the failure, once for "value
      * of" and once for "root." The problem is that we need to include it in "value of" in case it's
@@ -187,7 +185,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void valuesForKeyNamed() {
     ImmutableMultimap<Integer, Integer> multimap = ImmutableMultimap.of(1, 5);
-    expectFailure.whenTesting().that(multimap).valuesForKey(1).named("valuez").containsExactly(4);
+    expectFailureWhenTestingThat(multimap).valuesForKey(1).named("valuez").containsExactly(4);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -225,7 +223,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void containsKeyFailure() {
     ImmutableMultimap<String, String> multimap = ImmutableMultimap.of("kurt", "kluever");
-    expectFailure.whenTesting().that(multimap).containsKey("daniel");
+    expectFailureWhenTestingThat(multimap).containsKey("daniel");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{kurt=[kluever]}> contains key <daniel>");
@@ -241,7 +239,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void containsKeyNullFailure() {
     ImmutableMultimap<String, String> multimap = ImmutableMultimap.of("kurt", "kluever");
-    expectFailure.whenTesting().that(multimap).containsKey(null);
+    expectFailureWhenTestingThat(multimap).containsKey(null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{kurt=[kluever]}> contains key <null>");
@@ -249,9 +247,8 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void containsKey_failsWithSameToString() {
-    expectFailure
-        .whenTesting()
-        .that(ImmutableMultimap.of(1L, "value1a", 1L, "value1b", 2L, "value2", "1", "value3"))
+    expectFailureWhenTestingThat(
+            ImmutableMultimap.of(1L, "value1a", 1L, "value1b", 2L, "value2", "1", "value3"))
         .containsKey(1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -271,7 +268,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void doesNotContainKeyFailure() {
     ImmutableMultimap<String, String> multimap = ImmutableMultimap.of("kurt", "kluever");
-    expectFailure.whenTesting().that(multimap).doesNotContainKey("kurt");
+    expectFailureWhenTestingThat(multimap).doesNotContainKey("kurt");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{kurt=[kluever]}> does not contain key <kurt>");
@@ -281,7 +278,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   public void doesNotContainNullKeyFailure() {
     Multimap<String, String> multimap = HashMultimap.create();
     multimap.put(null, "null");
-    expectFailure.whenTesting().that(multimap).doesNotContainKey(null);
+    expectFailureWhenTestingThat(multimap).doesNotContainKey(null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{null=[null]}> does not contain key <null>");
@@ -296,7 +293,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void containsEntryFailure() {
     ImmutableMultimap<String, String> multimap = ImmutableMultimap.of("kurt", "kluever");
-    expectFailure.whenTesting().that(multimap).containsEntry("daniel", "ploch");
+    expectFailureWhenTestingThat(multimap).containsEntry("daniel", "ploch");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{kurt=[kluever]}> contains entry <daniel=ploch>");
@@ -312,7 +309,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void failContainsEntry() {
     ImmutableMultimap<String, String> actual = ImmutableMultimap.of("a", "A");
-    expectFailure.whenTesting().that(actual).containsEntry("a", "a");
+    expectFailureWhenTestingThat(actual).containsEntry("a", "a");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -324,7 +321,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   public void failContainsEntryWithNullValuePresentExpected() {
     ListMultimap<String, String> actual = ArrayListMultimap.create();
     actual.put("a", null);
-    expectFailure.whenTesting().that(actual).containsEntry("a", "A");
+    expectFailureWhenTestingThat(actual).containsEntry("a", "A");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -335,7 +332,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void failContainsEntryWithPresentValueNullExpected() {
     ImmutableMultimap<String, String> actual = ImmutableMultimap.of("a", "A");
-    expectFailure.whenTesting().that(actual).containsEntry("a", null);
+    expectFailureWhenTestingThat(actual).containsEntry("a", null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -345,9 +342,8 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void containsEntry_failsWithSameToString() throws Exception {
-    expectFailure
-        .whenTesting()
-        .that(ImmutableMultimap.builder().put(1, "1").put(1, 1L).put(1L, 1).put(2, 3).build())
+    expectFailureWhenTestingThat(
+            ImmutableMultimap.builder().put(1, "1").put(1, 1L).put(1L, 1).put(2, 3).build())
         .containsEntry(1, 1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -368,7 +364,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void doesNotContainEntryFailure() {
     ImmutableMultimap<String, String> multimap = ImmutableMultimap.of("kurt", "kluever");
-    expectFailure.whenTesting().that(multimap).doesNotContainEntry("kurt", "kluever");
+    expectFailureWhenTestingThat(multimap).doesNotContainEntry("kurt", "kluever");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{kurt=[kluever]}> does not contain entry <kurt=kluever>");
@@ -409,10 +405,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
     assertThat(actual).containsExactly(ImmutableMultimap.of());
     assertThat(actual).containsExactly(ImmutableMultimap.of()).inOrder();
 
-    expectFailure
-        .whenTesting()
-        .that(ImmutableMultimap.of(42, "Answer", 42, "6x7"))
-        .containsExactly();
+    expectFailureWhenTestingThat(ImmutableMultimap.of(42, "Answer", 42, "6x7")).containsExactly();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{42=[Answer, 6x7]}> is empty");
@@ -455,7 +448,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
         ImmutableListMultimap.of(3, "one", 3, "two", 3, "one", 4, "five", 4, "five");
     ImmutableSetMultimap<Integer, String> expected = ImmutableSetMultimap.copyOf(actual);
 
-    expectFailure.whenTesting().that(actual).containsExactlyEntriesIn(expected);
+    expectFailureWhenTestingThat(actual).containsExactlyEntriesIn(expected);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -473,7 +466,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
     actual.remove(3, "six");
     actual.remove(4, "five");
 
-    expectFailure.whenTesting().that(actual).containsExactlyEntriesIn(expected);
+    expectFailureWhenTestingThat(actual).containsExactlyEntriesIn(expected);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -491,7 +484,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
     actual.put(4, "nine");
     actual.put(5, "eight");
 
-    expectFailure.whenTesting().that(actual).containsExactlyEntriesIn(expected);
+    expectFailureWhenTestingThat(actual).containsExactlyEntriesIn(expected);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -511,7 +504,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
     actual.put(4, "nine");
     actual.put(5, "eight");
 
-    expectFailure.whenTesting().that(actual).containsExactlyEntriesIn(expected);
+    expectFailureWhenTestingThat(actual).containsExactlyEntriesIn(expected);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -524,7 +517,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void containsExactlyFailureWithEmptyStringMissing() {
-    expectFailure.whenTesting().that(ImmutableMultimap.of()).containsExactly("", "a");
+    expectFailureWhenTestingThat(ImmutableMultimap.of()).containsExactly("", "a");
 
     assertThat(expectFailure.getFailure().getMessage())
         .isEqualTo(
@@ -534,10 +527,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void containsExactlyFailureWithEmptyStringExtra() {
-    expectFailure
-        .whenTesting()
-        .that(ImmutableMultimap.of("a", "", "", ""))
-        .containsExactly("a", "");
+    expectFailureWhenTestingThat(ImmutableMultimap.of("a", "", "", "")).containsExactly("a", "");
 
     assertThat(expectFailure.getFailure().getMessage())
         .isEqualTo(
@@ -547,7 +537,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void containsExactlyFailureWithEmptyStringBoth() {
-    expectFailure.whenTesting().that(ImmutableMultimap.of("a", "")).containsExactly("", "a");
+    expectFailureWhenTestingThat(ImmutableMultimap.of("a", "")).containsExactly("", "a");
 
     assertThat(expectFailure.getFailure().getMessage())
         .isEqualTo(
@@ -583,7 +573,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
         ImmutableMultimap.of(4, "four", 3, "six", 4, "five", 3, "two", 3, "one");
 
     assertThat(actual).containsExactlyEntriesIn(expected);
-    expectFailure.whenTesting().that(actual).containsExactlyEntriesIn(expected).inOrder();
+    expectFailureWhenTestingThat(actual).containsExactlyEntriesIn(expected).inOrder();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .startsWith(
@@ -598,7 +588,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
         ImmutableMultimap.of(3, "six", 3, "two", 3, "one", 4, "five", 4, "four");
 
     assertThat(actual).containsExactlyEntriesIn(expected);
-    expectFailure.whenTesting().that(actual).containsExactlyEntriesIn(expected).inOrder();
+    expectFailureWhenTestingThat(actual).containsExactlyEntriesIn(expected).inOrder();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -633,9 +623,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
     actual.remove(3, "six");
     actual.remove(4, "five");
 
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .containsExactly(3, "one", 3, "six", 3, "two", 4, "five", 4, "four");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -654,9 +642,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
     actual.put(4, "nine");
     actual.put(5, "eight");
 
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .containsExactly(3, "one", 3, "six", 3, "two", 4, "five", 4, "four");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -677,9 +663,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
     actual.put(4, "nine");
     actual.put(5, "eight");
 
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .containsExactly(3, "one", 3, "six", 3, "two", 4, "five", 4, "four");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -705,7 +689,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
         ImmutableListMultimap.of(3, "one", 3, "two", 3, "one", 4, "five", 4, "five");
     ImmutableSetMultimap<Integer, String> expected = ImmutableSetMultimap.copyOf(actual);
 
-    expectFailure.whenTesting().that(actual).containsExactly(3, "one", 3, "two", 4, "five");
+    expectFailureWhenTestingThat(actual).containsExactly(3, "one", 3, "two", 4, "five");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -733,9 +717,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
         ImmutableMultimap.of(4, "four", 3, "six", 4, "five", 3, "two", 3, "one");
 
     assertThat(actual).containsExactly(4, "four", 3, "six", 4, "five", 3, "two", 3, "one");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .containsExactly(4, "four", 3, "six", 4, "five", 3, "two", 3, "one")
         .inOrder();
     assertThat(expectFailure.getFailure())
@@ -752,9 +734,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
         ImmutableMultimap.of(3, "six", 3, "two", 3, "one", 4, "five", 4, "four");
 
     assertThat(actual).containsExactly(3, "six", 3, "two", 3, "one", 4, "five", 4, "four");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .containsExactly(3, "six", 3, "two", 3, "one", 4, "five", 4, "four")
         .inOrder();
     assertThat(expectFailure.getFailure())
@@ -769,9 +749,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void containsExactlyEntriesIn_homogeneousMultimap_failsWithSameToString()
       throws Exception {
-    expectFailure
-        .whenTesting()
-        .that(ImmutableMultimap.of(1, "a", 1, "b", 2, "c"))
+    expectFailureWhenTestingThat(ImmutableMultimap.of(1, "a", 1, "b", 2, "c"))
         .containsExactlyEntriesIn(ImmutableMultimap.of(1L, "a", 1L, "b", 2L, "c"));
     assertWithMessage("Full message: %s", expectFailure.getFailure().getMessage())
         .that(expectFailure.getFailure())
@@ -786,9 +764,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void containsExactlyEntriesIn_heterogeneousMultimap_failsWithSameToString()
       throws Exception {
-    expectFailure
-        .whenTesting()
-        .that(ImmutableMultimap.of(1, "a", 1, "b", 2L, "c"))
+    expectFailureWhenTestingThat(ImmutableMultimap.of(1, "a", 1, "b", 2L, "c"))
         .containsExactlyEntriesIn(ImmutableMultimap.of(1L, "a", 1L, "b", 2, "c"));
     assertWithMessage("Full message: %s", expectFailure.getFailure().getMessage())
         .that(expectFailure.getFailure())
@@ -818,9 +794,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   public void comparingValuesUsing_containsEntry_failsExpectedKeyHasWrongValues() {
     ImmutableListMultimap<String, String> actual =
         ImmutableListMultimap.of("abc", "+123", "def", "+456", "def", "+789");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsEntry("def", 123);
     assertThat(expectFailure.getFailure())
@@ -835,9 +809,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   public void comparingValuesUsing_containsEntry_failsWrongKeyHasExpectedValue() {
     ImmutableListMultimap<String, String> actual =
         ImmutableListMultimap.of("abc", "+123", "def", "+456", "def", "+789");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsEntry("xyz", 789);
     assertThat(expectFailure.getFailure())
@@ -852,9 +824,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   public void comparingValuesUsing_containsEntry_failsMissingExpectedKeyAndValue() {
     ImmutableListMultimap<String, String> actual =
         ImmutableListMultimap.of("abc", "+123", "def", "+456", "def", "+789");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsEntry("xyz", 321);
     assertThat(expectFailure.getFailure())
@@ -908,9 +878,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   public void comparingValuesUsing_doesNotContainEntry_failure() {
     ImmutableListMultimap<String, String> actual =
         ImmutableListMultimap.of("abc", "+123", "def", "+456", "def", "+789");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .doesNotContainEntry("def", 789);
     assertThat(expectFailure.getFailure())
@@ -951,9 +919,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
         ImmutableListMultimap.of("def", "+64", "def", "0x40", "def", "+128");
     ImmutableListMultimap<String, Integer> expected =
         ImmutableListMultimap.of("def", 64, "def", 128, "def", 64, "abc", 123);
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactlyEntriesIn(expected);
     assertThat(expectFailure.getFailure())
@@ -972,9 +938,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
         ImmutableListMultimap.of("abc", "+123", "def", "+64", "def", "0x40", "def", "+128");
     ImmutableListMultimap<String, Integer> expected =
         ImmutableListMultimap.of("def", 64, "def", 128, "def", 64);
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactlyEntriesIn(expected);
     assertThat(expectFailure.getFailure())
@@ -992,9 +956,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
         ImmutableListMultimap.of("abc", "+123", "def", "+64", "def", "0x40", "def", "+128");
     ImmutableListMultimap<String, Integer> expected =
         ImmutableListMultimap.of("def", 64, "def", 128, "def", 128, "abc", 123);
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactlyEntriesIn(expected);
     String expectedPreamble =
@@ -1045,9 +1007,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
         ImmutableListMultimap.of("abc", "+123", "def", "+64", "def", "0x40", "def", "+128");
     ImmutableListMultimap<String, Integer> expected =
         ImmutableListMultimap.of("def", 64, "def", 64, "def", 128, "abc", 123);
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactlyEntriesIn(expected)
         .inOrder();
@@ -1065,9 +1025,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
         ImmutableListMultimap.of("abc", "+123", "def", "+64", "def", "0x40", "def", "+128");
     ImmutableListMultimap<String, Integer> expected =
         ImmutableListMultimap.of("abc", 123, "def", 64, "def", 128, "def", 64);
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactlyEntriesIn(expected)
         .inOrder();
@@ -1084,9 +1042,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
     ImmutableListMultimap<String, String> actual = ImmutableListMultimap.of("abc", "+123");
     ImmutableListMultimap<String, Integer> expected =
         ImmutableListMultimap.of("abc", 123, "def", 456);
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .named("multymap")
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactlyEntriesIn(expected);
@@ -1111,9 +1067,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
         .containsExactly()
         .inOrder();
 
-    expectFailure
-        .whenTesting()
-        .that(ImmutableListMultimap.of("abc", "+123"))
+    expectFailureWhenTestingThat(ImmutableListMultimap.of("abc", "+123"))
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactly();
     assertThat(expectFailure.getFailure())
@@ -1134,9 +1088,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   public void comparingValuesUsing_containsExactly_missingKey() {
     ImmutableListMultimap<String, String> actual =
         ImmutableListMultimap.of("def", "+64", "def", "0x40", "def", "+128");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactly("def", 64, "def", 128, "def", 64, "abc", 123);
     assertThat(expectFailure.getFailure())
@@ -1153,9 +1105,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   public void comparingValuesUsing_containsExactly_extraKey() {
     ImmutableListMultimap<String, String> actual =
         ImmutableListMultimap.of("abc", "+123", "def", "+64", "def", "0x40", "def", "+128");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactly("def", 64, "def", 128, "def", 64);
     assertThat(expectFailure.getFailure())
@@ -1171,9 +1121,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   public void comparingValuesUsing_containsExactly_wrongValueForKey() {
     ImmutableListMultimap<String, String> actual =
         ImmutableListMultimap.of("abc", "+123", "def", "+64", "def", "0x40", "def", "+128");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactly("def", 64, "def", 128, "def", 128, "abc", 123);
     String expectedPreamble =
@@ -1218,9 +1166,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   public void comparingValuesUsing_containsExactly_inOrder_wrongKeyOrder() {
     ImmutableListMultimap<String, String> actual =
         ImmutableListMultimap.of("abc", "+123", "def", "+64", "def", "0x40", "def", "+128");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactly("def", 64, "def", 64, "def", 128, "abc", 123)
         .inOrder();
@@ -1236,9 +1182,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   public void comparingValuesUsing_containsExactly_inOrder_wrongValueOrder() {
     ImmutableListMultimap<String, String> actual =
         ImmutableListMultimap.of("abc", "+123", "def", "+64", "def", "0x40", "def", "+128");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactly("abc", 123, "def", 64, "def", 128, "def", 64)
         .inOrder();
@@ -1253,9 +1197,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void comparingValuesUsing_containsExactly_failsWithNamed() {
     ImmutableListMultimap<String, String> actual = ImmutableListMultimap.of("abc", "+123");
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .named("multymap")
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsExactly("abc", 123, "def", 456);
@@ -1266,5 +1208,9 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
                 + "that is equal to and a value that parses to the key and value of each element "
                 + "of <[abc=123, def=456]>. It is missing an element that has a key that is "
                 + "equal to and a value that parses to the key and value of <def=456>");
+  }
+
+  private MultimapSubject expectFailureWhenTestingThat(Multimap<?, ?> actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/MultisetSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/MultisetSubjectTest.java
@@ -42,7 +42,7 @@ public class MultisetSubjectTest extends BaseSubjectTestCase {
   @Test
   public void multisetIsEmptyWithFailure() {
     ImmutableMultiset<Integer> multiset = ImmutableMultiset.of(1, 5);
-    expectFailure.whenTesting().that(multiset).isEmpty();
+    expectFailureWhenTestingThat(multiset).isEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[1, 5]> is empty");
@@ -57,7 +57,7 @@ public class MultisetSubjectTest extends BaseSubjectTestCase {
   @Test
   public void multisetIsNotEmptyWithFailure() {
     ImmutableMultiset<Integer> multiset = ImmutableMultiset.of();
-    expectFailure.whenTesting().that(multiset).isNotEmpty();
+    expectFailureWhenTestingThat(multiset).isNotEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[]> is not empty");
@@ -95,7 +95,7 @@ public class MultisetSubjectTest extends BaseSubjectTestCase {
   @Test
   public void hasCountFail() {
     ImmutableMultiset<String> multiset = ImmutableMultiset.of("kurt", "kurt", "kluever");
-    expectFailure.whenTesting().that(multiset).hasCount("kurt", 3);
+    expectFailureWhenTestingThat(multiset).hasCount("kurt", 3);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[kurt x 2, kluever]> has a count for <kurt> of <3>. It is <2>");
@@ -110,7 +110,7 @@ public class MultisetSubjectTest extends BaseSubjectTestCase {
   @Test
   public void containsFailure() {
     ImmutableMultiset<String> multiset = ImmutableMultiset.of("kurt", "kluever");
-    expectFailure.whenTesting().that(multiset).contains("greg");
+    expectFailureWhenTestingThat(multiset).contains("greg");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("<[kurt, kluever]> should have contained <greg>");
@@ -119,7 +119,7 @@ public class MultisetSubjectTest extends BaseSubjectTestCase {
   @Test
   public void containsNullFailure() {
     ImmutableMultiset<String> multiset = ImmutableMultiset.of("kurt", "kluever");
-    expectFailure.whenTesting().that(multiset).contains(null);
+    expectFailureWhenTestingThat(multiset).contains(null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("<[kurt, kluever]> should have contained <null>");
@@ -142,7 +142,7 @@ public class MultisetSubjectTest extends BaseSubjectTestCase {
   @Test
   public void doesNotContainFailure() {
     ImmutableMultiset<String> multiset = ImmutableMultiset.of("kurt", "kluever");
-    expectFailure.whenTesting().that(multiset).doesNotContain("kurt");
+    expectFailureWhenTestingThat(multiset).doesNotContain("kurt");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("<[kurt, kluever]> should not have contained <kurt>");
@@ -152,9 +152,13 @@ public class MultisetSubjectTest extends BaseSubjectTestCase {
   public void doesNotContainNull() {
     Multiset<String> multiset = HashMultiset.create();
     multiset.add(null);
-    expectFailure.whenTesting().that(multiset).doesNotContain(null);
+    expectFailureWhenTestingThat(multiset).doesNotContain(null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("<[null]> should not have contained <null>");
+  }
+
+  private MultisetSubject expectFailureWhenTestingThat(Multiset<?> actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/ObjectArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/ObjectArraySubjectTest.java
@@ -60,7 +60,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasLengthFail() {
-    expectFailure.whenTesting().that(objectArray("A", 5L)).hasLength(1);
+    expectFailureWhenTestingThat(objectArray("A", 5L)).hasLength(1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[A, 5]> has length <1>");
@@ -68,7 +68,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasLengthFailNamed() {
-    expectFailure.whenTesting().that(objectArray("A", 5L)).named("foo").hasLength(1);
+    expectFailureWhenTestingThat(objectArray("A", 5L)).named("foo").hasLength(1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that foo (<[A, 5]>) has length <1>");
@@ -76,7 +76,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasLengthMultiFail() {
-    expectFailure.whenTesting().that(new Object[][] {{"A"}, {5L}}).hasLength(1);
+    expectFailureWhenTestingThat(new Object[][] {{"A"}, {5L}}).hasLength(1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[[A], [5]]> has length <1>");
@@ -99,7 +99,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEmptyFail() {
-    expectFailure.whenTesting().that(objectArray("A", 5L)).isEmpty();
+    expectFailureWhenTestingThat(objectArray("A", 5L)).isEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[A, 5]> is empty");
@@ -113,7 +113,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isNotEmptyFail() {
-    expectFailure.whenTesting().that(EMPTY).isNotEmpty();
+    expectFailureWhenTestingThat(EMPTY).isNotEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[]> is not empty");
@@ -121,7 +121,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_Fail_UnequalOrdering() {
-    expectFailure.whenTesting().that(objectArray("A", 5L)).isEqualTo(objectArray(5L, "A"));
+    expectFailureWhenTestingThat(objectArray("A", 5L)).isEqualTo(objectArray(5L, "A"));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[A, 5]> is equal to <[5, A]>. differs at index: [0]");
@@ -129,9 +129,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_Fail_UnequalOrderingMultiDimensional_00() {
-    expectFailure
-        .whenTesting()
-        .that(new Object[][] {{"A"}, {5L}})
+    expectFailureWhenTestingThat(new Object[][] {{"A"}, {5L}})
         .isEqualTo(new Object[][] {{5L}, {"A"}});
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -140,9 +138,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_Fail_UnequalOrderingMultiDimensional_01() {
-    expectFailure
-        .whenTesting()
-        .that(new Object[][] {{"A", "B"}, {5L}})
+    expectFailureWhenTestingThat(new Object[][] {{"A", "B"}, {5L}})
         .isEqualTo(new Object[][] {{"A"}, {5L}});
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -153,9 +149,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_Fail_UnequalOrderingMultiDimensional_11() {
-    expectFailure
-        .whenTesting()
-        .that(new Object[][] {{"A"}, {5L}})
+    expectFailureWhenTestingThat(new Object[][] {{"A"}, {5L}})
         .isEqualTo(new Object[][] {{"A"}, {5L, 6L}});
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -166,7 +160,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_Fail_NotAnArray() {
-    expectFailure.whenTesting().that(objectArray("A", 5L)).isEqualTo(new Object());
+    expectFailureWhenTestingThat(objectArray("A", 5L)).isEqualTo(new Object());
     AssertionError e = expectFailure.getFailure();
     assertThat(e).hasMessageThat().contains("is equal to");
     assertThat(e).hasMessageThat().contains("java.lang.Object");
@@ -192,7 +186,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isNotEqualTo_FailEquals() {
-    expectFailure.whenTesting().that(objectArray("A", 5L)).isNotEqualTo(objectArray("A", 5L));
+    expectFailureWhenTestingThat(objectArray("A", 5L)).isNotEqualTo(objectArray("A", 5L));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[A, 5]> is not equal to <[A, 5]>");
@@ -200,9 +194,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isNotEqualTo_FailEqualsMultiDimensional() {
-    expectFailure
-        .whenTesting()
-        .that(new Object[][] {{"A"}, {5L}})
+    expectFailureWhenTestingThat(new Object[][] {{"A"}, {5L}})
         .isNotEqualTo(new Object[][] {{"A"}, {5L}});
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -213,7 +205,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
   @Test
   public void isNotEqualTo_FailSame() {
     Object[] same = objectArray("A", 5L);
-    expectFailure.whenTesting().that(same).isNotEqualTo(same);
+    expectFailureWhenTestingThat(same).isNotEqualTo(same);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[A, 5]> is not equal to <[A, 5]>");
@@ -223,7 +215,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
   @Test
   public void isNotEqualTo_FailSameMultiDimensional() {
     Object[][] same = new Object[][] {{"A"}, {5L}};
-    expectFailure.whenTesting().that(same).isNotEqualTo(same);
+    expectFailureWhenTestingThat(same).isNotEqualTo(same);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[[A], [5]]> is not equal to <[[A], [5]]>");
@@ -248,7 +240,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void stringArrayIsEqualTo_Fail_UnequalLength() {
-    expectFailure.whenTesting().that(objectArray("A", "B")).isEqualTo(objectArray("B"));
+    expectFailureWhenTestingThat(objectArray("A", "B")).isEqualTo(objectArray("B"));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -257,10 +249,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void stringArrayIsEqualTo_Fail_UnequalLengthMultiDimensional() {
-    expectFailure
-        .whenTesting()
-        .that(new String[][] {{"A"}, {"B"}})
-        .isEqualTo(new String[][] {{"A"}});
+    expectFailureWhenTestingThat(new String[][] {{"A"}, {"B"}}).isEqualTo(new String[][] {{"A"}});
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -270,7 +259,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void stringArrayIsEqualTo_Fail_UnequalOrdering() {
-    expectFailure.whenTesting().that(objectArray("A", "B")).isEqualTo(objectArray("B", "A"));
+    expectFailureWhenTestingThat(objectArray("A", "B")).isEqualTo(objectArray("B", "A"));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[A, B]> is equal to <[B, A]>. differs at index: [0]");
@@ -278,9 +267,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void stringArrayIsEqualTo_Fail_UnequalOrderingMultiDimensional() {
-    expectFailure
-        .whenTesting()
-        .that(new String[][] {{"A"}, {"B"}})
+    expectFailureWhenTestingThat(new String[][] {{"A"}, {"B"}})
         .isEqualTo(new String[][] {{"B"}, {"A"}});
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -289,9 +276,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void SetArrayIsEqualTo_Fail_UnequalOrdering() {
-    expectFailure
-        .whenTesting()
-        .that(objectArray(ImmutableSet.of("A"), ImmutableSet.of("B")))
+    expectFailureWhenTestingThat(objectArray(ImmutableSet.of("A"), ImmutableSet.of("B")))
         .isEqualTo(objectArray(ImmutableSet.of("B"), ImmutableSet.of("A")));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -308,9 +293,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void primitiveMultiDimensionalArrayIsEqualTo_Fail_UnequalOrdering() {
-    expectFailure
-        .whenTesting()
-        .that(new int[][] {{1, 2}, {3}, {4, 5, 6}})
+    expectFailureWhenTestingThat(new int[][] {{1, 2}, {3}, {4, 5, 6}})
         .isEqualTo(new int[][] {{1, 2}, {3}, {4, 5, 6, 7}});
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -327,9 +310,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void primitiveMultiDimensionalArrayIsNotEqualTo_Fail_Equal() {
-    expectFailure
-        .whenTesting()
-        .that(new int[][] {{1, 2}, {3}, {4, 5, 6}})
+    expectFailureWhenTestingThat(new int[][] {{1, 2}, {3}, {4, 5, 6}})
         .isNotEqualTo(new int[][] {{1, 2}, {3}, {4, 5, 6}});
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -339,9 +320,7 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void boxedAndUnboxed() {
-    expectFailure
-        .whenTesting()
-        .that(new Object[] {new int[] {0}})
+    expectFailureWhenTestingThat(new Object[] {new int[] {0}})
         .isEqualTo(new Object[] {new Integer[] {0}});
     assertThat(expectFailure.getFailure()).hasMessageThat().contains("toString");
     assertThat(expectFailure.getFailure())
@@ -359,5 +338,9 @@ public class ObjectArraySubjectTest extends BaseSubjectTestCase {
 
   private static Set[] objectArray(Set... ts) {
     return ts;
+  }
+
+  private ObjectArraySubject<?> expectFailureWhenTestingThat(Object[] actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/PlatformBaseSubjectTestCase.java
+++ b/core/src/test/java/com/google/common/truth/PlatformBaseSubjectTestCase.java
@@ -15,5 +15,9 @@
  */
 package com.google.common.truth;
 
+import org.junit.Rule;
+
 /** Base class for truth subject tests to extend. */
-abstract class BaseSubjectTestCase extends PlatformBaseSubjectTestCase {}
+public abstract class PlatformBaseSubjectTestCase {
+  @Rule public final ExpectFailure expectFailure = new ExpectFailure();
+}

--- a/core/src/test/java/com/google/common/truth/PrimitiveBooleanArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveBooleanArraySubjectTest.java
@@ -48,7 +48,7 @@ public class PrimitiveBooleanArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_Fail_UnequalOrdering() {
-    expectFailure.whenTesting().that(array(true, false, true)).isEqualTo(array(false, true, true));
+    expectFailureWhenTestingThat(array(true, false, true)).isEqualTo(array(false, true, true));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -58,7 +58,7 @@ public class PrimitiveBooleanArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_Fail_NotAnArray() {
-    expectFailure.whenTesting().that(array(true, false, true)).isEqualTo(new Object());
+    expectFailureWhenTestingThat(array(true, false, true)).isEqualTo(new Object());
   }
 
   @Test
@@ -78,7 +78,7 @@ public class PrimitiveBooleanArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isNotEqualTo_FailEquals() {
-    expectFailure.whenTesting().that(array(true, false)).isNotEqualTo(array(true, false));
+    expectFailureWhenTestingThat(array(true, false)).isNotEqualTo(array(true, false));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[true, false]> is not equal to <[true, false]>");
@@ -88,7 +88,7 @@ public class PrimitiveBooleanArraySubjectTest extends BaseSubjectTestCase {
   @Test
   public void isNotEqualTo_FailSame() {
     boolean[] same = array(true, false);
-    expectFailure.whenTesting().that(same).isNotEqualTo(same);
+    expectFailureWhenTestingThat(same).isNotEqualTo(same);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[true, false]> is not equal to <[true, false]>");
@@ -96,5 +96,9 @@ public class PrimitiveBooleanArraySubjectTest extends BaseSubjectTestCase {
 
   private static boolean[] array(boolean... ts) {
     return ts;
+  }
+
+  private PrimitiveBooleanArraySubject expectFailureWhenTestingThat(boolean[] actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/PrimitiveByteArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveByteArraySubjectTest.java
@@ -54,7 +54,7 @@ public class PrimitiveByteArraySubjectTest extends BaseSubjectTestCase {
   public void isEqualTo_Fail_shortVersion() {
     byte[] actual = new byte[] {124, 112, 12, 11, 10};
     byte[] expect = new byte[] {24, 12, 2, 1, 0};
-    expectFailure.whenTesting().that(actual).isEqualTo(expect);
+    expectFailureWhenTestingThat(actual).isEqualTo(expect);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -75,7 +75,7 @@ public class PrimitiveByteArraySubjectTest extends BaseSubjectTestCase {
           124, 112, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 7, 101, 120, 97, 109, 112, 108, 101, 3, 99, 111,
           109, 0, 0, 1, 0, 1
         };
-    expectFailure.whenTesting().that(actual).isEqualTo(expect);
+    expectFailureWhenTestingThat(actual).isEqualTo(expect);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -87,10 +87,7 @@ public class PrimitiveByteArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_Fail_UnequalOrdering() {
-    expectFailure
-        .whenTesting()
-        .that(array(BYTE_0, (byte) 123))
-        .isEqualTo(array((byte) 123, BYTE_0));
+    expectFailureWhenTestingThat(array(BYTE_0, (byte) 123)).isEqualTo(array((byte) 123, BYTE_0));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("expected: [123, 0]; but was: [0, 123] expected:<[7B00]> but was:<[007B]>");
@@ -98,7 +95,7 @@ public class PrimitiveByteArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_Fail_NotAnArray() {
-    expectFailure.whenTesting().that(array(BYTE_0, BYTE_1)).isEqualTo(new int[] {});
+    expectFailureWhenTestingThat(array(BYTE_0, BYTE_1)).isEqualTo(new int[] {});
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .contains("wrong type; expected: int[]; but was: byte[]");
@@ -121,7 +118,7 @@ public class PrimitiveByteArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isNotEqualTo_FailEquals() {
-    expectFailure.whenTesting().that(array(BYTE_0, BYTE_1)).isNotEqualTo(array(BYTE_0, BYTE_1));
+    expectFailureWhenTestingThat(array(BYTE_0, BYTE_1)).isNotEqualTo(array(BYTE_0, BYTE_1));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <0001> is not equal to <0001>");
@@ -131,7 +128,7 @@ public class PrimitiveByteArraySubjectTest extends BaseSubjectTestCase {
   @Test
   public void isNotEqualTo_FailSame() {
     byte[] same = array(BYTE_0, BYTE_1);
-    expectFailure.whenTesting().that(same).isNotEqualTo(same);
+    expectFailureWhenTestingThat(same).isNotEqualTo(same);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <0001> is not equal to <0001>");
@@ -139,5 +136,9 @@ public class PrimitiveByteArraySubjectTest extends BaseSubjectTestCase {
 
   private static byte[] array(byte... ts) {
     return ts;
+  }
+
+  private PrimitiveByteArraySubject expectFailureWhenTestingThat(byte[] actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/PrimitiveCharArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveCharArraySubjectTest.java
@@ -48,7 +48,7 @@ public class PrimitiveCharArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_Fail_UnequalOrdering() {
-    expectFailure.whenTesting().that(array('a', 'q')).isEqualTo(array('q', 'a'));
+    expectFailureWhenTestingThat(array('a', 'q')).isEqualTo(array('q', 'a'));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[a, q]> is equal to <[q, a]>. differs at index: [0]");
@@ -56,7 +56,7 @@ public class PrimitiveCharArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_Fail_NotAnArray() {
-    expectFailure.whenTesting().that(array('a', 'q')).isEqualTo(new int[] {});
+    expectFailureWhenTestingThat(array('a', 'q')).isEqualTo(new int[] {});
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .contains("wrong type; expected: int[]; but was: char[]");
@@ -79,7 +79,7 @@ public class PrimitiveCharArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isNotEqualTo_FailEquals() {
-    expectFailure.whenTesting().that(array('a', 'q')).isNotEqualTo(array('a', 'q'));
+    expectFailureWhenTestingThat(array('a', 'q')).isNotEqualTo(array('a', 'q'));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[a, q]> is not equal to <[a, q]>");
@@ -89,7 +89,7 @@ public class PrimitiveCharArraySubjectTest extends BaseSubjectTestCase {
   @Test
   public void isNotEqualTo_FailSame() {
     char[] same = array('a', 'q');
-    expectFailure.whenTesting().that(same).isNotEqualTo(same);
+    expectFailureWhenTestingThat(same).isNotEqualTo(same);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[a, q]> is not equal to <[a, q]>");
@@ -97,5 +97,9 @@ public class PrimitiveCharArraySubjectTest extends BaseSubjectTestCase {
 
   private static char[] array(char... ts) {
     return ts;
+  }
+
+  private PrimitiveCharArraySubject expectFailureWhenTestingThat(char[] actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/PrimitiveDoubleArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveDoubleArraySubjectTest.java
@@ -78,7 +78,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_WithoutToleranceParameter_Fail_NotEqual() {
-    expectFailure.whenTesting().that(array(2.2d)).isEqualTo(array(OVER_2POINT2));
+    expectFailureWhenTestingThat(array(2.2d)).isEqualTo(array(OVER_2POINT2));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -87,7 +87,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_WithoutToleranceParameter_Fail_DifferentOrder() {
-    expectFailure.whenTesting().that(array(2.2d, 3.3d)).isEqualTo(array(3.3d, 2.2d));
+    expectFailureWhenTestingThat(array(2.2d, 3.3d)).isEqualTo(array(3.3d, 2.2d));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[2.2, 3.3]> is equal to <[3.3, 2.2]>. differs at index: [0]");
@@ -95,7 +95,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_WithoutToleranceParameter_Fail_Longer() {
-    expectFailure.whenTesting().that(array(2.2d, 3.3d)).isEqualTo(array(2.2d, 3.3d, 4.4d));
+    expectFailureWhenTestingThat(array(2.2d, 3.3d)).isEqualTo(array(2.2d, 3.3d, 4.4d));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -105,7 +105,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_WithoutToleranceParameter_Fail_Shorter() {
-    expectFailure.whenTesting().that(array(2.2d, 3.3d)).isEqualTo(array(2.2d));
+    expectFailureWhenTestingThat(array(2.2d, 3.3d)).isEqualTo(array(2.2d));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -115,7 +115,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_WithoutToleranceParameter_Fail_PlusMinusZero() {
-    expectFailure.whenTesting().that(array(0.0d)).isEqualTo(array(-0.0d));
+    expectFailureWhenTestingThat(array(0.0d)).isEqualTo(array(-0.0d));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[0.0]> is equal to <[-0.0]>. differs at index: [0]");
@@ -123,14 +123,12 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_WithoutToleranceParameter_Fail_NotAnArray() {
-    expectFailure.whenTesting().that(array(2.2d, 3.3d, 4.4d)).isEqualTo(new Object());
+    expectFailureWhenTestingThat(array(2.2d, 3.3d, 4.4d)).isEqualTo(new Object());
   }
 
   @Test
   public void isNotEqualTo_WithoutToleranceParameter_FailEquals() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2d, 5.4d, POSITIVE_INFINITY, NEGATIVE_INFINITY))
+    expectFailureWhenTestingThat(array(2.2d, 5.4d, POSITIVE_INFINITY, NEGATIVE_INFINITY))
         .isNotEqualTo(array(2.2d, 5.4d, POSITIVE_INFINITY, NEGATIVE_INFINITY));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -141,9 +139,8 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isNotEqualTo_WithoutToleranceParameter_NaN_plusZero_FailEquals() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2d, 5.4d, POSITIVE_INFINITY, NEGATIVE_INFINITY, NaN, 0.0, -0.0))
+    expectFailureWhenTestingThat(
+            array(2.2d, 5.4d, POSITIVE_INFINITY, NEGATIVE_INFINITY, NaN, 0.0, -0.0))
         .isNotEqualTo(array(2.2d, 5.4d, POSITIVE_INFINITY, NEGATIVE_INFINITY, NaN, 0.0, -0.0));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -194,9 +191,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOf_FailNotQuiteApproximatelyEquals() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2d, 3.3d))
+    expectFailureWhenTestingThat(array(2.2d, 3.3d))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .of(2.2d, INTOLERABLE_3POINT3);
     assertThat(expectFailure.getFailure())
@@ -211,9 +206,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOf_Fail_DifferentOrder() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2d, 3.3d))
+    expectFailureWhenTestingThat(array(2.2d, 3.3d))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .of(3.3d, 2.2d);
     assertThat(expectFailure.getFailure())
@@ -227,9 +220,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOf_Fail_Longer() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2d, 3.3d))
+    expectFailureWhenTestingThat(array(2.2d, 3.3d))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .of(2.2d, 3.3d, 1.1d);
     assertThat(expectFailure.getFailure())
@@ -243,7 +234,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOf_Fail_Shorter() {
-    expectFailure.whenTesting().that(array(2.2d, 3.3d)).hasValuesWithin(DEFAULT_TOLERANCE).of(2.2d);
+    expectFailureWhenTestingThat(array(2.2d, 3.3d)).hasValuesWithin(DEFAULT_TOLERANCE).of(2.2d);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -255,9 +246,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOf_Fail_Infinity() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2d, POSITIVE_INFINITY))
+    expectFailureWhenTestingThat(array(2.2d, POSITIVE_INFINITY))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .of(2.2d, POSITIVE_INFINITY);
     assertThat(expectFailure.getFailure())
@@ -272,7 +261,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
   @Test
   public void hasValuesWithinOf_Fail_SameInfinity() {
     double[] same = array(2.2d, POSITIVE_INFINITY);
-    expectFailure.whenTesting().that(same).hasValuesWithin(DEFAULT_TOLERANCE).of(same);
+    expectFailureWhenTestingThat(same).hasValuesWithin(DEFAULT_TOLERANCE).of(same);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -284,9 +273,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOf_Fail_OneInfinity() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2d, 3.3d))
+    expectFailureWhenTestingThat(array(2.2d, 3.3d))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .of(2.2d, POSITIVE_INFINITY);
     assertThat(expectFailure.getFailure())
@@ -300,9 +287,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOf_Fail_LongerOneInfinity() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2d, 3.3d))
+    expectFailureWhenTestingThat(array(2.2d, 3.3d))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .of(POSITIVE_INFINITY);
     assertThat(expectFailure.getFailure())
@@ -316,7 +301,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOf_Fail_NaN() {
-    expectFailure.whenTesting().that(array(NaN)).hasValuesWithin(DEFAULT_TOLERANCE).of(NaN);
+    expectFailureWhenTestingThat(array(NaN)).hasValuesWithin(DEFAULT_TOLERANCE).of(NaN);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -386,9 +371,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOfElementsIn_FailNotQuiteApproximatelyEquals() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2d, 3.3d))
+    expectFailureWhenTestingThat(array(2.2d, 3.3d))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Doubles.asList(2.2d, INTOLERABLE_3POINT3));
     assertThat(expectFailure.getFailure())
@@ -403,9 +386,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOfElementsIn_Fail_DifferentOrder() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2d, 3.3d))
+    expectFailureWhenTestingThat(array(2.2d, 3.3d))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Doubles.asList(3.3d, 2.2d));
     assertThat(expectFailure.getFailure())
@@ -419,9 +400,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOfElementsIn_Fail_Longer() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2d, 3.3d))
+    expectFailureWhenTestingThat(array(2.2d, 3.3d))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Doubles.asList(2.2d, 3.3d, 1.1d));
     assertThat(expectFailure.getFailure())
@@ -435,9 +414,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOfElementsIn_Fail_Shorter() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2d, 3.3d))
+    expectFailureWhenTestingThat(array(2.2d, 3.3d))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Doubles.asList(2.2d));
     assertThat(expectFailure.getFailure())
@@ -451,9 +428,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOfElementsIn_Fail_Infinity() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2d, POSITIVE_INFINITY))
+    expectFailureWhenTestingThat(array(2.2d, POSITIVE_INFINITY))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Doubles.asList(2.2d, POSITIVE_INFINITY));
     assertThat(expectFailure.getFailure())
@@ -467,9 +442,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOfElementsIn_Fail_OneInfinity() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2d, 3.3d))
+    expectFailureWhenTestingThat(array(2.2d, 3.3d))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Doubles.asList(2.2d, POSITIVE_INFINITY));
     assertThat(expectFailure.getFailure())
@@ -483,9 +456,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOfElementsIn_Fail_LongerOneInfinity() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2d, 3.3d))
+    expectFailureWhenTestingThat(array(2.2d, 3.3d))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Doubles.asList(POSITIVE_INFINITY));
     assertThat(expectFailure.getFailure())
@@ -499,9 +470,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOfElementsIn_Fail_NaN() {
-    expectFailure
-        .whenTesting()
-        .that(array(NaN))
+    expectFailureWhenTestingThat(array(NaN))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Doubles.asList(NaN));
     assertThat(expectFailure.getFailure())
@@ -562,9 +531,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
   @Test
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOf_FailEquals() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2d, 3.3d))
+    expectFailureWhenTestingThat(array(2.2d, 3.3d))
         .hasValuesNotWithin(DEFAULT_TOLERANCE)
         .of(2.2d, 3.3d);
     assertThat(expectFailure.getFailure())
@@ -578,9 +545,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
   @Test
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOf_FailApproximatelyEquals() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2d, 3.3d))
+    expectFailureWhenTestingThat(array(2.2d, 3.3d))
         .hasValuesNotWithin(DEFAULT_TOLERANCE)
         .of(2.2d, TOLERABLE_3POINT3);
     assertThat(expectFailure.getFailure())
@@ -605,7 +570,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOf_FailSame() {
     double[] same = array(2.2d, 3.3d);
-    expectFailure.whenTesting().that(same).hasValuesNotWithin(DEFAULT_TOLERANCE).of(same);
+    expectFailureWhenTestingThat(same).hasValuesNotWithin(DEFAULT_TOLERANCE).of(same);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -617,9 +582,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
   @Test
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOf_Fail_Infinity() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2d, POSITIVE_INFINITY))
+    expectFailureWhenTestingThat(array(2.2d, POSITIVE_INFINITY))
         .hasValuesNotWithin(DEFAULT_TOLERANCE)
         .of(2.2d, POSITIVE_INFINITY);
     assertThat(expectFailure.getFailure())
@@ -635,7 +598,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOf_Fail_SameInfinity() {
     double[] same = array(2.2d, POSITIVE_INFINITY);
-    expectFailure.whenTesting().that(same).hasValuesNotWithin(DEFAULT_TOLERANCE).of(same);
+    expectFailureWhenTestingThat(same).hasValuesNotWithin(DEFAULT_TOLERANCE).of(same);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -648,9 +611,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
   @Test
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOf_OneInfinity() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2d, 3.3d))
+    expectFailureWhenTestingThat(array(2.2d, 3.3d))
         .hasValuesNotWithin(DEFAULT_TOLERANCE)
         .of(2.2d, POSITIVE_INFINITY);
     assertThat(expectFailure.getFailure())
@@ -671,7 +632,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
   @Test
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOf_Fail_NaN() {
-    expectFailure.whenTesting().that(array(NaN)).hasValuesNotWithin(DEFAULT_TOLERANCE).of(NaN);
+    expectFailureWhenTestingThat(array(NaN)).hasValuesNotWithin(DEFAULT_TOLERANCE).of(NaN);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -746,9 +707,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
   @Test
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOfElementsIn_FailEquals() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2d, 3.3d))
+    expectFailureWhenTestingThat(array(2.2d, 3.3d))
         .hasValuesNotWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Doubles.asList(2.2d, 3.3d));
     assertThat(expectFailure.getFailure())
@@ -762,9 +721,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
   @Test
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOfElementsIn_FailApproximatelyEquals() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2d, 3.3d))
+    expectFailureWhenTestingThat(array(2.2d, 3.3d))
         .hasValuesNotWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Doubles.asList(2.2d, TOLERABLE_3POINT3));
     assertThat(expectFailure.getFailure())
@@ -788,9 +745,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
   @Test
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOfElementsIn_Fail_Infinity() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2d, POSITIVE_INFINITY))
+    expectFailureWhenTestingThat(array(2.2d, POSITIVE_INFINITY))
         .hasValuesNotWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Doubles.asList(2.2d, POSITIVE_INFINITY));
     assertThat(expectFailure.getFailure())
@@ -805,9 +760,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
   @Test
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOfElementsIn_OneInfinity() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2d, 3.3d))
+    expectFailureWhenTestingThat(array(2.2d, 3.3d))
         .hasValuesNotWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Doubles.asList(2.2d, POSITIVE_INFINITY));
     assertThat(expectFailure.getFailure())
@@ -830,9 +783,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
   @Test
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOfElementsIn_Fail_NaN() {
-    expectFailure
-        .whenTesting()
-        .that(array(NaN))
+    expectFailureWhenTestingThat(array(NaN))
         .hasValuesNotWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Doubles.asList(NaN));
     assertThat(expectFailure.getFailure())
@@ -892,9 +843,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingTolerance_contains_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.1, INTOLERABLE_2POINT2, 3.3))
+    expectFailureWhenTestingThat(array(1.1, INTOLERABLE_2POINT2, 3.3))
         .usingTolerance(DEFAULT_TOLERANCE)
         .contains(2.2);
     assertThat(expectFailure.getFailure())
@@ -909,9 +858,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingTolerance_contains_failureWithInfinity() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.1, POSITIVE_INFINITY, 3.3))
+    expectFailureWhenTestingThat(array(1.1, POSITIVE_INFINITY, 3.3))
         .usingTolerance(DEFAULT_TOLERANCE)
         .contains(POSITIVE_INFINITY);
     assertThat(expectFailure.getFailure())
@@ -926,9 +873,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingTolerance_contains_failureWithNaN() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.1, NaN, 3.3))
+    expectFailureWhenTestingThat(array(1.1, NaN, 3.3))
         .usingTolerance(DEFAULT_TOLERANCE)
         .contains(NaN);
     assertThat(expectFailure.getFailure())
@@ -1009,9 +954,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingTolerance_containsAllOf_primitiveDoubleArray_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.1, TOLERABLE_2POINT2, 3.3))
+    expectFailureWhenTestingThat(array(1.1, TOLERABLE_2POINT2, 3.3))
         .usingTolerance(DEFAULT_TOLERANCE)
         .containsAllOf(array(2.2, 99.99));
     assertThat(expectFailure.getFailure())
@@ -1038,9 +981,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingTolerance_containsAllOf_primitiveDoubleArray_inOrder_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.1, TOLERABLE_2POINT2, 3.3))
+    expectFailureWhenTestingThat(array(1.1, TOLERABLE_2POINT2, 3.3))
         .usingTolerance(DEFAULT_TOLERANCE)
         .containsAllOf(array(2.2, 1.1))
         .inOrder();
@@ -1064,9 +1005,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingTolerance_containsAnyOf_primitiveDoubleArray_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.1, TOLERABLE_2POINT2, 3.3))
+    expectFailureWhenTestingThat(array(1.1, TOLERABLE_2POINT2, 3.3))
         .usingTolerance(DEFAULT_TOLERANCE)
         .containsAnyOf(array(99.99, 999.999));
     assertThat(expectFailure.getFailure())
@@ -1088,9 +1027,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingTolerance_containsExactly_primitiveDoubleArray_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.1, TOLERABLE_2POINT2, 3.3))
+    expectFailureWhenTestingThat(array(1.1, TOLERABLE_2POINT2, 3.3))
         .usingTolerance(DEFAULT_TOLERANCE)
         .containsExactly(array(2.2, 1.1));
     assertThat(expectFailure.getFailure())
@@ -1113,9 +1050,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingTolerance_containsExactly_primitiveDoubleArray_inOrder_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.1, TOLERABLE_2POINT2, 3.3))
+    expectFailureWhenTestingThat(array(1.1, TOLERABLE_2POINT2, 3.3))
         .usingTolerance(DEFAULT_TOLERANCE)
         .containsExactly(array(2.2, 1.1, 3.3))
         .inOrder();
@@ -1139,9 +1074,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingTolerance_containsNoneOf_primitiveDoubleArray_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.1, TOLERABLE_2POINT2, 3.3))
+    expectFailureWhenTestingThat(array(1.1, TOLERABLE_2POINT2, 3.3))
         .usingTolerance(DEFAULT_TOLERANCE)
         .containsNoneOf(array(99.99, 2.2));
     assertThat(expectFailure.getFailure())
@@ -1163,11 +1096,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingExactEquality_contains_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.1, OVER_2POINT2, 3.3))
-        .usingExactEquality()
-        .contains(2.2);
+    expectFailureWhenTestingThat(array(1.1, OVER_2POINT2, 3.3)).usingExactEquality().contains(2.2);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -1235,7 +1164,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingExactEquality_contains_failureWithNegativeZero() {
-    expectFailure.whenTesting().that(array(1.1, -0.0, 3.3)).usingExactEquality().contains(0.0);
+    expectFailureWhenTestingThat(array(1.1, -0.0, 3.3)).usingExactEquality().contains(0.0);
     /*
      * TODO(cpovirk): Find a way to print "0.0" rather than 0 in the error, even under GWT. One
      * easy(?) hack would be to make UsingCorrespondence use Platform.doubleToString() when
@@ -1268,9 +1197,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingExactEquality_containsAllOf_primitiveDoubleArray_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.1, 2.2, 3.3))
+    expectFailureWhenTestingThat(array(1.1, 2.2, 3.3))
         .usingExactEquality()
         .containsAllOf(array(2.2, 99.99));
     assertThat(expectFailure.getFailure())
@@ -1289,9 +1216,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingExactEquality_containsAllOf_primitiveDoubleArray_inOrder_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.1, 2.2, 3.3))
+    expectFailureWhenTestingThat(array(1.1, 2.2, 3.3))
         .usingExactEquality()
         .containsAllOf(array(2.2, 1.1))
         .inOrder();
@@ -1310,9 +1235,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingExactEquality_containsAnyOf_primitiveDoubleArray_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.1, 2.2, 3.3))
+    expectFailureWhenTestingThat(array(1.1, 2.2, 3.3))
         .usingExactEquality()
         .containsAnyOf(array(99.99, 999.999));
     assertThat(expectFailure.getFailure())
@@ -1330,9 +1253,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingExactEquality_containsExactly_primitiveDoubleArray_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.1, 2.2, 3.3))
+    expectFailureWhenTestingThat(array(1.1, 2.2, 3.3))
         .usingExactEquality()
         .containsExactly(array(2.2, 1.1));
     assertThat(expectFailure.getFailure())
@@ -1353,9 +1274,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingExactEquality_containsExactly_primitiveDoubleArray_inOrder_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.1, 2.2, 3.3))
+    expectFailureWhenTestingThat(array(1.1, 2.2, 3.3))
         .usingExactEquality()
         .containsExactly(array(2.2, 1.1, 3.3))
         .inOrder();
@@ -1374,9 +1293,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingExactEquality_containsNoneOf_primitiveDoubleArray_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.1, 2.2, 3.3))
+    expectFailureWhenTestingThat(array(1.1, 2.2, 3.3))
         .usingExactEquality()
         .containsNoneOf(array(99.99, 2.2));
     assertThat(expectFailure.getFailure())
@@ -1389,16 +1306,14 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void smallDifferenceInLongRepresentation() {
-    expectFailure
-        .whenTesting()
-        .that(array(-4.4501477170144023E-308))
+    expectFailureWhenTestingThat(array(-4.4501477170144023E-308))
         .isEqualTo(array(-4.450147717014402E-308));
   }
 
   @Test
   public void noCommas() {
     // Maybe we should include commas, but we don't yet, so make sure we don't under GWT, either.
-    expectFailure.whenTesting().that(array(10000.0)).isEqualTo(array(20000.0));
+    expectFailureWhenTestingThat(array(10000.0)).isEqualTo(array(20000.0));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[10000.0]> is equal to <[20000.0]>. differs at index: [0]");
@@ -1406,5 +1321,9 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   private static double[] array(double... primitives) {
     return primitives;
+  }
+
+  private PrimitiveDoubleArraySubject expectFailureWhenTestingThat(double[] actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/PrimitiveFloatArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveFloatArraySubjectTest.java
@@ -72,7 +72,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_WithoutToleranceParameter_Fail_NotEqual() {
-    expectFailure.whenTesting().that(array(2.2f)).isEqualTo(array(JUST_OVER_2POINT2));
+    expectFailureWhenTestingThat(array(2.2f)).isEqualTo(array(JUST_OVER_2POINT2));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -83,7 +83,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_WithoutToleranceParameter_Fail_DifferentOrder() {
-    expectFailure.whenTesting().that(array(2.2f, 3.3f)).isEqualTo(array(3.3f, 2.2f));
+    expectFailureWhenTestingThat(array(2.2f, 3.3f)).isEqualTo(array(3.3f, 2.2f));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -100,7 +100,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_WithoutToleranceParameter_Fail_Longer() {
-    expectFailure.whenTesting().that(array(2.2f, 3.3f)).isEqualTo(array(2.2f, 3.3f, 4.4f));
+    expectFailureWhenTestingThat(array(2.2f, 3.3f)).isEqualTo(array(2.2f, 3.3f, 4.4f));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -119,7 +119,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_WithoutToleranceParameter_Fail_Shorter() {
-    expectFailure.whenTesting().that(array(2.2f, 3.3f)).isEqualTo(array(2.2f));
+    expectFailureWhenTestingThat(array(2.2f, 3.3f)).isEqualTo(array(2.2f));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -134,7 +134,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_WithoutToleranceParameter_Fail_PlusMinusZero() {
-    expectFailure.whenTesting().that(array(0.0f)).isEqualTo(array(-0.0f));
+    expectFailureWhenTestingThat(array(0.0f)).isEqualTo(array(-0.0f));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[0.0]> is equal to <[-0.0]>. differs at index: [0]");
@@ -142,14 +142,13 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_WithoutToleranceParameter_Fail_NotAnArray() {
-    expectFailure.whenTesting().that(array(2.2f, 3.3f, 4.4f)).isEqualTo(new Object());
+    expectFailureWhenTestingThat(array(2.2f, 3.3f, 4.4f)).isEqualTo(new Object());
   }
 
   @Test
   public void isNotEqualTo_WithoutToleranceParameter_FailEquals() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2f, 5.4f, POSITIVE_INFINITY, NEGATIVE_INFINITY, NaN, 0.0f, -0.0f))
+    expectFailureWhenTestingThat(
+            array(2.2f, 5.4f, POSITIVE_INFINITY, NEGATIVE_INFINITY, NaN, 0.0f, -0.0f))
         .isNotEqualTo(array(2.2f, 5.4f, POSITIVE_INFINITY, NEGATIVE_INFINITY, NaN, 0.0f, -0.0f));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -207,9 +206,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOf_FailNotQuiteApproximatelyEquals() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2f, 3.3f))
+    expectFailureWhenTestingThat(array(2.2f, 3.3f))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .of(2.2f, INTOLERABLE_3POINT3);
     assertThat(expectFailure.getFailure())
@@ -223,9 +220,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOf_Fail_DifferentOrder() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2f, 3.3f))
+    expectFailureWhenTestingThat(array(2.2f, 3.3f))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .of(3.3f, 2.2f);
     assertThat(expectFailure.getFailure())
@@ -239,9 +234,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOf_Fail_Longer() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2f, 3.3f))
+    expectFailureWhenTestingThat(array(2.2f, 3.3f))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .of(2.2f, 3.3f, 1.1f);
     assertThat(expectFailure.getFailure())
@@ -255,7 +248,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOf_Fail_Shorter() {
-    expectFailure.whenTesting().that(array(2.2f, 3.3f)).hasValuesWithin(DEFAULT_TOLERANCE).of(2.2f);
+    expectFailureWhenTestingThat(array(2.2f, 3.3f)).hasValuesWithin(DEFAULT_TOLERANCE).of(2.2f);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -267,9 +260,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOf_Fail_Infinity() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2f, POSITIVE_INFINITY))
+    expectFailureWhenTestingThat(array(2.2f, POSITIVE_INFINITY))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .of(2.2f, POSITIVE_INFINITY);
     assertThat(expectFailure.getFailure())
@@ -284,7 +275,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
   @Test
   public void hasValuesWithinOf_Fail_SameInfinity() {
     float[] same = array(2.2f, POSITIVE_INFINITY);
-    expectFailure.whenTesting().that(same).hasValuesWithin(DEFAULT_TOLERANCE).of(same);
+    expectFailureWhenTestingThat(same).hasValuesWithin(DEFAULT_TOLERANCE).of(same);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -296,9 +287,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOf_Fail_OneInfinity() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2f, 3.3f))
+    expectFailureWhenTestingThat(array(2.2f, 3.3f))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .of(2.2f, POSITIVE_INFINITY);
     assertThat(expectFailure.getFailure())
@@ -312,9 +301,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOf_Fail_LongerOneInfinity() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2f, 3.3f))
+    expectFailureWhenTestingThat(array(2.2f, 3.3f))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .of(POSITIVE_INFINITY);
     assertThat(expectFailure.getFailure())
@@ -328,7 +315,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOf_Fail_NaN() {
-    expectFailure.whenTesting().that(array(NaN)).hasValuesWithin(DEFAULT_TOLERANCE).of(NaN);
+    expectFailureWhenTestingThat(array(NaN)).hasValuesWithin(DEFAULT_TOLERANCE).of(NaN);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -400,9 +387,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOfElementsIn_FailNotQuiteApproximatelyEquals() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2f, 3.3f))
+    expectFailureWhenTestingThat(array(2.2f, 3.3f))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Floats.asList(2.2f, INTOLERABLE_3POINT3));
     assertThat(expectFailure.getFailure())
@@ -416,9 +401,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOfElementsIn_Fail_DifferentOrder() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2f, 3.3f))
+    expectFailureWhenTestingThat(array(2.2f, 3.3f))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Floats.asList(3.3f, 2.2f));
     assertThat(expectFailure.getFailure())
@@ -432,9 +415,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOfElementsIn_Fail_Longer() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2f, 3.3f))
+    expectFailureWhenTestingThat(array(2.2f, 3.3f))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Floats.asList(2.2f, 3.3f, 1.1f));
     assertThat(expectFailure.getFailure())
@@ -448,9 +429,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOfElementsIn_Fail_Shorter() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2f, 3.3f))
+    expectFailureWhenTestingThat(array(2.2f, 3.3f))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Floats.asList(2.2f));
     assertThat(expectFailure.getFailure())
@@ -464,9 +443,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOfElementsIn_Fail_Infinity() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2f, POSITIVE_INFINITY))
+    expectFailureWhenTestingThat(array(2.2f, POSITIVE_INFINITY))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Floats.asList(2.2f, POSITIVE_INFINITY));
     assertThat(expectFailure.getFailure())
@@ -480,9 +457,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOfElementsIn_Fail_OneInfinity() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2f, 3.3f))
+    expectFailureWhenTestingThat(array(2.2f, 3.3f))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Floats.asList(2.2f, POSITIVE_INFINITY));
     assertThat(expectFailure.getFailure())
@@ -496,9 +471,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOfElementsIn_Fail_LongerOneInfinity() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2f, 3.3f))
+    expectFailureWhenTestingThat(array(2.2f, 3.3f))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Floats.asList(POSITIVE_INFINITY));
     assertThat(expectFailure.getFailure())
@@ -512,9 +485,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasValuesWithinOfElementsIn_Fail_NaN() {
-    expectFailure
-        .whenTesting()
-        .that(array(NaN))
+    expectFailureWhenTestingThat(array(NaN))
         .hasValuesWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Floats.asList(NaN));
     assertThat(expectFailure.getFailure())
@@ -577,9 +548,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
   @Test
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOf_FailEquals() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2f, 3.3f))
+    expectFailureWhenTestingThat(array(2.2f, 3.3f))
         .hasValuesNotWithin(DEFAULT_TOLERANCE)
         .of(2.2f, 3.3f);
     assertThat(expectFailure.getFailure())
@@ -593,9 +562,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
   @Test
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOf_FailApproximatelyEquals() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2f, 3.3f))
+    expectFailureWhenTestingThat(array(2.2f, 3.3f))
         .hasValuesNotWithin(DEFAULT_TOLERANCE)
         .of(2.2f, TOLERABLE_3POINT3);
     assertThat(expectFailure.getFailure())
@@ -618,7 +585,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOf_FailSame() {
     float[] same = array(2.2f, 3.3f);
-    expectFailure.whenTesting().that(same).hasValuesNotWithin(DEFAULT_TOLERANCE).of(same);
+    expectFailureWhenTestingThat(same).hasValuesNotWithin(DEFAULT_TOLERANCE).of(same);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -630,9 +597,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
   @Test
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOf_Fail_Infinity() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2f, POSITIVE_INFINITY))
+    expectFailureWhenTestingThat(array(2.2f, POSITIVE_INFINITY))
         .hasValuesNotWithin(DEFAULT_TOLERANCE)
         .of(2.2f, POSITIVE_INFINITY);
     assertThat(expectFailure.getFailure())
@@ -647,7 +612,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOf_Fail_SameInfinity() {
     float[] same = array(2.2f, POSITIVE_INFINITY);
-    expectFailure.whenTesting().that(same).hasValuesNotWithin(DEFAULT_TOLERANCE).of(same);
+    expectFailureWhenTestingThat(same).hasValuesNotWithin(DEFAULT_TOLERANCE).of(same);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -659,9 +624,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
   @Test
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOf_OneInfinity() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2f, 3.3f))
+    expectFailureWhenTestingThat(array(2.2f, 3.3f))
         .hasValuesNotWithin(DEFAULT_TOLERANCE)
         .of(2.2f, POSITIVE_INFINITY);
     assertThat(expectFailure.getFailure())
@@ -681,7 +644,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
   @Test
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOf_Fail_NaN() {
-    expectFailure.whenTesting().that(array(NaN)).hasValuesNotWithin(DEFAULT_TOLERANCE).of(NaN);
+    expectFailureWhenTestingThat(array(NaN)).hasValuesNotWithin(DEFAULT_TOLERANCE).of(NaN);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -758,9 +721,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
   @Test
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOfElementsIn_FailEquals() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2f, 3.3f))
+    expectFailureWhenTestingThat(array(2.2f, 3.3f))
         .hasValuesNotWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Floats.asList(2.2f, 3.3f));
     assertThat(expectFailure.getFailure())
@@ -774,9 +735,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
   @Test
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOfElementsIn_FailApproximatelyEquals() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2f, 3.3f))
+    expectFailureWhenTestingThat(array(2.2f, 3.3f))
         .hasValuesNotWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Floats.asList(2.2f, TOLERABLE_3POINT3));
     assertThat(expectFailure.getFailure())
@@ -798,9 +757,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
   @Test
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOfElementsIn_Fail_Infinity() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2f, POSITIVE_INFINITY))
+    expectFailureWhenTestingThat(array(2.2f, POSITIVE_INFINITY))
         .hasValuesNotWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Floats.asList(2.2f, POSITIVE_INFINITY));
     assertThat(expectFailure.getFailure())
@@ -814,9 +771,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
   @Test
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOfElementsIn_OneInfinity() {
-    expectFailure
-        .whenTesting()
-        .that(array(2.2f, 3.3f))
+    expectFailureWhenTestingThat(array(2.2f, 3.3f))
         .hasValuesNotWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Floats.asList(2.2f, POSITIVE_INFINITY));
     assertThat(expectFailure.getFailure())
@@ -838,9 +793,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
   @Test
   @SuppressWarnings("deprecation") // testing deprecated method
   public void hasValuesNotWithinOfElementsIn_Fail_NaN() {
-    expectFailure
-        .whenTesting()
-        .that(array(NaN))
+    expectFailureWhenTestingThat(array(NaN))
         .hasValuesNotWithin(DEFAULT_TOLERANCE)
         .ofElementsIn(Floats.asList(NaN));
     assertThat(expectFailure.getFailure())
@@ -902,9 +855,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingTolerance_contains_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.0f, INTOLERABLE_TWO, 3.0f))
+    expectFailureWhenTestingThat(array(1.0f, INTOLERABLE_TWO, 3.0f))
         .usingTolerance(DEFAULT_TOLERANCE)
         .contains(2.0f);
     assertThat(expectFailure.getFailure())
@@ -919,9 +870,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingTolerance_contains_failureWithInfinity() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.0f, POSITIVE_INFINITY, 3.0f))
+    expectFailureWhenTestingThat(array(1.0f, POSITIVE_INFINITY, 3.0f))
         .usingTolerance(DEFAULT_TOLERANCE)
         .contains(POSITIVE_INFINITY);
     assertThat(expectFailure.getFailure())
@@ -936,9 +885,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingTolerance_contains_failureWithNaN() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.0f, NaN, 3.0f))
+    expectFailureWhenTestingThat(array(1.0f, NaN, 3.0f))
         .usingTolerance(DEFAULT_TOLERANCE)
         .contains(NaN);
     assertThat(expectFailure.getFailure())
@@ -1022,9 +969,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingTolerance_containsAllOf_primitiveFloatArray_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.0f, TOLERABLE_TWO, 3.0f))
+    expectFailureWhenTestingThat(array(1.0f, TOLERABLE_TWO, 3.0f))
         .usingTolerance(DEFAULT_TOLERANCE)
         .containsAllOf(array(2.0f, 99.99f));
     assertThat(expectFailure.getFailure())
@@ -1055,9 +1000,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingTolerance_containsAllOf_primitiveFloatArray_inOrder_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.0f, TOLERABLE_TWO, 3.0f))
+    expectFailureWhenTestingThat(array(1.0f, TOLERABLE_TWO, 3.0f))
         .usingTolerance(DEFAULT_TOLERANCE)
         .containsAllOf(array(2.0f, 1.0f))
         .inOrder();
@@ -1080,9 +1023,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingTolerance_containsAnyOf_primitiveFloatArray_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.0f, TOLERABLE_TWO, 3.0f))
+    expectFailureWhenTestingThat(array(1.0f, TOLERABLE_TWO, 3.0f))
         .usingTolerance(DEFAULT_TOLERANCE)
         .containsAnyOf(array(99.99f, 999.999f));
     assertThat(expectFailure.getFailure())
@@ -1104,9 +1045,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingTolerance_containsExactly_primitiveFloatArray_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.0f, TOLERABLE_TWO, 3.0f))
+    expectFailureWhenTestingThat(array(1.0f, TOLERABLE_TWO, 3.0f))
         .usingTolerance(DEFAULT_TOLERANCE)
         .containsExactly(array(2.0f, 1.0f));
     assertThat(expectFailure.getFailure())
@@ -1130,9 +1069,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingTolerance_containsExactly_primitiveFloatArray_inOrder_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.0f, TOLERABLE_TWO, 3.0f))
+    expectFailureWhenTestingThat(array(1.0f, TOLERABLE_TWO, 3.0f))
         .usingTolerance(DEFAULT_TOLERANCE)
         .containsExactly(array(2.0f, 1.0f, 3.0f))
         .inOrder();
@@ -1155,9 +1092,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingTolerance_containsNoneOf_primitiveFloatArray_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.0f, TOLERABLE_TWO, 3.0f))
+    expectFailureWhenTestingThat(array(1.0f, TOLERABLE_TWO, 3.0f))
         .usingTolerance(DEFAULT_TOLERANCE)
         .containsNoneOf(array(99.99f, 2.0f));
     assertThat(expectFailure.getFailure())
@@ -1184,9 +1119,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingExactEquality_contains_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.0f, JUST_OVER_2POINT2, 3.0f))
+    expectFailureWhenTestingThat(array(1.0f, JUST_OVER_2POINT2, 3.0f))
         .usingExactEquality()
         .contains(2.2f);
     assertThat(expectFailure.getFailure())
@@ -1278,7 +1211,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingExactEquality_contains_failureWithNegativeZero() {
-    expectFailure.whenTesting().that(array(1.0f, -0.0f, 3.0f)).usingExactEquality().contains(0.0f);
+    expectFailureWhenTestingThat(array(1.0f, -0.0f, 3.0f)).usingExactEquality().contains(0.0f);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -1305,9 +1238,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingExactEquality_containsAllOf_primitiveFloatArray_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.0f, 2.0f, 3.0f))
+    expectFailureWhenTestingThat(array(1.0f, 2.0f, 3.0f))
         .usingExactEquality()
         .containsAllOf(array(2.0f, 99.99f));
     assertThat(expectFailure.getFailure())
@@ -1331,9 +1262,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingExactEquality_containsAllOf_primitiveFloatArray_inOrder_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.0f, 2.0f, 3.0f))
+    expectFailureWhenTestingThat(array(1.0f, 2.0f, 3.0f))
         .usingExactEquality()
         .containsAllOf(array(2.0f, 1.0f))
         .inOrder();
@@ -1354,9 +1283,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingExactEquality_containsAnyOf_primitiveFloatArray_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.0f, 2.0f, 3.0f))
+    expectFailureWhenTestingThat(array(1.0f, 2.0f, 3.0f))
         .usingExactEquality()
         .containsAnyOf(array(99.99f, 999.999f));
     assertThat(expectFailure.getFailure())
@@ -1378,9 +1305,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingExactEquality_containsExactly_primitiveFloatArray_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.0f, 2.0f, 3.0f))
+    expectFailureWhenTestingThat(array(1.0f, 2.0f, 3.0f))
         .usingExactEquality()
         .containsExactly(array(2.0f, 1.0f));
     assertThat(expectFailure.getFailure())
@@ -1403,9 +1328,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingExactEquality_containsExactly_primitiveFloatArray_inOrder_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.0f, 2.0f, 3.0f))
+    expectFailureWhenTestingThat(array(1.0f, 2.0f, 3.0f))
         .usingExactEquality()
         .containsExactly(array(2.0f, 1.0f, 3.0f))
         .inOrder();
@@ -1428,9 +1351,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingExactEquality_containsNoneOf_primitiveFloatArray_failure() {
-    expectFailure
-        .whenTesting()
-        .that(array(1.0f, 2.0f, 3.0f))
+    expectFailureWhenTestingThat(array(1.0f, 2.0f, 3.0f))
         .usingExactEquality()
         .containsNoneOf(array(99.99f, 2.0f));
     assertThat(expectFailure.getFailure())
@@ -1445,5 +1366,9 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
 
   private static float[] array(float... primitives) {
     return primitives;
+  }
+
+  private PrimitiveFloatArraySubject expectFailureWhenTestingThat(float[] actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/PrimitiveIntArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveIntArraySubjectTest.java
@@ -56,7 +56,7 @@ public class PrimitiveIntArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasLengthFail() {
-    expectFailure.whenTesting().that(array(2, 5)).hasLength(1);
+    expectFailureWhenTestingThat(array(2, 5)).hasLength(1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[2, 5]> has length <1>");
@@ -78,7 +78,7 @@ public class PrimitiveIntArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEmptyFail() {
-    expectFailure.whenTesting().that(array(2, 5)).isEmpty();
+    expectFailureWhenTestingThat(array(2, 5)).isEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[2, 5]> is empty");
@@ -91,7 +91,7 @@ public class PrimitiveIntArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isNotEmptyFail() {
-    expectFailure.whenTesting().that(EMPTY).isNotEmpty();
+    expectFailureWhenTestingThat(EMPTY).isNotEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[]> is not empty");
@@ -99,7 +99,7 @@ public class PrimitiveIntArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_Fail_UnequalOrdering() {
-    expectFailure.whenTesting().that(array(2, 3)).isEqualTo(array(3, 2));
+    expectFailureWhenTestingThat(array(2, 3)).isEqualTo(array(3, 2));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[2, 3]> is equal to <[3, 2]>. differs at index: [0]");
@@ -107,7 +107,7 @@ public class PrimitiveIntArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_Fail_NotAnArray() {
-    expectFailure.whenTesting().that(array(2, 3, 4)).isEqualTo(new Object());
+    expectFailureWhenTestingThat(array(2, 3, 4)).isEqualTo(new Object());
   }
 
   @Test
@@ -127,7 +127,7 @@ public class PrimitiveIntArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isNotEqualTo_FailEquals() {
-    expectFailure.whenTesting().that(array(2, 3)).isNotEqualTo(array(2, 3));
+    expectFailureWhenTestingThat(array(2, 3)).isNotEqualTo(array(2, 3));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[2, 3]> is not equal to <[2, 3]>");
@@ -137,7 +137,7 @@ public class PrimitiveIntArraySubjectTest extends BaseSubjectTestCase {
   @Test
   public void isNotEqualTo_FailSame() {
     int[] same = array(2, 3);
-    expectFailure.whenTesting().that(same).isNotEqualTo(same);
+    expectFailureWhenTestingThat(same).isNotEqualTo(same);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[2, 3]> is not equal to <[2, 3]>");
@@ -145,5 +145,9 @@ public class PrimitiveIntArraySubjectTest extends BaseSubjectTestCase {
 
   private static int[] array(int... ts) {
     return ts;
+  }
+
+  private PrimitiveIntArraySubject expectFailureWhenTestingThat(int[] actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/PrimitiveLongArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveLongArraySubjectTest.java
@@ -48,7 +48,7 @@ public class PrimitiveLongArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_Fail_UnequalOrdering() {
-    expectFailure.whenTesting().that(array(2, 3)).isEqualTo(array(3, 2));
+    expectFailureWhenTestingThat(array(2, 3)).isEqualTo(array(3, 2));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[2, 3]> is equal to <[3, 2]>. differs at index: [0]");
@@ -56,7 +56,7 @@ public class PrimitiveLongArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_Fail_NotAnArray() {
-    expectFailure.whenTesting().that(array(2, 3, 4)).isEqualTo(new int[] {});
+    expectFailureWhenTestingThat(array(2, 3, 4)).isEqualTo(new int[] {});
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .contains("wrong type; expected: int[]; but was: long[]");
@@ -79,7 +79,7 @@ public class PrimitiveLongArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isNotEqualTo_FailEquals() {
-    expectFailure.whenTesting().that(array(2, 3)).isNotEqualTo(array(2, 3));
+    expectFailureWhenTestingThat(array(2, 3)).isNotEqualTo(array(2, 3));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[2, 3]> is not equal to <[2, 3]>");
@@ -89,7 +89,7 @@ public class PrimitiveLongArraySubjectTest extends BaseSubjectTestCase {
   @Test
   public void isNotEqualTo_FailSame() {
     long[] same = array(2, 3);
-    expectFailure.whenTesting().that(same).isNotEqualTo(same);
+    expectFailureWhenTestingThat(same).isNotEqualTo(same);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[2, 3]> is not equal to <[2, 3]>");
@@ -97,5 +97,9 @@ public class PrimitiveLongArraySubjectTest extends BaseSubjectTestCase {
 
   private static long[] array(long... ts) {
     return ts;
+  }
+
+  private PrimitiveLongArraySubject expectFailureWhenTestingThat(long[] actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/PrimitiveShortArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveShortArraySubjectTest.java
@@ -48,7 +48,7 @@ public class PrimitiveShortArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void asListWithoutCastingFails() {
-    expectFailure.whenTesting().that(array(1, 1, 0)).asList().containsAllOf(1, 0);
+    expectFailureWhenTestingThat(array(1, 1, 0)).asList().containsAllOf(1, 0);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -60,7 +60,7 @@ public class PrimitiveShortArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_Fail_UnequalOrdering() {
-    expectFailure.whenTesting().that(array(1, 0, 1)).isEqualTo(array(0, 1, 1));
+    expectFailureWhenTestingThat(array(1, 0, 1)).isEqualTo(array(0, 1, 1));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[1, 0, 1]> is equal to <[0, 1, 1]>. differs at index: [0]");
@@ -68,7 +68,7 @@ public class PrimitiveShortArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isEqualTo_Fail_NotAnArray() {
-    expectFailure.whenTesting().that(array(1, 0, 1)).isEqualTo(new Object());
+    expectFailureWhenTestingThat(array(1, 0, 1)).isEqualTo(new Object());
   }
 
   @Test
@@ -88,7 +88,7 @@ public class PrimitiveShortArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void isNotEqualTo_FailEquals() {
-    expectFailure.whenTesting().that(array(1, 0)).isNotEqualTo(array(1, 0));
+    expectFailureWhenTestingThat(array(1, 0)).isNotEqualTo(array(1, 0));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[1, 0]> is not equal to <[1, 0]>");
@@ -98,7 +98,7 @@ public class PrimitiveShortArraySubjectTest extends BaseSubjectTestCase {
   @Test
   public void isNotEqualTo_FailSame() {
     short[] same = array(1, 0);
-    expectFailure.whenTesting().that(same).isNotEqualTo(same);
+    expectFailureWhenTestingThat(same).isNotEqualTo(same);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[1, 0]> is not equal to <[1, 0]>");
@@ -110,5 +110,9 @@ public class PrimitiveShortArraySubjectTest extends BaseSubjectTestCase {
 
   private static short[] array(int a, int b) {
     return new short[] {(short) a, (short) b};
+  }
+
+  private PrimitiveShortArraySubject expectFailureWhenTestingThat(short[] actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/SortedMapSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/SortedMapSubjectTest.java
@@ -69,7 +69,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastKey_empty_1() {
-    expectFailure.whenTesting().that(ImmutableSortedMap.of()).hasFirstKey(1);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of()).hasFirstKey(1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{}> has first key <1>");
@@ -77,7 +77,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastKey_empty_2() {
-    expectFailure.whenTesting().that(ImmutableSortedMap.of()).hasLastKey(1);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of()).hasLastKey(1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{}> has last key <1>");
@@ -85,7 +85,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastKey_empty_3() {
-    expectFailure.whenTesting().that(ImmutableSortedMap.of()).hasFirstKey(null);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of()).hasFirstKey(null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{}> has first key <null>");
@@ -93,7 +93,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastKey_empty_4() {
-    expectFailure.whenTesting().that(ImmutableSortedMap.of()).hasLastKey(null);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of()).hasLastKey(null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{}> has last key <null>");
@@ -101,7 +101,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastKey_wrongPosition_1() {
-    expectFailure.whenTesting().that(ImmutableSortedMap.of(0, 0, 1, 0, 2, 0)).hasFirstKey(1);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of(0, 0, 1, 0, 2, 0)).hasFirstKey(1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -111,7 +111,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastKey_wrongPosition_2() {
-    expectFailure.whenTesting().that(ImmutableSortedMap.of(0, 0, 1, 0, 2, 0)).hasLastKey(1);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of(0, 0, 1, 0, 2, 0)).hasLastKey(1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -121,7 +121,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastKey_absent_1() {
-    expectFailure.whenTesting().that(ImmutableSortedMap.of(0, 0)).hasFirstKey(1);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of(0, 0)).hasFirstKey(1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -131,7 +131,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastKey_absent_2() {
-    expectFailure.whenTesting().that(ImmutableSortedMap.of(0, 0)).hasLastKey(1);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of(0, 0)).hasLastKey(1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -155,7 +155,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastEntry_empty() {
-    expectFailure.whenTesting().that(ImmutableSortedMap.of()).hasFirstEntry(1, 0);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of()).hasFirstEntry(1, 0);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{}> has first entry <1=0>");
@@ -164,7 +164,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void hasFirstLastEntry_empty_2() {
 
-    expectFailure.whenTesting().that(ImmutableSortedMap.of()).hasLastEntry(1, 0);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of()).hasLastEntry(1, 0);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{}> has last entry <1=0>");
@@ -172,7 +172,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastEntry_empty_3() {
-    expectFailure.whenTesting().that(ImmutableSortedMap.of()).hasFirstEntry(null, null);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of()).hasFirstEntry(null, null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{}> has first entry <null=null>");
@@ -180,7 +180,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastEntry_empty_4() {
-    expectFailure.whenTesting().that(ImmutableSortedMap.of()).hasLastEntry(null, null);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of()).hasLastEntry(null, null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{}> has last entry <null=null>");
@@ -188,7 +188,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastEntry_wrongPosition() {
-    expectFailure.whenTesting().that(ImmutableSortedMap.of(0, 0, 1, 0, 2, 0)).hasFirstEntry(1, 0);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of(0, 0, 1, 0, 2, 0)).hasFirstEntry(1, 0);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -198,7 +198,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastEntry_wrongPosition_2() {
-    expectFailure.whenTesting().that(ImmutableSortedMap.of(0, 0, 1, 0, 2, 0)).hasLastEntry(1, 0);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of(0, 0, 1, 0, 2, 0)).hasLastEntry(1, 0);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -208,7 +208,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastEntry_wrongKey() {
-    expectFailure.whenTesting().that(ImmutableSortedMap.of(1, 0, 2, 0)).hasFirstEntry(0, 0);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of(1, 0, 2, 0)).hasFirstEntry(0, 0);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{1=0, 2=0}> has first entry <0=0>, the first key is <1>");
@@ -216,7 +216,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastEntry_wrongKey_2() {
-    expectFailure.whenTesting().that(ImmutableSortedMap.of(1, 0, 2, 0)).hasLastEntry(0, 0);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of(1, 0, 2, 0)).hasLastEntry(0, 0);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{1=0, 2=0}> has last entry <0=0>, the last key is <2>");
@@ -224,7 +224,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastEntry_wrongValue() {
-    expectFailure.whenTesting().that(ImmutableSortedMap.of(1, 0, 2, 0)).hasFirstEntry(1, 1);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of(1, 0, 2, 0)).hasFirstEntry(1, 1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{1=0, 2=0}> has first entry <1=1>, the first value is <0>");
@@ -232,7 +232,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastEntry_wrongValue_2() {
-    expectFailure.whenTesting().that(ImmutableSortedMap.of(1, 0, 2, 0)).hasLastEntry(2, 2);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of(1, 0, 2, 0)).hasLastEntry(2, 2);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{1=0, 2=0}> has last entry <2=2>, the last value is <0>");
@@ -240,7 +240,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastEntry_keyWrongPosition() {
-    expectFailure.whenTesting().that(ImmutableSortedMap.of(0, 0, 1, 0, 2, 0)).hasFirstEntry(1, 1);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of(0, 0, 1, 0, 2, 0)).hasFirstEntry(1, 1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -250,7 +250,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastEntry_keyWrongPosition_2() {
-    expectFailure.whenTesting().that(ImmutableSortedMap.of(0, 0, 1, 0, 2, 0)).hasLastEntry(1, 1);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of(0, 0, 1, 0, 2, 0)).hasLastEntry(1, 1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -260,7 +260,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastEntry_valueWrongPosition() {
-    expectFailure.whenTesting().that(ImmutableSortedMap.of(0, 0, 1, 1, 2, 2)).hasFirstEntry(10, 1);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of(0, 0, 1, 1, 2, 2)).hasFirstEntry(10, 1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -270,7 +270,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastEntry_valueWrongPosition_2() {
-    expectFailure.whenTesting().that(ImmutableSortedMap.of(0, 0, 1, 1, 2, 2)).hasLastEntry(10, 1);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of(0, 0, 1, 1, 2, 2)).hasLastEntry(10, 1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -280,9 +280,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastEntry_multipleValuesWrongPosition() {
-    expectFailure
-        .whenTesting()
-        .that(ImmutableSortedMap.of(0, 0, 1, 1, 2, 1, 3, 3))
+    expectFailureWhenTestingThat(ImmutableSortedMap.of(0, 0, 1, 1, 2, 1, 3, 3))
         .hasFirstEntry(10, 1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
@@ -294,10 +292,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastEntry_multipleValuesWrongPosition_2() {
-    expectFailure
-        .whenTesting()
-        .that(ImmutableSortedMap.of(0, 0, 1, 1, 2, 1, 3, 3))
-        .hasLastEntry(10, 1);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of(0, 0, 1, 1, 2, 1, 3, 3)).hasLastEntry(10, 1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -308,7 +303,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastEntry_absent() {
-    expectFailure.whenTesting().that(ImmutableSortedMap.of(1, 0)).hasFirstEntry(2, 2);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of(1, 0)).hasFirstEntry(2, 2);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -318,11 +313,15 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastEntry_absent_2() {
-    expectFailure.whenTesting().that(ImmutableSortedMap.of(1, 0)).hasLastEntry(2, 2);
+    expectFailureWhenTestingThat(ImmutableSortedMap.of(1, 0)).hasLastEntry(2, 2);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
             "Not true that <{1=0}> has last entry <2=2>. "
                 + "It does not contain this entry, and the last entry is <1=0>");
+  }
+
+  private SortedMapSubject expectFailureWhenTestingThat(SortedMap<?, ?> actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/SortedSetSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/SortedSetSubjectTest.java
@@ -69,7 +69,7 @@ public class SortedSetSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastElement_empty() {
-    expectFailure.whenTesting().that(ImmutableSortedSet.of()).hasFirstElement(1);
+    expectFailureWhenTestingThat(ImmutableSortedSet.of()).hasFirstElement(1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[]> has first element <1>");
@@ -77,7 +77,7 @@ public class SortedSetSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastElement_empty_2() {
-    expectFailure.whenTesting().that(ImmutableSortedSet.of()).hasLastElement(1);
+    expectFailureWhenTestingThat(ImmutableSortedSet.of()).hasLastElement(1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[]> has last element <1>");
@@ -85,7 +85,7 @@ public class SortedSetSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastElement_empty_3() {
-    expectFailure.whenTesting().that(ImmutableSortedSet.of()).hasFirstElement(null);
+    expectFailureWhenTestingThat(ImmutableSortedSet.of()).hasFirstElement(null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[]> has first element <null>");
@@ -93,7 +93,7 @@ public class SortedSetSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastElement_empty_4() {
-    expectFailure.whenTesting().that(ImmutableSortedSet.of()).hasLastElement(null);
+    expectFailureWhenTestingThat(ImmutableSortedSet.of()).hasLastElement(null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <[]> has last element <null>");
@@ -101,7 +101,7 @@ public class SortedSetSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastElement_wrongPosition() {
-    expectFailure.whenTesting().that(ImmutableSortedSet.of(0, 1, 2)).hasFirstElement(1);
+    expectFailureWhenTestingThat(ImmutableSortedSet.of(0, 1, 2)).hasFirstElement(1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -111,7 +111,7 @@ public class SortedSetSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastElement_wrongPosition_2() {
-    expectFailure.whenTesting().that(ImmutableSortedSet.of(0, 1, 2)).hasLastElement(1);
+    expectFailureWhenTestingThat(ImmutableSortedSet.of(0, 1, 2)).hasLastElement(1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -121,7 +121,7 @@ public class SortedSetSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastElement_absent() {
-    expectFailure.whenTesting().that(ImmutableSortedSet.of(0)).hasFirstElement(1);
+    expectFailureWhenTestingThat(ImmutableSortedSet.of(0)).hasFirstElement(1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -131,11 +131,15 @@ public class SortedSetSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasFirstLastElement_absent_2() {
-    expectFailure.whenTesting().that(ImmutableSortedSet.of(0)).hasLastElement(1);
+    expectFailureWhenTestingThat(ImmutableSortedSet.of(0)).hasLastElement(1);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
             "Not true that <[0]> has last element <1>. "
                 + "It does not contain this element, and the last element is <0>");
+  }
+
+  private SortedSetSubject expectFailureWhenTestingThat(SortedSet<?> actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/StringSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/StringSubjectTest.java
@@ -46,7 +46,7 @@ public class StringSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasLengthFails() {
-    expectFailure.whenTesting().that("kurt").hasLength(5);
+    expectFailureWhenTestingThat("kurt").hasLength(5);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <\"kurt\"> has a length of 5. It is 4.");
@@ -68,7 +68,7 @@ public class StringSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void stringIsEmptyFail() {
-    expectFailure.whenTesting().that("abc").isEmpty();
+    expectFailureWhenTestingThat("abc").isEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <\"abc\"> is empty");
@@ -76,8 +76,7 @@ public class StringSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void stringIsEmptyFailNull() {
-    String s = null;
-    expectFailure.whenTesting().that(s).isEmpty();
+    expectFailureWhenTestingThat(null).isEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that null reference is empty");
@@ -90,7 +89,7 @@ public class StringSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void stringIsNotEmptyFail() {
-    expectFailure.whenTesting().that("").isNotEmpty();
+    expectFailureWhenTestingThat("").isNotEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <\"\"> is not empty");
@@ -98,8 +97,7 @@ public class StringSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void stringIsNotEmptyFailNull() {
-    String s = null;
-    expectFailure.whenTesting().that(s).isNotEmpty();
+    expectFailureWhenTestingThat(null).isNotEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that null reference is not empty");
@@ -118,7 +116,7 @@ public class StringSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void stringContainsFail() {
-    expectFailure.whenTesting().that("abc").contains("d");
+    expectFailureWhenTestingThat("abc").contains("d");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .contains("Not true that <\"abc\"> contains <\"d\">");
@@ -137,7 +135,7 @@ public class StringSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void stringDoesNotContainFail() {
-    expectFailure.whenTesting().that("abc").doesNotContain("b");
+    expectFailureWhenTestingThat("abc").doesNotContain("b");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .contains("<\"abc\"> unexpectedly contains <\"b\">");
@@ -151,7 +149,7 @@ public class StringSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void stringEqualityToNull() {
-    expectFailure.whenTesting().that("abc").isEqualTo(null);
+    expectFailureWhenTestingThat("abc").isEqualTo(null);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .contains("Not true that <\"abc\"> is null");
@@ -194,7 +192,7 @@ public class StringSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void stringNamedNullFail() {
-    expectFailure.whenTesting().that((String) null).named("foo").isEqualTo("abd");
+    expectFailureWhenTestingThat(null).named("foo").isEqualTo("abd");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that foo (<null>) is equal to <\"abd\">");
@@ -203,7 +201,7 @@ public class StringSubjectTest extends BaseSubjectTestCase {
   @GwtIncompatible // ComparisonFailure-style message
   @Test
   public void stringEqualityFailMultiline() {
-    expectFailure.whenTesting().that("abc\ndef\nxyz").isEqualTo("aaa\nqqq\nzzz");
+    expectFailureWhenTestingThat("abc\ndef\nxyz").isEqualTo("aaa\nqqq\nzzz");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("expected:<a[aa\nqqq\nzz]z> but was:<a[bc\ndef\nxy]z>");
@@ -216,7 +214,7 @@ public class StringSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void stringStartsWithFail() {
-    expectFailure.whenTesting().that("abc").startsWith("bc");
+    expectFailureWhenTestingThat("abc").startsWith("bc");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .contains("Not true that <\"abc\"> starts with <\"bc\">");
@@ -229,7 +227,7 @@ public class StringSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void stringEndsWithFail() {
-    expectFailure.whenTesting().that("abc").endsWith("ab");
+    expectFailureWhenTestingThat("abc").endsWith("ab");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .contains("Not true that <\"abc\"> ends with <\"ab\">");
@@ -252,7 +250,7 @@ public class StringSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void stringMatchesStringWithFail() {
-    expectFailure.whenTesting().that("abcaqadev").matches(".*aaa.*");
+    expectFailureWhenTestingThat("abcaqadev").matches(".*aaa.*");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <\"abcaqadev\"> matches <.*aaa.*>");
@@ -267,7 +265,7 @@ public class StringSubjectTest extends BaseSubjectTestCase {
   @Test
   @GwtIncompatible("Pattern")
   public void stringMatchesPatternWithFail() {
-    expectFailure.whenTesting().that("abcaaadev").doesNotMatch(Pattern.compile(".*aaa.*"));
+    expectFailureWhenTestingThat("abcaaadev").doesNotMatch(Pattern.compile(".*aaa.*"));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <\"abcaaadev\"> fails to match <.*aaa.*>");
@@ -284,7 +282,7 @@ public class StringSubjectTest extends BaseSubjectTestCase {
   public void stringContainsMatchString() {
     assertThat("aba").containsMatch(".*b.*");
 
-    expectFailure.whenTesting().that("aaa").containsMatch(".*b.*");
+    expectFailureWhenTestingThat("aaa").containsMatch(".*b.*");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("<\"aaa\"> should have contained a match for <.*b.*>");
@@ -295,7 +293,7 @@ public class StringSubjectTest extends BaseSubjectTestCase {
   public void stringContainsMatchPattern() {
     assertThat("aba").containsMatch(Pattern.compile(".*b.*"));
 
-    expectFailure.whenTesting().that("aaa").containsMatch(Pattern.compile(".*b.*"));
+    expectFailureWhenTestingThat("aaa").containsMatch(Pattern.compile(".*b.*"));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("<\"aaa\"> should have contained a match for <.*b.*>");
@@ -305,7 +303,7 @@ public class StringSubjectTest extends BaseSubjectTestCase {
   public void stringDoesNotContainMatchString() {
     assertThat("aaa").doesNotContainMatch(".*b.*");
 
-    expectFailure.whenTesting().that("aba").doesNotContainMatch(".*b.*");
+    expectFailureWhenTestingThat("aba").doesNotContainMatch(".*b.*");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("<\"aba\"> should not have contained a match for <.*b.*>");
@@ -313,7 +311,7 @@ public class StringSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void stringDoesNotContainMatchStringUsesFind() {
-    expectFailure.whenTesting().that("aba").doesNotContainMatch("[b]");
+    expectFailureWhenTestingThat("aba").doesNotContainMatch("[b]");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("<\"aba\"> should not have contained a match for <[b]>");
@@ -324,9 +322,13 @@ public class StringSubjectTest extends BaseSubjectTestCase {
   public void stringDoesNotContainMatchPattern() {
     assertThat("aaa").doesNotContainMatch(Pattern.compile(".*b.*"));
 
-    expectFailure.whenTesting().that("aba").doesNotContainMatch(Pattern.compile(".*b.*"));
+    expectFailureWhenTestingThat("aba").doesNotContainMatch(Pattern.compile(".*b.*"));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("<\"aba\"> should not have contained a match for <.*b.*>");
+  }
+
+  private StringSubject expectFailureWhenTestingThat(String actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/TableSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/TableSubjectTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Table;
 import com.google.common.collect.Table.Cell;
 import com.google.common.collect.Tables;
 import org.junit.Test;
@@ -42,7 +43,7 @@ public class TableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void tableIsEmptyWithFailure() {
     ImmutableTable<Integer, Integer, Integer> table = ImmutableTable.of(1, 5, 7);
-    expectFailure.whenTesting().that(table).isEmpty();
+    expectFailureWhenTestingThat(table).isEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{1={5=7}}> is empty");
@@ -57,7 +58,7 @@ public class TableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void tableIsNotEmptyWithFailure() {
     ImmutableTable<Integer, Integer, Integer> table = ImmutableTable.of();
-    expectFailure.whenTesting().that(table).isNotEmpty();
+    expectFailureWhenTestingThat(table).isNotEmpty();
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{}> is not empty");
@@ -91,7 +92,7 @@ public class TableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void containsFailure() {
     ImmutableTable<String, String, String> table = ImmutableTable.of("row", "col", "val");
-    expectFailure.whenTesting().that(table).contains("row", "row");
+    expectFailureWhenTestingThat(table).contains("row", "row");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{row={col=val}}> contains mapping for row/column <row> <row>");
@@ -109,7 +110,7 @@ public class TableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void doesNotContainFailure() {
     ImmutableTable<String, String, String> table = ImmutableTable.of("row", "col", "val");
-    expectFailure.whenTesting().that(table).doesNotContain("row", "col");
+    expectFailureWhenTestingThat(table).doesNotContain("row", "col");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
@@ -127,7 +128,7 @@ public class TableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void containsCellFailure() {
     ImmutableTable<String, String, String> table = ImmutableTable.of("row", "col", "val");
-    expectFailure.whenTesting().that(table).containsCell("row", "row", "val");
+    expectFailureWhenTestingThat(table).containsCell("row", "row", "val");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{row={col=val}}> contains cell <(row,row)=val>");
@@ -149,7 +150,7 @@ public class TableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void doesNotContainCellFailure() {
     ImmutableTable<String, String, String> table = ImmutableTable.of("row", "col", "val");
-    expectFailure.whenTesting().that(table).doesNotContainCell("row", "col", "val");
+    expectFailureWhenTestingThat(table).doesNotContainCell("row", "col", "val");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo("Not true that <{row={col=val}}> does not contain cell <(row,col)=val>");
@@ -157,5 +158,9 @@ public class TableSubjectTest extends BaseSubjectTestCase {
 
   private static <R, C, V> Cell<R, C, V> cell(R row, C col, V val) {
     return Tables.immutableCell(row, col, val);
+  }
+
+  private TableSubject expectFailureWhenTestingThat(Table actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/ThrowableSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/ThrowableSubjectTest.java
@@ -52,7 +52,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void hasMessageThat_failure() {
     NullPointerException actual = new NullPointerException("message");
-    expectFailure.whenTesting().that(actual).hasMessageThat().isEqualTo("foobar");
+    expectFailureWhenTestingThat(actual).hasMessageThat().isEqualTo("foobar");
     assertThat(expectFailure.getFailure().getMessage())
         .isEqualTo("value of: throwable.getMessage(): expected:<[foobar]> but was:<[message]>");
     assertErrorHasActualAsCause(actual, expectFailure.getFailure());
@@ -60,7 +60,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void hasMessageThat_MessageHasNullMessage_failure() {
-    expectFailure.whenTesting().that(new NullPointerException("message")).hasMessageThat().isNull();
+    expectFailureWhenTestingThat(new NullPointerException("message")).hasMessageThat().isNull();
     assertThat(expectFailure.getFailure().getMessage())
         .isEqualTo("value of: throwable.getMessage(): Not true that <\"message\"> is null");
   }
@@ -68,7 +68,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void hasMessageThat_Named_failure() {
     NullPointerException npe = new NullPointerException("message");
-    expectFailure.whenTesting().that(npe).named("NPE").hasMessageThat().isEqualTo("foobar");
+    expectFailureWhenTestingThat(npe).named("NPE").hasMessageThat().isEqualTo("foobar");
     assertThat(expectFailure.getFailure().getMessage())
         .isEqualTo("value of: NPE.getMessage(): expected:<[foobar]> but was:<[message]>");
   }
@@ -76,7 +76,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void hasMessageThat_NullMessageHasMessage_failure() {
     NullPointerException npe = new NullPointerException(null);
-    expectFailure.whenTesting().that(npe).hasMessageThat().isEqualTo("message");
+    expectFailureWhenTestingThat(npe).hasMessageThat().isEqualTo("message");
     assertThat(expectFailure.getFailure().getMessage())
         .isEqualTo(
             "value of: throwable.getMessage(): Not true that <null> is equal to <\"message\">");
@@ -105,7 +105,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void hasCauseThat_message_failure() {
     Exception actual = new Exception("foobar", new IOException("barfoo"));
-    expectFailure.whenTesting().that(actual).hasCauseThat().hasMessageThat().isEqualTo("message");
+    expectFailureWhenTestingThat(actual).hasCauseThat().hasMessageThat().isEqualTo("message");
     assertThat(expectFailure.getFailure().getMessage())
         .isEqualTo(
             "value of: throwable.getCause().getMessage(): expected:<[message]> but was:<[barfoo]>");
@@ -115,7 +115,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void hasCauseThat_instanceOf_failure() {
     Exception actual = new Exception("foobar", new IOException("barfoo"));
-    expectFailure.whenTesting().that(actual).hasCauseThat().isInstanceOf(RuntimeException.class);
+    expectFailureWhenTestingThat(actual).hasCauseThat().isInstanceOf(RuntimeException.class);
     assertThat(expectFailure.getFailure().getMessage())
         .isEqualTo(
             "value of: throwable.getCause(): Not true that <java.io.IOException: "
@@ -127,7 +127,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void hasCauseThat_tooDeep_failure() {
     Exception actual = new Exception("foobar");
-    expectFailure.whenTesting().that(actual).hasCauseThat().hasCauseThat().isNull();
+    expectFailureWhenTestingThat(actual).hasCauseThat().hasCauseThat().isNull();
     assertThat(expectFailure.getFailure().getMessage())
         .isEqualTo(
             "value of: throwable.getCause().getCause(): "
@@ -139,9 +139,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
   public void hasCauseThat_deepNull_failure() {
     Exception actual =
         new Exception("foobar", new RuntimeException("barfoo", new IOException("buzz")));
-    expectFailure
-        .whenTesting()
-        .that(actual)
+    expectFailureWhenTestingThat(actual)
         .hasCauseThat()
         .hasCauseThat()
         .hasMessageThat()
@@ -157,11 +155,15 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
   public void inheritedMethodChainsSubject() {
     NullPointerException expected = new NullPointerException("expected");
     NullPointerException actual = new NullPointerException("actual");
-    expectFailure.whenTesting().that(actual).isEqualTo(expected);
+    expectFailureWhenTestingThat(actual).isEqualTo(expected);
     assertErrorHasActualAsCause(actual, expectFailure.getFailure());
   }
 
   private static void assertErrorHasActualAsCause(Throwable actual, AssertionError failure) {
     assertThat(failure.getCause()).named("AssertionError's cause").isEqualTo(actual);
+  }
+
+  private ThrowableSubject expectFailureWhenTestingThat(Throwable actual) {
+    return expectFailure.whenTesting().that(actual);
   }
 }

--- a/core/src/test/java/com/google/common/truth/super/com/google/common/truth/PlatformBaseSubjectTestCase.java
+++ b/core/src/test/java/com/google/common/truth/super/com/google/common/truth/PlatformBaseSubjectTestCase.java
@@ -18,7 +18,7 @@ package com.google.common.truth;
 import org.junit.After;
 import org.junit.Before;
 
-public abstract class BaseSubjectTestCase {
+public abstract class PlatformBaseSubjectTestCase {
 
   final ExpectFailure expectFailure = new ExpectFailure();
 

--- a/extensions/java8/src/test/java/com/google/common/truth/OptionalSubjectTest.java
+++ b/extensions/java8/src/test/java/com/google/common/truth/OptionalSubjectTest.java
@@ -32,15 +32,6 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class OptionalSubjectTest {
-  @Test
-  public void namedOptional() {
-    Optional<String> optional = Optional.of("actual");
-    AssertionError expected =
-        expectFailure(whenTesting -> whenTesting.that(optional).named("name").hasValue("expected"));
-    assertThat(expected)
-        .hasMessageThat()
-        .isEqualTo("Not true that name (<Optional[actual]>) has value <expected>");
-  }
 
   @Test
   public void isPresent() {
@@ -55,7 +46,7 @@ public class OptionalSubjectTest {
   }
 
   @Test
-  public void isPresentFailingWithNamed() {
+  public void isPresentFailing_named() {
     AssertionError expected =
         expectFailure(whenTesting -> whenTesting.that(Optional.empty()).named("name").isPresent());
     assertThat(expected).hasMessageThat().isEqualTo("Not true that \"name\" is present");
@@ -91,7 +82,7 @@ public class OptionalSubjectTest {
   }
 
   @Test
-  public void hasValue_FailingWithEmpty() {
+  public void hasValue_failingWithEmpty() {
     AssertionError expected =
         expectFailure(whenTesting -> whenTesting.that(Optional.empty()).hasValue("foo"));
     assertThat(expected)
@@ -100,7 +91,7 @@ public class OptionalSubjectTest {
   }
 
   @Test
-  public void hasValue_NPEWithNullParameter() {
+  public void hasValue_npeWithNullParameter() {
     try {
       assertThat(Optional.of("foo")).hasValue(null);
       fail("Expected NPE");
@@ -110,7 +101,7 @@ public class OptionalSubjectTest {
   }
 
   @Test
-  public void hasValue_FailingWithWrongValueForString() {
+  public void hasValue_failingWithWrongValueForString() {
     AssertionError expected =
         expectFailure(whenTesting -> whenTesting.that(Optional.of("foo")).hasValue("boo"));
     assertThat(expected)
@@ -119,14 +110,7 @@ public class OptionalSubjectTest {
   }
 
   @Test
-  public void hasValue_FailingWithWrongValueForOther() {
-    AssertionError expected =
-        expectFailure(whenTesting -> whenTesting.that(Optional.of(5)).hasValue(10));
-    assertThat(expected).hasMessageThat().isEqualTo("Not true that <Optional[5]> has value <10>");
-  }
-
-  @Test
-  public void hasValue_Named_Failing() {
+  public void hasValue_failingWithWrongValueForString_named() {
     AssertionError expected =
         expectFailure(
             whenTesting -> whenTesting.that(Optional.of("foo")).named("bar").hasValue("boo"));
@@ -136,7 +120,25 @@ public class OptionalSubjectTest {
   }
 
   @Test
-  public void hasValue_Named_FailingWithSameToStrings() {
+  public void hasValue_failingWithWrongValueForOther() {
+    AssertionError expected =
+        expectFailure(whenTesting -> whenTesting.that(Optional.of(5)).hasValue(10));
+    assertThat(expected).hasMessageThat().isEqualTo("Not true that <Optional[5]> has value <10>");
+  }
+
+  @Test
+  public void hasValue_failingWithSameToStrings() {
+    AssertionError expected =
+        expectFailure(whenTesting -> whenTesting.that(Optional.of(10)).hasValue("10"));
+    assertThat(expected)
+        .hasMessageThat()
+        .isEqualTo(
+            "Not true that <Optional[10]> (class java.lang.Integer) "
+                + "has value <10> (class java.lang.String)");
+  }
+
+  @Test
+  public void hasValue_failingWithSameToStrings_named() {
     AssertionError expected =
         expectFailure(whenTesting -> whenTesting.that(Optional.of(10)).named("bar").hasValue("10"));
     assertThat(expected)


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Minor cleanups to GuavaOptionalSubjectTest:

- Delete namedOptional(), which is redundant with hasValue_Named_Failing().

- Move each named() test to come immediately after the corresponding non-named() test and have the same method name but with "_named" at the end.

- Correct "_Foo" to "_foo," as required by the style guide.

902fc50e1cf363ee9b468fa026f877e77c72af9f

-------

<p> Add a tiny helper method.

It saves 2 characters, but mostly it's about avoiding the need to cast null or extract a variable for it.

0e2070e919af3669a335a4402d6d63be456c7db1

-------

<p> Add a package-private ErrorWithFields interface.

This lets our forthcoming tests access fields without caring which type of AssertionError was thrown.
(I'm probably going to put in some special cases for ComparisonFailureWithFields, anyway, but the 2 classes are still mostly the same.)

885652d6a7f6ecc0b6dd4139605940068100fadf

-------

<p> Split BaseSubjectTestCase into 2 parts:

- PlatformBaseSubjectTestCase, the part that has separate implementations for GWT and non-GWT.
- BaseSubjectTestCase, the part that will soon contain helper methods.

359199de2ab6215e200908b8dff4b9be791394ff

-------

<p> More expectFailureWhenTesting() helpers.

Besides simplifying things for null, the helper also prevents us from needing 3 lines (expectFailure, whenTesting, that) when google-java-format puts each call on its own line.

It also identified a least one test (and maybe others; I forget) that wassn't testing what it appears to be: ComparableSubjectTest.isEquivalentAccordingToCompareTo() was testing BigDecimalSubject, not ComparableSubjectTest.

Finally, this prompted me to remove a bunch of duplicate tests in IntegerSubjectTest, to reorganize it to match LongSubjectTest, and to move a few tests from the former to the latter.

(I grant that, for some tests, there's little to no improvement, but it didn't seem worth trying to pick and choose where to add the helper and where not to, especially since it's hard to predict when we'll have bugs like the one in ComparableSubjectTest.)

c8b7335cd95de1863fa60005c84aa834c89c5dd6

-------

<p> Minor cleanups to OptionalSubjectTest.

This is just like what bbd289b1b11bd1c290500b24ec570ac4be3f8326 did to GuavaOptionalSubjectTest, plus a few more changes to bring the two files in line with one another.

d78c8528b41c1063ac63924ebed4203000d6773a