### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/FailureMetadata.java
+++ b/core/src/main/java/com/google/common/truth/FailureMetadata.java
@@ -209,25 +209,18 @@ public final class FailureMetadata {
   private String addToMessage(String body) {
     ImmutableList<?> messages = allPrefixMessages();
     StringBuilder result = new StringBuilder(body.length());
-    Joiner.on(": ").appendTo(result, messages);
+    Joiner.on("\n").appendTo(result, messages);
     if (!messages.isEmpty()) {
-      if (body.isEmpty()) {
-        /*
-         * The only likely case of an empty body is with failComparing(). In that case, we still
-         * want a colon because ComparisonFailure will construct a message of the form
-         * "<ourString> <theirString>." For consistency with the normal behavior of withMessage,
-         * we want a colon between the parts.
-         *
-         * That actually makes it sound like we'd want to *always* include the trailing colon in
-         * the case of failComparing(), but I don't want to bite that off now in case it requires
-         * updating more existing Subjects' tests.
-         */
-        result.append(":");
-      } else {
-        result.append(": ");
-      }
+      result.append("\n");
     }
     result.append(body);
+    /*
+     * JUnit's ComparisonFailure will append " expected: <...> but was: <...> to the end of this.
+     * Note the space at the beginning. That means that, if the body is empty, the "expected... but
+     * was" text will come at the beginning of a line... indented by one space :\ The right fix for
+     * this is to stop depending on JUnit's ComparisonFailure formatting. That's coming. For now,
+     * the space is an annoyance.
+     */
     return result.toString();
   }
 

--- a/core/src/main/java/com/google/common/truth/Truth.java
+++ b/core/src/main/java/com/google/common/truth/Truth.java
@@ -314,7 +314,7 @@ public final class Truth {
   @Nullable
   static String appendSuffixIfNotNull(String message, String suffix) {
     if (suffix != null) {
-      message += ": " + suffix;
+      message += "\n" + suffix;
     }
     return message;
   }

--- a/core/src/test/java/com/google/common/truth/ChainingTest.java
+++ b/core/src/test/java/com/google/common/truth/ChainingTest.java
@@ -101,7 +101,7 @@ public final class ChainingTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat("root")
         .delegatingToNamed("child", "child")
         .isThePresentKingOfFrance();
-    assertNoCause("value of: myObject.child: message: myObject was: root");
+    assertNoCause("value of: myObject.child\nmessage\nmyObject was: root");
   }
 
   @Test
@@ -110,7 +110,7 @@ public final class ChainingTest extends BaseSubjectTestCase {
         .delegatingToNamed("child", "child")
         .delegatingToNamed("grandchild", "grandchild")
         .isThePresentKingOfFrance();
-    assertNoCause("value of: myObject.child.grandchild: message: myObject was: root");
+    assertNoCause("value of: myObject.child.grandchild\nmessage\nmyObject was: root");
   }
 
   @Test
@@ -119,7 +119,7 @@ public final class ChainingTest extends BaseSubjectTestCase {
         .delegatingToNamed("child", "child")
         .delegatingTo("grandchild")
         .isThePresentKingOfFrance();
-    assertNoCause("message: myObject was: root");
+    assertNoCause("message\nmyObject was: root");
   }
 
   @Test
@@ -128,7 +128,7 @@ public final class ChainingTest extends BaseSubjectTestCase {
         .delegatingTo("child")
         .delegatingToNamed("grandchild", "grandchild")
         .isThePresentKingOfFrance();
-    assertNoCause("value of: myObject.grandchild: message: myObject was: root");
+    assertNoCause("value of: myObject.grandchild\nmessage\nmyObject was: root");
   }
 
   @Test
@@ -136,7 +136,7 @@ public final class ChainingTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat("root")
         .delegatingToNamedNoNeedToDisplayBoth("child", "child")
         .isThePresentKingOfFrance();
-    assertNoCause("value of: myObject.child: message");
+    assertNoCause("value of: myObject.child\nmessage");
   }
 
   @Test
@@ -145,7 +145,7 @@ public final class ChainingTest extends BaseSubjectTestCase {
         .delegatingToNamedNoNeedToDisplayBoth("child", "child")
         .delegatingToNamedNoNeedToDisplayBoth("grandchild", "grandchild")
         .isThePresentKingOfFrance();
-    assertNoCause("value of: myObject.child.grandchild: message");
+    assertNoCause("value of: myObject.child.grandchild\nmessage");
   }
 
   @Test
@@ -163,7 +163,7 @@ public final class ChainingTest extends BaseSubjectTestCase {
         .delegatingTo("child")
         .delegatingToNamedNoNeedToDisplayBoth("grandchild", "grandchild")
         .isThePresentKingOfFrance();
-    assertNoCause("value of: myObject.grandchild: message");
+    assertNoCause("value of: myObject.grandchild\nmessage");
   }
 
   @Test
@@ -172,7 +172,7 @@ public final class ChainingTest extends BaseSubjectTestCase {
         .delegatingToNamedNoNeedToDisplayBoth("child", "child")
         .delegatingToNamed("grandchild", "grandchild")
         .isThePresentKingOfFrance();
-    assertNoCause("value of: myObject.child.grandchild: message: myObject was: root");
+    assertNoCause("value of: myObject.child.grandchild\nmessage\nmyObject was: root");
   }
 
   @Test
@@ -181,14 +181,14 @@ public final class ChainingTest extends BaseSubjectTestCase {
         .delegatingToNamed("child", "child")
         .delegatingToNamedNoNeedToDisplayBoth("grandchild", "grandchild")
         .isThePresentKingOfFrance();
-    assertNoCause("value of: myObject.child.grandchild: message: myObject was: root");
+    assertNoCause("value of: myObject.child.grandchild\nmessage\nmyObject was: root");
   }
 
   @Test
   public void namedAndComparisonFailure() {
     expectFailureWhenTestingThat("root").delegatingToNamed("child", "child").isEqualToString("z");
     assertNoCause(
-        "value of: myObject.child: message expected:<[child]> but was:<[z]>: myObject was: root");
+        "value of: myObject.child\nmessage expected:<[child]> but was:<[z]>\nmyObject was: root");
   }
 
   @Test
@@ -200,7 +200,7 @@ public final class ChainingTest extends BaseSubjectTestCase {
         .that("root")
         .delegatingToNamed("child", "child")
         .isThePresentKingOfFrance();
-    assertNoCause("prefix: value of: myObject.child: message: myObject was: root");
+    assertNoCause("prefix\nvalue of: myObject.child\nmessage\nmyObject was: root");
   }
 
   @Test
@@ -212,7 +212,7 @@ public final class ChainingTest extends BaseSubjectTestCase {
   @Test
   public void checkFailWithName() {
     expectFailureWhenTestingThat("root").doCheckFail("child");
-    assertNoCause("value of: myObject.child: message: myObject was: root");
+    assertNoCause("value of: myObject.child\nmessage\nmyObject was: root");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/CustomFailureMessageTest.java
+++ b/core/src/test/java/com/google/common/truth/CustomFailureMessageTest.java
@@ -41,7 +41,7 @@ public class CustomFailureMessageTest {
     } catch (AssertionError expected) {
       assertThat(expected)
           .hasMessageThat()
-          .isEqualTo("Invalid month: Not true that <13> is in <" + range + ">");
+          .isEqualTo("Invalid month\nNot true that <13> is in <" + range + ">");
       return;
     }
     fail("Should have thrown");
@@ -55,7 +55,7 @@ public class CustomFailureMessageTest {
     } catch (AssertionError expected) {
       assertThat(expected)
           .hasMessageThat()
-          .isEqualTo("Invalid month: Not true that Septober (<13>) is in <" + range + ">");
+          .isEqualTo("Invalid month\nNot true that Septober (<13>) is in <" + range + ">");
       return;
     }
     fail("Should have thrown");
@@ -69,7 +69,7 @@ public class CustomFailureMessageTest {
       assertThat(expected)
           .hasMessageThat()
           .isEqualTo(
-              "This is a custom message: The subject was expected to be true, but was false");
+              "This is a custom message\nThe subject was expected to be true, but was false");
       return;
     }
     fail("Should have thrown");
@@ -83,7 +83,7 @@ public class CustomFailureMessageTest {
     } catch (AssertionError expected) {
       assertThat(expected)
           .hasMessageThat()
-          .isEqualTo("Invalid month: Not true that <13> is in <" + range + ">");
+          .isEqualTo("Invalid month\nNot true that <13> is in <" + range + ">");
       return;
     }
     fail("Should have thrown");
@@ -97,7 +97,7 @@ public class CustomFailureMessageTest {
     } catch (AssertionError expected) {
       assertThat(expected)
           .hasMessageThat()
-          .isEqualTo("Invalid month: Not true that Septober (<13>) is in <" + range + ">");
+          .isEqualTo("Invalid month\nNot true that Septober (<13>) is in <" + range + ">");
       return;
     }
     fail("Should have thrown");
@@ -111,7 +111,7 @@ public class CustomFailureMessageTest {
       assertThat(expected)
           .hasMessageThat()
           .isEqualTo(
-              "This is a custom message: The subject was expected to be true, but was false");
+              "This is a custom message\nThe subject was expected to be true, but was false");
       return;
     }
     fail("Should have thrown");
@@ -142,7 +142,7 @@ public class CustomFailureMessageTest {
     } catch (AssertionError expected) {
       assertThat(expected)
           .hasMessageThat()
-          .isEqualTo("Invalid month: Not true that <13> is in <" + range + ">");
+          .isEqualTo("Invalid month\nNot true that <13> is in <" + range + ">");
       return;
     }
     fail("Should have thrown");
@@ -156,7 +156,7 @@ public class CustomFailureMessageTest {
     } catch (AssertionError expected) {
       assertThat(expected)
           .hasMessageThat()
-          .isEqualTo("Invalid month: Not true that Septober (<13>) is in <" + range + ">");
+          .isEqualTo("Invalid month\nNot true that Septober (<13>) is in <" + range + ">");
       return;
     }
     fail("Should have thrown");
@@ -170,7 +170,7 @@ public class CustomFailureMessageTest {
       assertThat(expected)
           .hasMessageThat()
           .isEqualTo(
-              "This is a custom message: The subject was expected to be true, but was false");
+              "This is a custom message\nThe subject was expected to be true, but was false");
       return;
     }
     fail("Should have thrown");
@@ -184,7 +184,7 @@ public class CustomFailureMessageTest {
     } catch (AssertionError expected) {
       assertThat(expected)
           .hasMessageThat()
-          .isEqualTo("Invalid month: Not true that <13> is in <" + range + ">");
+          .isEqualTo("Invalid month\nNot true that <13> is in <" + range + ">");
       return;
     }
     fail("Should have thrown");
@@ -198,7 +198,7 @@ public class CustomFailureMessageTest {
     } catch (AssertionError expected) {
       assertThat(expected)
           .hasMessageThat()
-          .isEqualTo("Invalid month: Not true that Septober (<13>) is in <" + range + ">");
+          .isEqualTo("Invalid month\nNot true that Septober (<13>) is in <" + range + ">");
       return;
     }
     fail("Should have thrown");
@@ -212,7 +212,7 @@ public class CustomFailureMessageTest {
       assertThat(expected)
           .hasMessageThat()
           .isEqualTo(
-              "This is a custom message: The subject was expected to be true, but was false");
+              "This is a custom message\nThe subject was expected to be true, but was false");
       return;
     }
     fail("Should have thrown");

--- a/core/src/test/java/com/google/common/truth/IterableSubjectCorrespondenceTest.java
+++ b/core/src/test/java/com/google/common/truth/IterableSubjectCorrespondenceTest.java
@@ -1036,6 +1036,83 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
   }
 
   @Test
+  public void comparingElementsUsing_displayingDiffsPairedBy_containsAnyIn_withKeyMatches() {
+    ImmutableList<Record> expected =
+        ImmutableList.of(
+            Record.create(1, 100),
+            Record.create(2, 200),
+            Record.create(3, 300),
+            Record.createWithoutId(999));
+    ImmutableList<Record> actual =
+        ImmutableList.of(
+            Record.create(3, 311),
+            Record.create(2, 211),
+            Record.create(2, 222),
+            Record.create(4, 404),
+            Record.createWithoutId(888));
+    expectFailure
+        .whenTesting()
+        .that(actual)
+        .comparingElementsUsing(RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10)
+        .displayingDiffsPairedBy(RECORD_ID)
+        .containsAnyIn(expected);
+    assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .isEqualTo(
+            "Not true that <[3/311, 2/211, 2/222, 4/404, none/888]> contains at least one element "
+                + "that has the same id as and a score is within 10 of any element in "
+                + "<[1/100, 2/200, 3/300, none/999]>. It contains the following values that match "
+                + "by key: with key 2, would have accepted 2/200, but got "
+                + "[2/211 (diff: score:11), 2/222 (diff: score:22)]; with key 3, would have "
+                + "accepted 3/300, but got [3/311 (diff: score:11)]");
+  }
+
+  @Test
+  public void comparingElementsUsing_displayingDiffsPairedBy_containsAnyIn_withoutKeyMatches() {
+    ImmutableList<Record> expected =
+        ImmutableList.of(Record.create(1, 100), Record.create(2, 200), Record.createWithoutId(999));
+    ImmutableList<Record> actual =
+        ImmutableList.of(Record.create(3, 300), Record.create(4, 411), Record.createWithoutId(888));
+    expectFailure
+        .whenTesting()
+        .that(actual)
+        .comparingElementsUsing(RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10)
+        .displayingDiffsPairedBy(RECORD_ID)
+        .containsAnyIn(expected);
+    assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .isEqualTo(
+            "Not true that <[3/300, 4/411, none/888]> contains at least one element that has the "
+                + "same id as and a score is within 10 of any element in "
+                + "<[1/100, 2/200, none/999]>. It does not contain any matches by key, either");
+  }
+
+  @Test
+  public void comparingElementsUsing_displayingDiffsPairedBy_containsAnyIn_notUnique() {
+    ImmutableList<Record> expected =
+        ImmutableList.of(
+            Record.create(1, 100),
+            Record.create(2, 200),
+            Record.create(2, 250),
+            Record.createWithoutId(999));
+    ImmutableList<Record> actual =
+        ImmutableList.of(Record.create(3, 300), Record.create(2, 211), Record.createWithoutId(888));
+    expectFailure
+        .whenTesting()
+        .that(actual)
+        .comparingElementsUsing(RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10)
+        .displayingDiffsPairedBy(RECORD_ID)
+        .containsAnyIn(expected);
+    assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .isEqualTo(
+            "Not true that <[3/300, 2/211, none/888]> contains at least one element that has the "
+                + "same id as and a score is within 10 of any element in "
+                + "<[1/100, 2/200, 2/250, none/999]>. (N.B. A key function which does not uniquely "
+                + "key the expected elements was provided and has consequently been ignored.)");
+  }
+
+  @Test
   public void comparingElementsUsing_containsAnyIn_null() {
     List<String> actual = asList("+128", "+64", null, "0x40");
     List<Integer> expected = asList(255, null, 257);

--- a/core/src/test/java/com/google/common/truth/IterableSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/IterableSubjectTest.java
@@ -117,7 +117,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().withMessage("custom msg").that(asList(1, 2, 3)).contains(5);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("custom msg: <[1, 2, 3]> should have contained <5>");
+        .isEqualTo("custom msg\n<[1, 2, 3]> should have contained <5>");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/MultimapSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/MultimapSubjectTest.java
@@ -176,9 +176,9 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "value of: multymap.valuesForKey(1): "
+            "value of: multymap.valuesForKey(1)\n"
                 + "Not true that <[5]> contains exactly <[4]>. "
-                + "It is missing <[4]> and has unexpected items <[5]>: "
+                + "It is missing <[4]> and has unexpected items <[5]>\n"
                 + "multimap was: multymap ({1=[5]})");
   }
 
@@ -189,9 +189,9 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "value of: multimap.valuesForKey(1): "
+            "value of: multimap.valuesForKey(1)\n"
                 + "Not true that valuez (<[5]>) contains exactly <[4]>. "
-                + "It is missing <[4]> and has unexpected items <[5]>: "
+                + "It is missing <[4]> and has unexpected items <[5]>\n"
                 + "multimap was: {1=[5]}");
   }
 

--- a/core/src/test/java/com/google/common/truth/PrimitiveDoubleArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveDoubleArraySubjectTest.java
@@ -849,7 +849,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "value of: array.asList(): Not true that <[1.1, "
+            "value of: array.asList()\nNot true that <[1.1, "
                 + INTOLERABLE_2POINT2
                 + ", 3.3]> contains at least one element that is a finite number within "
                 + DEFAULT_TOLERANCE
@@ -864,7 +864,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "value of: array.asList(): Not true that <[1.1, Infinity, 3.3]> "
+            "value of: array.asList()\nNot true that <[1.1, Infinity, 3.3]> "
                 + "contains at least one element that is "
                 + "a finite number within "
                 + DEFAULT_TOLERANCE
@@ -879,7 +879,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "value of: array.asList(): Not true that <[1.1, NaN, 3.3]> "
+            "value of: array.asList()\nNot true that <[1.1, NaN, 3.3]> "
                 + "contains at least one element that is "
                 + "a finite number within "
                 + DEFAULT_TOLERANCE
@@ -960,7 +960,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "value of: array.asList(): Not true that <[1.1, "
+            "value of: array.asList()\nNot true that <[1.1, "
                 + TOLERABLE_2POINT2
                 + ", 3.3]> contains at least one element that is a finite number "
                 + "within "
@@ -988,7 +988,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "value of: array.asList(): Not true that <[1.1, "
+            "value of: array.asList()\nNot true that <[1.1, "
                 + TOLERABLE_2POINT2
                 + ", 3.3]> contains, in order, at least one element that is a finite number "
                 + "within "
@@ -1011,7 +1011,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "value of: array.asList(): Not true that <[1.1, "
+            "value of: array.asList()\nNot true that <[1.1, "
                 + TOLERABLE_2POINT2
                 + ", 3.3]> contains at least one element that is a finite number within "
                 + DEFAULT_TOLERANCE
@@ -1033,7 +1033,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "value of: array.asList(): Not true that <[1.1, "
+            "value of: array.asList()\nNot true that <[1.1, "
                 + TOLERABLE_2POINT2
                 + ", 3.3]> contains exactly one element that is a finite number within "
                 + DEFAULT_TOLERANCE
@@ -1057,7 +1057,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "value of: array.asList(): Not true that <[1.1, "
+            "value of: array.asList()\nNot true that <[1.1, "
                 + TOLERABLE_2POINT2
                 + ", 3.3]> contains, in order, exactly one element that is a finite number "
                 + "within "
@@ -1080,7 +1080,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "value of: array.asList(): Not true that <[1.1, "
+            "value of: array.asList()\nNot true that <[1.1, "
                 + TOLERABLE_2POINT2
                 + ", 3.3]> contains no element that is a finite number within "
                 + DEFAULT_TOLERANCE
@@ -1100,7 +1100,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "value of: array.asList(): Not true that <[1.1, "
+            "value of: array.asList()\nNot true that <[1.1, "
                 + OVER_2POINT2
                 + ", 3.3]> contains at least one element that is exactly equal to <2.2>");
   }
@@ -1174,7 +1174,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "value of: array.asList(): Not true that <[1.1, -0.0, 3.3]> "
+            "value of: array.asList()\nNot true that <[1.1, -0.0, 3.3]> "
                 + "contains at least one element that is "
                 + "exactly equal to <"
                 + 0.0
@@ -1203,7 +1203,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "value of: array.asList(): Not true that <[1.1, 2.2, 3.3]> "
+            "value of: array.asList()\nNot true that <[1.1, 2.2, 3.3]> "
                 + "contains at least one element that is exactly equal "
                 + "to each element of <[2.2, 99.99]>. It is missing an element that is exactly "
                 + "equal to <99.99>");
@@ -1223,7 +1223,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "value of: array.asList(): Not true that <[1.1, 2.2, 3.3]> "
+            "value of: array.asList()\nNot true that <[1.1, 2.2, 3.3]> "
                 + "contains, in order, at least one element that is "
                 + "exactly equal to each element of <[2.2, 1.1]>");
   }
@@ -1241,7 +1241,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "value of: array.asList(): Not true that <[1.1, 2.2, 3.3]> "
+            "value of: array.asList()\nNot true that <[1.1, 2.2, 3.3]> "
                 + "contains at least one element that is exactly equal "
                 + "to any element in <[99.99, 999.999]>");
   }
@@ -1259,7 +1259,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "value of: array.asList(): Not true that <[1.1, 2.2, 3.3]> "
+            "value of: array.asList()\nNot true that <[1.1, 2.2, 3.3]> "
                 + "contains exactly one element that is exactly equal "
                 + "to each element of <[2.2, 1.1]>. It has unexpected elements <[3.3]>");
   }
@@ -1281,7 +1281,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "value of: array.asList(): Not true that <[1.1, 2.2, 3.3]> "
+            "value of: array.asList()\nNot true that <[1.1, 2.2, 3.3]> "
                 + "contains, in order, exactly one element that is "
                 + "exactly equal to each element of <[2.2, 1.1, 3.3]>");
   }
@@ -1299,7 +1299,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "value of: array.asList(): Not true that <[1.1, 2.2, 3.3]> "
+            "value of: array.asList()\nNot true that <[1.1, 2.2, 3.3]> "
                 + "contains no element that is exactly equal to any "
                 + "element in <[99.99, 2.2]>. It contains <[2.2 which corresponds to 2.2]>");
   }

--- a/core/src/test/java/com/google/common/truth/PrimitiveFloatArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveFloatArraySubjectTest.java
@@ -862,7 +862,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "value of: array.asList(): Not true that <[%s, %s, %s]> "
+                "value of: array.asList()\nNot true that <[%s, %s, %s]> "
                     + "contains at least one element that is a finite "
                     + "number within %s of <%s>",
                 1.0f, INTOLERABLE_TWO, 3.0f, (double) DEFAULT_TOLERANCE, 2.0f));
@@ -877,7 +877,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "value of: array.asList(): Not true that <[%s, Infinity, %s]> "
+                "value of: array.asList()\nNot true that <[%s, Infinity, %s]> "
                     + "contains at least one element that is "
                     + "a finite number within %s of <Infinity>",
                 1.0f, 3.0f, (double) DEFAULT_TOLERANCE));
@@ -892,7 +892,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "value of: array.asList(): Not true that <[%s, NaN, %s]> "
+                "value of: array.asList()\nNot true that <[%s, NaN, %s]> "
                     + "contains at least one element that is "
                     + "a finite number within %s of <NaN>",
                 1.0f, 3.0f, (double) DEFAULT_TOLERANCE));
@@ -976,7 +976,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "value of: array.asList(): Not true that <[%s, %s, %s]> "
+                "value of: array.asList()\nNot true that <[%s, %s, %s]> "
                     + "contains at least one element that is a "
                     + "finite number within %s of each element of <[%s, %s]>. "
                     + "It is missing an element that is a finite number within %s of <%s>",
@@ -1008,7 +1008,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "value of: array.asList(): Not true that <[%s, %s, %s]> "
+                "value of: array.asList()\nNot true that <[%s, %s, %s]> "
                     + "contains, in order, at least one element that"
                     + " is a finite number within %s of each element of <[%s, %s]>",
                 1.0f, TOLERABLE_TWO, 3.0f, (double) DEFAULT_TOLERANCE, 2.0f, 1.0f));
@@ -1030,7 +1030,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "value of: array.asList(): Not true that <[%s, %s, %s]> "
+                "value of: array.asList()\nNot true that <[%s, %s, %s]> "
                     + "contains at least one element that is "
                     + "a finite number within %s of any element in <[%s, %s]>",
                 1.0f, TOLERABLE_TWO, 3.0f, (double) DEFAULT_TOLERANCE, 99.99f, 999.999f));
@@ -1052,7 +1052,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "value of: array.asList(): Not true that <[%s, %s, %s]> "
+                "value of: array.asList()\nNot true that <[%s, %s, %s]> "
                     + "contains exactly one element that is a finite "
                     + "number within %s of each element of <[%s, %s]>. "
                     + "It has unexpected elements <[%s]>",
@@ -1077,7 +1077,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "value of: array.asList(): Not true that <[%s, %s, %s]> "
+                "value of: array.asList()\nNot true that <[%s, %s, %s]> "
                     + "contains, in order, exactly one element that is a "
                     + "finite number within %s of each element of <[%s, %s, %s]>",
                 1.0f, TOLERABLE_TWO, 3.0f, (double) DEFAULT_TOLERANCE, 2.0f, 1.0f, 3.0f));
@@ -1099,7 +1099,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "value of: array.asList(): Not true that <[%s, %s, %s]> "
+                "value of: array.asList()\nNot true that <[%s, %s, %s]> "
                     + "contains no element that is a finite number within %s"
                     + " of any element in <[%s, %s]>. It contains <[%s which corresponds to %s]>",
                 1.0f,
@@ -1126,7 +1126,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "value of: array.asList(): Not true that <[%s, %s, %s]> "
+                "value of: array.asList()\nNot true that <[%s, %s, %s]> "
                     + "contains at least one element "
                     + "that is exactly equal to <%s>",
                 1.0f, JUST_OVER_2POINT2, 3.0f, 2.2f));
@@ -1216,7 +1216,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "value of: array.asList(): Not true that <[%s, -0.0, %s]> "
+                "value of: array.asList()\nNot true that <[%s, -0.0, %s]> "
                     + "contains at least one element that is "
                     + "exactly equal to <%s>",
                 1.0f, 3.0f, 0.0f));
@@ -1245,7 +1245,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "value of: array.asList(): Not true that <[%s, %s, %s]> "
+                "value of: array.asList()\nNot true that <[%s, %s, %s]> "
                     + "contains at least one element that is exactly equal "
                     + "to each element of <[%s, %s]>. It is missing an element that is exactly "
                     + "equal to <%s>",
@@ -1270,7 +1270,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "value of: array.asList(): Not true that <[%s, %s, %s]> "
+                "value of: array.asList()\nNot true that <[%s, %s, %s]> "
                     + "contains, in order, at least one element that is "
                     + "exactly equal to each element of <[%s, %s]>",
                 1.0f, 2.0f, 3.0f, 2.0f, 1.0f));
@@ -1290,7 +1290,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "value of: array.asList(): Not true that <[%s, %s, %s]> "
+                "value of: array.asList()\nNot true that <[%s, %s, %s]> "
                     + "contains at least one element that is exactly equal "
                     + "to any element in <[%s, %s]>",
                 1.0f, 2.0f, 3.0f, 99.99f, 999.999f));
@@ -1312,7 +1312,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "value of: array.asList(): Not true that <[%s, %s, %s]> "
+                "value of: array.asList()\nNot true that <[%s, %s, %s]> "
                     + "contains exactly one element that is exactly equal "
                     + "to each element of <[%s, %s]>. It has unexpected elements <[%s]>",
                 1.0f, 2.0f, 3.0f, 2.0f, 1.0f, 3.0f));
@@ -1336,7 +1336,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "value of: array.asList(): Not true that <[%s, %s, %s]> "
+                "value of: array.asList()\nNot true that <[%s, %s, %s]> "
                     + "contains, in order, exactly one element that is "
                     + "exactly equal to each element of <[%s, %s, %s]>",
                 1.0f, 2.0f, 3.0f, 2.0f, 1.0f, 3.0f));
@@ -1358,7 +1358,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         .hasMessageThat()
         .isEqualTo(
             format(
-                "value of: array.asList(): Not true that <[%s, %s, %s]> "
+                "value of: array.asList()\nNot true that <[%s, %s, %s]> "
                     + "contains no element that is exactly equal to any "
                     + "element in <[%s, %s]>. It contains <[%s which corresponds to %s]>",
                 1.0f, 2.0f, 3.0f, 99.99f, 2.0f, 2.0f, 2.0f));

--- a/core/src/test/java/com/google/common/truth/PrimitiveShortArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveShortArraySubjectTest.java
@@ -52,7 +52,7 @@ public class PrimitiveShortArraySubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "value of: array.asList(): Not true that <[1, 1, 0]> "
+            "value of: array.asList()\nNot true that <[1, 1, 0]> "
                 + "contains all of <[1, 0]>. It is missing "
                 + "<[1, 0] (java.lang.Integer)>. However, it does contain "
                 + "<[1 [2 copies], 0] (java.lang.Short)>.");

--- a/core/src/test/java/com/google/common/truth/RelabeledSubjectsTest.java
+++ b/core/src/test/java/com/google/common/truth/RelabeledSubjectsTest.java
@@ -97,7 +97,7 @@ public class RelabeledSubjectsTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .isEqualTo(
-            "value of: crazy list.asList(): Not true that <[1.3, 1.1]> "
+            "value of: crazy list.asList()\nNot true that <[1.3, 1.1]> "
                 + "contains exactly one element that is a "
                 + "finite number within 1.0E-7 of each element of <[1.3, 1.0]>. It is missing an "
                 + "element that is a finite number within 1.0E-7 of <1.0> and has unexpected "
@@ -110,7 +110,7 @@ public class RelabeledSubjectsTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(actual).named("crazy list").asList().contains(789L);
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("value of: crazy list.asList(): <[123, 456]> should have contained <789>");
+        .isEqualTo("value of: crazy list.asList()\n<[123, 456]> should have contained <789>");
   }
 
   @Test
@@ -119,6 +119,6 @@ public class RelabeledSubjectsTest extends BaseSubjectTestCase {
     expectFailure.whenTesting().that(actual).named("crazy list").asList().contains("rabbit");
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo("value of: crazy list.asList(): <[cat, dog]> should have contained <rabbit>");
+        .isEqualTo("value of: crazy list.asList()\n<[cat, dog]> should have contained <rabbit>");
   }
 }

--- a/core/src/test/java/com/google/common/truth/ThrowableSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/ThrowableSubjectTest.java
@@ -54,7 +54,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
     NullPointerException actual = new NullPointerException("message");
     expectFailureWhenTestingThat(actual).hasMessageThat().isEqualTo("foobar");
     assertThat(expectFailure.getFailure().getMessage())
-        .isEqualTo("value of: throwable.getMessage(): expected:<[foobar]> but was:<[message]>");
+        .isEqualTo("value of: throwable.getMessage()\n expected:<[foobar]> but was:<[message]>");
     assertErrorHasActualAsCause(actual, expectFailure.getFailure());
   }
 
@@ -62,7 +62,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
   public void hasMessageThat_MessageHasNullMessage_failure() {
     expectFailureWhenTestingThat(new NullPointerException("message")).hasMessageThat().isNull();
     assertThat(expectFailure.getFailure().getMessage())
-        .isEqualTo("value of: throwable.getMessage(): Not true that <\"message\"> is null");
+        .isEqualTo("value of: throwable.getMessage()\nNot true that <\"message\"> is null");
   }
 
   @Test
@@ -70,7 +70,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
     NullPointerException npe = new NullPointerException("message");
     expectFailureWhenTestingThat(npe).named("NPE").hasMessageThat().isEqualTo("foobar");
     assertThat(expectFailure.getFailure().getMessage())
-        .isEqualTo("value of: NPE.getMessage(): expected:<[foobar]> but was:<[message]>");
+        .isEqualTo("value of: NPE.getMessage()\n expected:<[foobar]> but was:<[message]>");
   }
 
   @Test
@@ -79,7 +79,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(npe).hasMessageThat().isEqualTo("message");
     assertThat(expectFailure.getFailure().getMessage())
         .isEqualTo(
-            "value of: throwable.getMessage(): Not true that <null> is equal to <\"message\">");
+            "value of: throwable.getMessage()\nNot true that <null> is equal to <\"message\">");
   }
 
   @Test
@@ -108,7 +108,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(actual).hasCauseThat().hasMessageThat().isEqualTo("message");
     assertThat(expectFailure.getFailure().getMessage())
         .isEqualTo(
-            "value of: throwable.getCause().getMessage(): expected:<[message]> but was:<[barfoo]>");
+            "value of: throwable.getCause().getMessage()\n expected:<[message]> but was:<[barfoo]>");
     assertErrorHasActualAsCause(actual, expectFailure.getFailure());
   }
 
@@ -118,7 +118,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(actual).hasCauseThat().isInstanceOf(RuntimeException.class);
     assertThat(expectFailure.getFailure().getMessage())
         .isEqualTo(
-            "value of: throwable.getCause(): Not true that <java.io.IOException: "
+            "value of: throwable.getCause()\nNot true that <java.io.IOException: "
                 + "barfoo> is an instance of <java.lang.RuntimeException>. "
                 + "It is an instance of <java.io.IOException>");
     assertErrorHasActualAsCause(actual, expectFailure.getFailure());
@@ -130,7 +130,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(actual).hasCauseThat().hasCauseThat().isNull();
     assertThat(expectFailure.getFailure().getMessage())
         .isEqualTo(
-            "value of: throwable.getCause().getCause(): "
+            "value of: throwable.getCause().getCause()\n"
                 + "Causal chain is not deep enough - add a .isNotNull() check?");
     assertErrorHasActualAsCause(actual, expectFailure.getFailure());
   }
@@ -146,7 +146,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
         .isEqualTo("message");
     assertThat(expectFailure.getFailure().getMessage())
         .isEqualTo(
-            "value of: throwable.getCause().getCause().getMessage(): "
+            "value of: throwable.getCause().getCause().getMessage()\n "
                 + "expected:<[message]> but was:<[buzz]>");
     assertErrorHasActualAsCause(actual, expectFailure.getFailure());
   }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Put "value of," "object was," and any user messages on their own lines, separate from the body.

This inches us closer to the format we'll have after we shift to a field-style format and API.
In particular, it will let us reimplement failWithRawMessage(...) as a call to failWithFields(fieldWithoutValue(...)) and migrate callers.

It also breaks up long lines like those plenty of existing subjects
produce.

RELNOTES=Put any user messages on their own lines, separate from the main failure message.

3adc73e217746bc7cf1d90b38716e1ccb158aaad

-------

<p> Make IterableSubject.UsingCorrespondence.displayingDiffsPairedBy() work for containsAnyOf/In().

This is the final change for this feature, apart from documentation... and multimaps, where the behaviour is TBD.

(The text of the failure messages is hopefully 'good enough' for now. I don't think it's worth fiddling with the punctuation given the upcoming changes. It's quite wordy, but it does happen only if the caller specifically asks for it.)

c0b435515992a50fcb3044027952ed2c58bf9294