### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/Correspondence.java
+++ b/core/src/main/java/com/google/common/truth/Correspondence.java
@@ -103,11 +103,6 @@ public abstract class Correspondence<A, E> {
    * <p>The implementation on the {@link Correspondence} base class always returns {@code null}. To
    * enable diffing, subclasses should override this method.
    *
-   * <p>N.B. Implementing this method is currently of limited value as not all the assertions which
-   * could make use of this do so. However, instances that implement it now will get those
-   * improvements for free when they are made. TODO(b/32960783): Implement the rest of the planned
-   * changes.
-   *
    * <p>Assertions should only invoke this with parameters for which {@link #compare} returns {@code
    * false}.
    */

--- a/core/src/test/java/com/google/common/truth/IterableSubjectCorrespondenceTest.java
+++ b/core/src/test/java/com/google/common/truth/IterableSubjectCorrespondenceTest.java
@@ -766,6 +766,61 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
   }
 
   @Test
+  public void comparingElementsUsing_displayingElementsPairedBy_containsAllIn() {
+    ImmutableList<Record> expected =
+        ImmutableList.of(Record.create(1, 100), Record.create(2, 200), Record.createWithoutId(999));
+    ImmutableList<Record> actual =
+        ImmutableList.of(
+            Record.create(1, 101),
+            Record.create(2, 211),
+            Record.create(2, 222),
+            Record.create(3, 303),
+            Record.createWithoutId(888));
+    expectFailure
+        .whenTesting()
+        .that(actual)
+        .comparingElementsUsing(RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10)
+        .displayingDiffsPairedBy(RECORD_ID)
+        .containsAllIn(expected);
+    assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .isEqualTo(
+            "Not true that <[1/101, 2/211, 2/222, 3/303, none/888]> contains at least one element "
+                + "that has the same id as and a score is within 10 of each element of "
+                + "<[1/100, 2/200, none/999]>. It is missing an element that corresponds to "
+                + "<2/200> (but did have elements <[2/211 (diff: score:11), "
+                + "2/222 (diff: score:22)]> with matching key 2), and is missing an element that "
+                + "corresponds to <none/999> (without matching keys)");
+  }
+
+  @Test
+  public void comparingElementsUsing_displayingElementsPairedBy_containsAllIn_notUnique() {
+    ImmutableList<Record> expected =
+        ImmutableList.of(
+            Record.create(1, 100),
+            Record.create(2, 200),
+            Record.create(2, 201),
+            Record.createWithoutId(999));
+    ImmutableList<Record> actual =
+        ImmutableList.of(Record.create(1, 101), Record.create(3, 303), Record.createWithoutId(999));
+    expectFailure
+        .whenTesting()
+        .that(actual)
+        .comparingElementsUsing(RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10)
+        .displayingDiffsPairedBy(RECORD_ID)
+        .containsAllIn(expected);
+    assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .isEqualTo(
+            "Not true that <[1/101, 3/303, none/999]> contains at least one element that has the "
+                + "same id as and a score is within 10 of each element of "
+                + "<[1/100, 2/200, 2/201, none/999]>. It is missing an element that has the same "
+                + "id as and a score is within 10 of each of <[2/200, 2/201]>. (N.B. A key "
+                + "function which does not uniquely key the expected elements was provided and has "
+                + "consequently been ignored.)");
+  }
+
+  @Test
   public void comparingElementsUsing_containsAllIn_failsMultipleMissingCandidates() {
     ImmutableList<Integer> expected = ImmutableList.of(64, 128, 256, 128);
     ImmutableList<String> actual =


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Make IterableSubject.UsingCorrespondence.displayingDiffsPairedBy() work for containsAllOf/In().

Also remove the warning on Correspondence.formatDiff saying that it's of limited use, since most of the use-cases are now implemented (only containsAnyOf/In() is left).

Also drive-by fixes of missing private modifiers and a couple of places where (private method) javadoc wasn't updated to reflect a change in method signature.

ff76987c4ddab40e100866a4db95cb8740454854