### PR TITLE
Moe Sync

### DIFF
--- a/core/src/test/java/com/google/common/truth/IterableSubjectCorrespondenceTest.java
+++ b/core/src/test/java/com/google/common/truth/IterableSubjectCorrespondenceTest.java
@@ -21,6 +21,7 @@ import static com.google.common.truth.Correspondence.tolerance;
 import static com.google.common.truth.TestCorrespondences.PARSED_RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10;
 import static com.google.common.truth.TestCorrespondences.PARSED_RECORD_ID;
 import static com.google.common.truth.TestCorrespondences.RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10;
+import static com.google.common.truth.TestCorrespondences.RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10_NO_DIFF;
 import static com.google.common.truth.TestCorrespondences.RECORD_ID;
 import static com.google.common.truth.TestCorrespondences.STRING_PARSES_TO_INTEGER_CORRESPONDENCE;
 import static com.google.common.truth.TestCorrespondences.WITHIN_10_OF;
@@ -379,6 +380,94 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
                 + "with key 2, and is missing an element that corresponds to each of "
                 + "<[3/300, none/900]> and has unexpected elements <[4/400, none/999]> without "
                 + "matching keys");
+  }
+
+  @Test
+  public void comparingElementsUsing_displayingDiffsPairedBy_containsExactlyElementsIn_onlyKeyed() {
+    ImmutableList<Record> expected =
+        ImmutableList.of(
+            Record.create(1, 100),
+            Record.create(2, 200),
+            Record.create(3, 300),
+            Record.createWithoutId(999));
+    ImmutableList<Record> actual =
+        ImmutableList.of(
+            Record.create(1, 100),
+            Record.create(2, 211),
+            Record.create(3, 303),
+            Record.createWithoutId(999));
+    expectFailure
+        .whenTesting()
+        .that(actual)
+        .comparingElementsUsing(RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10)
+        .displayingDiffsPairedBy(RECORD_ID)
+        .containsExactlyElementsIn(expected);
+    assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .isEqualTo(
+            "Not true that <[1/100, 2/211, 3/303, none/999]> contains exactly one element that has "
+                + "the same id as and a score is within 10 of each element of "
+                + "<[1/100, 2/200, 3/300, none/999]>. It is missing an element that corresponds to "
+                + "<2/200> and has unexpected elements <[2/211 (diff: score:11)]> with key 2");
+  }
+
+  @Test
+  public void comparingElementsUsing_displayingDiffsPairedBy_containsExactlyElementsIn_noKeyed() {
+    ImmutableList<Record> expected =
+        ImmutableList.of(
+            Record.create(1, 100),
+            Record.create(2, 200),
+            Record.create(3, 300),
+            Record.createWithoutId(900));
+    ImmutableList<Record> actual =
+        ImmutableList.of(
+            Record.create(1, 100),
+            Record.create(2, 201),
+            Record.create(4, 400),
+            Record.createWithoutId(999));
+    expectFailure
+        .whenTesting()
+        .that(actual)
+        .comparingElementsUsing(RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10)
+        .displayingDiffsPairedBy(RECORD_ID)
+        .containsExactlyElementsIn(expected);
+    assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .isEqualTo(
+            "Not true that <[1/100, 2/201, 4/400, none/999]> contains exactly one element that has "
+                + "the same id as and a score is within 10 of each element of "
+                + "<[1/100, 2/200, 3/300, none/900]>. It is missing an element that corresponds "
+                + "to each of <[3/300, none/900]> and has unexpected elements "
+                + "<[4/400, none/999]> without matching keys");
+  }
+
+  @Test
+  public void comparingElementsUsing_displayingDiffsPairedBy_containsExactlyElementsIn_noDiffs() {
+    ImmutableList<Record> expected =
+        ImmutableList.of(
+            Record.create(1, 100),
+            Record.create(2, 200),
+            Record.create(3, 300),
+            Record.createWithoutId(999));
+    ImmutableList<Record> actual =
+        ImmutableList.of(
+            Record.create(1, 100),
+            Record.create(2, 211),
+            Record.create(3, 303),
+            Record.createWithoutId(999));
+    expectFailure
+        .whenTesting()
+        .that(actual)
+        .comparingElementsUsing(RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10_NO_DIFF)
+        .displayingDiffsPairedBy(RECORD_ID)
+        .containsExactlyElementsIn(expected);
+    assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .isEqualTo(
+            "Not true that <[1/100, 2/211, 3/303, none/999]> contains exactly one element that has "
+                + "the same id as and a score is within 10 of each element of "
+                + "<[1/100, 2/200, 3/300, none/999]>. It is missing an element that corresponds to "
+                + "<2/200> and has unexpected elements <[2/211]> with key 2");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/TestCorrespondences.java
+++ b/core/src/test/java/com/google/common/truth/TestCorrespondences.java
@@ -166,6 +166,28 @@ final class TestCorrespondences {
     }
   }
 
+  private static class RecordCorrespondence extends Correspondence<Record, Record> {
+
+    @Override
+    public boolean compare(Record actual, Record expected) {
+      return actual.hasSameId(expected) && Math.abs(actual.getScore() - expected.getScore()) <= 10;
+    }
+
+    @Override
+    public String formatDiff(Record actual, Record expected) {
+      if (actual.hasId() && expected.hasId() && actual.getId() == expected.getId()) {
+        return "score:" + Integer.toString(actual.getScore() - expected.getScore());
+      } else {
+        return null;
+      }
+    }
+
+    @Override
+    public String toString() {
+      return "has the same id as and a score is within 10 of";
+    }
+  }
+
   /**
    * A correspondence between {@link Record} instances which tests whether their {@code id} values
    * are equal and their {@code score} values are within 10 of each other. Smart diffing is enabled
@@ -174,26 +196,15 @@ final class TestCorrespondences {
    * not support null records.
    */
   static final Correspondence<Record, Record> RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10 =
-      new Correspondence<Record, Record>() {
+      new RecordCorrespondence();
 
-        @Override
-        public boolean compare(Record actual, Record expected) {
-          return actual.hasSameId(expected)
-              && Math.abs(actual.getScore() - expected.getScore()) <= 10;
-        }
+  /** Like {@link #RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10} but with no smart diffing. */
+  static final Correspondence<Record, Record> RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10_NO_DIFF =
+      new RecordCorrespondence() {
 
         @Override
         public String formatDiff(Record actual, Record expected) {
-          if (actual.hasId() && expected.hasId() && actual.getId() == expected.getId()) {
-            return "score:" + Integer.toString(actual.getScore() - expected.getScore());
-          } else {
-            return null;
-          }
-        }
-
-        @Override
-        public String toString() {
-          return "has the same id as and a score is within 10 of";
+          return null;
         }
       };
 
@@ -222,7 +233,7 @@ final class TestCorrespondences {
 
         @Override
         public String toString() {
-          return "parses to a record that " + RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10.toString();
+          return "parses to a record that " + RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10;
         }
       };
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add a few missing tests for comparingElementsUsing.displayingDiffsPairedBy.containsExactlyElementsIn.

9d4daeb794bd9810711caa8f3ee56e85afd5a4af