### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/ExpectFailure.java
+++ b/core/src/main/java/com/google/common/truth/ExpectFailure.java
@@ -18,6 +18,8 @@ package com.google.common.truth;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.truth.StringUtil.format;
+import static com.google.common.truth.Truth.assertAbout;
+import static com.google.common.truth.TruthFailureSubject.truthFailures;
 
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.truth.Truth.SimpleAssertionError;
@@ -182,6 +184,15 @@ public final class ExpectFailure implements Platform.JUnitTestRule {
             assertionCallback.invokeAssertion(whenTesting.about(factory));
           }
         });
+  }
+
+  // TODO(cpovirk): Expose this publicly once we finalize names.
+  /**
+   * Creates a subject for asserting about the given {@link AssertionError}, usually one produced by
+   * Truth.
+   */
+  static TruthFailureSubject assertThat(AssertionError actual) {
+    return (TruthFailureSubject) assertAbout(truthFailures()).that(actual);
   }
 
   @Override

--- a/core/src/main/java/com/google/common/truth/Field.java
+++ b/core/src/main/java/com/google/common/truth/Field.java
@@ -25,10 +25,18 @@ import javax.annotation.Nullable;
 
 /** A string key-value pair in a failure message, such as "expected: abc" or "but was: xyz." */
 final class Field {
+  /**
+   * Creates a field with the given key and value, which will be printed in a format like "key:
+   * value." The value is converted to a string by calling {@code String.valueOf} on it.
+   */
   static Field field(String key, Object value) {
     return new Field(key, String.valueOf(value));
   }
 
+  /**
+   * Creates a field with no value, which will be printed in the format "key" (with no colon or
+   * value).
+   */
   static Field fieldWithoutValue(String key) {
     return new Field(key, null);
   }
@@ -43,8 +51,8 @@ final class Field {
 
   /**
    * Returns a simple string representation for the field. While this is used by the old-style
-   * messages, we're moving away from it and onto {@link #makeMessage}, which aligns fields
-   * horizontally and indents multiline values.
+   * messages and {@code TruthFailureSubject} output, we're moving away from the old-style messages
+   * and onto {@link #makeMessage}, which aligns fields horizontally and indents multiline values.
    */
   @Override
   public String toString() {

--- a/core/src/main/java/com/google/common/truth/ThrowableSubject.java
+++ b/core/src/main/java/com/google/common/truth/ThrowableSubject.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
  *
  * @author Kurt Alfred Kluever
  */
-public final class ThrowableSubject extends Subject<ThrowableSubject, Throwable> {
+public class ThrowableSubject extends Subject<ThrowableSubject, Throwable> {
   ThrowableSubject(
       FailureMetadata metadata, @Nullable Throwable throwable, @Nullable String typeDescription) {
     super(metadata, throwable, typeDescription);
@@ -41,12 +41,12 @@ public final class ThrowableSubject extends Subject<ThrowableSubject, Throwable>
    *     for less brittle tests.
    */
   @Deprecated
-  public void hasMessage(@Nullable String expected) {
+  public final void hasMessage(@Nullable String expected) {
     hasMessageThat().isEqualTo(expected);
   }
 
   /** Returns a {@code StringSubject} to make assertions about the throwable's message. */
-  public StringSubject hasMessageThat() {
+  public final StringSubject hasMessageThat() {
     return check("getMessage()").that(actual().getMessage());
   }
 
@@ -55,7 +55,7 @@ public final class ThrowableSubject extends Subject<ThrowableSubject, Throwable>
    * cause. This method can be invoked repeatedly (e.g. {@code
    * assertThat(e).hasCauseThat().hasCauseThat()....} to assert on a particular indirect cause.
    */
-  public ThrowableSubject hasCauseThat() {
+  public final ThrowableSubject hasCauseThat() {
     // provides a more helpful error message if hasCauseThat() methods are chained too deep
     // e.g. assertThat(new Exception()).hCT().hCT()....
     // TODO(diamondm) in keeping with other subjects' behavior this should still NPE if the subject

--- a/core/src/main/java/com/google/common/truth/TruthFailureSubject.java
+++ b/core/src/main/java/com/google/common/truth/TruthFailureSubject.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.truth;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.truth.Field.field;
+
+import com.google.common.collect.ImmutableList;
+import javax.annotation.Nullable;
+
+// TODO(cpovirk): Expose this publicly once we finalize names.
+
+/**
+ * Subject for {@link AssertionError} objects thrown by Truth. {@code TruthFailureSubject} contains
+ * methods for asserting about the individual "fields" of those failures. This allows tests to avoid
+ * asserting about the same field more often than necessary, including avoiding asserting about
+ * fields that are set by other subjects that the main subject delegates to. This keeps tests
+ * shorter and less fragile.
+ *
+ * <p>To create an instance, call {@link ExpectFailure#assertThat}.
+ *
+ * <p>This class accepts any {@code AssertionError} value, but it will throw an exception if a
+ * caller tries to access the fields of an error that wasn't produced by Truth.
+ */
+final class TruthFailureSubject extends ThrowableSubject {
+  /*
+   * TODO(cpovirk): Expose this publicly once it can have the right type. That can't happen until we
+   * add type parameters to ThrowableSubject, make TruthFailureSubject not extend ThrowableSubject,
+   * remove the type parameters from Subject altogether, or *maybe* just loosen the type parameters
+   * on Factory. At that point, also mention it in the class-level docs.
+   */
+
+  /**
+   * Package-private factory for creating {@link TruthFailureSubject} instances. At the moment, the
+   * only public way to create an instance is {@link ExpectFailure#assertThat}.
+   */
+  static Factory<ThrowableSubject, Throwable> truthFailures() {
+    return FACTORY;
+  }
+
+  private static final Factory<ThrowableSubject, Throwable> FACTORY =
+      new Factory<ThrowableSubject, Throwable>() {
+        @Override
+        public ThrowableSubject createSubject(FailureMetadata metadata, Throwable actual) {
+          return new TruthFailureSubject(metadata, actual, "failure");
+        }
+      };
+
+  TruthFailureSubject(
+      FailureMetadata metadata, @Nullable Throwable throwable, @Nullable String typeDescription) {
+    super(metadata, throwable, typeDescription);
+  }
+
+  /** Returns a subject for the list of field keys. */
+  public IterableSubject fieldKeys() {
+    if (!(actual() instanceof ErrorWithFields)) {
+      failWithRawMessage("expected a failure thrown by Truth's new failure API");
+      return ignoreCheck().that(ImmutableList.of());
+    }
+    ErrorWithFields error = (ErrorWithFields) actual();
+    return check("fieldKeys()").that(getFieldKeys(error));
+  }
+
+  private static ImmutableList<String> getFieldKeys(ErrorWithFields error) {
+    ImmutableList.Builder<String> fields = ImmutableList.builder();
+    for (Field field : error.fields()) {
+      fields.add(field.key);
+    }
+    return fields.build();
+  }
+
+  /**
+   * Returns a subject for the value with the given name.
+   *
+   * <p>The value, if present, is always a string, the {@code String.valueOf} representation of the
+   * value passed to {@link Field#field}.
+   *
+   * <p>The value is null in the case of {@linkplain Field#fieldWithoutValue fields that have no
+   * value}. By contrast, fields that have a value that is rendered as "null" (such as those created
+   * with {@code field("key", null)}) are considered to have a value, the string "null."
+   *
+   * <p>If the failure under test contains more than one field with the given key, this method will
+   * fail the test. To assert about such a failure, use {@linkplain #fieldValue(String, int) the
+   * other overload} of {@code fieldValue}.
+   */
+  public StringSubject fieldValue(String key) {
+    return doFieldValue(key, null);
+  }
+
+  /**
+   * Returns a subject for the value of the {@code index}-th instance of the field with the given
+   * name. Most Truth failures do not contain multiple fields with the same key, so most tests
+   * should use {@linkplain #fieldValue(String) the other overload} of {@code fieldValue}.
+   */
+  public StringSubject fieldValue(String key, int index) {
+    checkArgument(index >= 0, "index must be nonnegative: %s", index);
+    return doFieldValue(key, index);
+  }
+
+  private StringSubject doFieldValue(String key, @Nullable Integer index) {
+    checkNotNull(key);
+    if (!(actual() instanceof ErrorWithFields)) {
+      failWithRawMessage("expected a failure thrown by Truth's new failure API");
+      return ignoreCheck().that("");
+    }
+    ErrorWithFields error = (ErrorWithFields) actual();
+
+    /*
+     * We don't care as much about including the actual Throwable and its fields in these because
+     * the Throwable will be attached as a cause in nearly all cases.
+     */
+    ImmutableList<Field> fieldsWithName = fieldsWithName(error, key);
+    if (fieldsWithName.isEmpty()) {
+      failWithRawMessage(
+          field("expected to contain field", key)
+              + "\n"
+              + field("but contained only", getFieldKeys(error)));
+      return ignoreCheck().that("");
+    }
+    if (index == null && fieldsWithName.size() > 1) {
+      failWithRawMessage(
+          field("expected to contain a single field with key", key)
+              + "\n"
+              + field("but contained multiple", fieldsWithName));
+      return ignoreCheck().that("");
+    }
+    if (index != null && index > fieldsWithName.size()) {
+      failWithRawMessage(
+          field("for key", key)
+              + "\n"
+              + field("index too high", index)
+              + "\n"
+              + field("field count was", fieldsWithName.size()));
+      return ignoreCheck().that("");
+    }
+    StandardSubjectBuilder check =
+        index == null ? check("fieldValue(%s)", key) : check("fieldValue(%s, %s)", key, index);
+    return check.that(fieldsWithName.get(firstNonNull(index, 0)).value);
+  }
+
+  private static ImmutableList<Field> fieldsWithName(ErrorWithFields error, String key) {
+    ImmutableList.Builder<Field> fields = ImmutableList.builder();
+    for (Field field : error.fields()) {
+      if (field.key.equals(key)) {
+        fields.add(field);
+      }
+    }
+    return fields.build();
+  }
+}

--- a/core/src/test/java/com/google/common/truth/TruthFailureSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/TruthFailureSubjectTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.truth;
+
+import static com.google.common.truth.Field.field;
+import static com.google.common.truth.TruthFailureSubject.truthFailures;
+import static org.junit.Assert.fail;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link TruthFailureSubject}. */
+@RunWith(JUnit4.class)
+public class TruthFailureSubjectTest extends BaseSubjectTestCase {
+  // TODO(cpovirk): Switch to using field-based assertions once Truth generates field-based errors.
+
+  // fieldKeys()
+
+  @Test
+  public void fieldKeys() {
+    assertThat(field("foo", "the foo")).fieldKeys().containsExactly("foo");
+  }
+
+  @Test
+  public void fieldKeysFail() {
+    expectFailureWhenTestingThat(field("foo", "the foo")).fieldKeys().containsExactly("bar");
+    Truth.assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .contains("value of: failure.fieldKeys()");
+  }
+
+  // fieldValue(String)
+
+  @Test
+  public void fieldValue() {
+    assertThat(field("foo", "the foo")).fieldValue("foo").isEqualTo("the foo");
+  }
+
+  @Test
+  public void fieldValueFailWrongValue() {
+    expectFailureWhenTestingThat(field("foo", "the foo")).fieldValue("foo").isEqualTo("the bar");
+    Truth.assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .contains("value of: failure.fieldValue(foo)");
+  }
+
+  @Test
+  public void fieldValueFailNoSuchKey() {
+    Object unused = expectFailureWhenTestingThat(field("foo", "the foo")).fieldValue("bar");
+    assertMessage("expected to contain field: bar\nbut contained only: [foo]");
+  }
+
+  @Test
+  public void fieldValueFailMultipleKeys() {
+    Object unused =
+        expectFailureWhenTestingThat(field("foo", "the foo"), field("foo", "the other foo"))
+            .fieldValue("foo");
+    assertMessage(
+        "expected to contain a single field with key: foo\n"
+            + "but contained multiple: [foo: the foo, foo: the other foo]");
+  }
+
+  // fieldValue(String, int)
+
+  @Test
+  public void fieldValueInt() {
+    assertThat(field("foo", "the foo")).fieldValue("foo", 0).isEqualTo("the foo");
+  }
+
+  @Test
+  public void fieldValueIntMultipleKeys() {
+    assertThat(field("foo", "the foo"), field("foo", "the other foo"))
+        .fieldValue("foo", 1)
+        .isEqualTo("the other foo");
+  }
+
+  @Test
+  public void fieldValueIntFailNegative() {
+    try {
+      assertThat(field("foo", "the foo")).fieldValue("foo", -1);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
+  @Test
+  public void fieldValueIntFailWrongValue() {
+    expectFailureWhenTestingThat(field("foo", "the foo")).fieldValue("foo", 0).isEqualTo("the bar");
+    Truth.assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .contains("value of: failure.fieldValue(foo, 0)");
+  }
+
+  @Test
+  public void fieldValueIntFailNoSuchKey() {
+    Object unused = expectFailureWhenTestingThat(field("foo", "the foo")).fieldValue("bar", 0);
+    assertMessage("expected to contain field: bar\nbut contained only: [foo]");
+  }
+
+  @Test
+  public void fieldValueIntFailNotEnoughWithKey() {
+    Object unused = expectFailureWhenTestingThat(field("foo", "the foo")).fieldValue("foo", 5);
+    assertMessage("for key: foo\nindex too high: 5\nfield count was: 1");
+  }
+
+  // other tests
+
+  @Test
+  public void nonTruthErrorFieldKeys() {
+    Object unused = expectFailureWhenTestingThat(new AssertionError()).fieldKeys();
+    assertMessage("expected a failure thrown by Truth's new failure API");
+  }
+
+  @Test
+  public void nonTruthErrorFieldValue() {
+    Object unused = expectFailureWhenTestingThat(new AssertionError()).fieldValue("foo");
+    assertMessage("expected a failure thrown by Truth's new failure API");
+  }
+
+  private TruthFailureSubject assertThat(Field... fields) {
+    return ExpectFailure.assertThat(failure(fields));
+  }
+
+  private TruthFailureSubject expectFailureWhenTestingThat(Field... fields) {
+    return expectFailureWhenTestingThat(failure(fields));
+  }
+
+  private TruthFailureSubject expectFailureWhenTestingThat(AssertionError failure) {
+    return (TruthFailureSubject) expectFailure.whenTesting().about(truthFailures()).that(failure);
+  }
+
+  private AssertionErrorWithFields failure(Field... fields) {
+    return AssertionErrorWithFields.create(
+        ImmutableList.<String>of(), ImmutableList.copyOf(fields), /* cause= */ null);
+  }
+
+  private void assertMessage(String expected) {
+    ExpectFailure.assertThat(expectFailure.getFailure()).hasMessageThat().isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Introduce TruthFailureSubject and ExpectFailure.assertThat.

They're package-private until we decide what name to use for various APIs that are currently named "field."

f3ec16eba958d35aaea8bd09a2ad6653b2f7d343