### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/AssertionErrorWithFacts.java
+++ b/core/src/main/java/com/google/common/truth/AssertionErrorWithFacts.java
@@ -16,30 +16,30 @@
 package com.google.common.truth;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.truth.Field.makeMessage;
+import static com.google.common.truth.Fact.makeMessage;
 
 import com.google.common.collect.ImmutableList;
 import javax.annotation.Nullable;
 
 /**
- * An {@link AssertionError} composed of structured {@link Field} instances and other string
+ * An {@link AssertionError} composed of structured {@link Fact} instances and other string
  * messages.
  */
-final class AssertionErrorWithFields extends AssertionError implements ErrorWithFields {
-  static AssertionErrorWithFields create(
-      ImmutableList<String> messages, ImmutableList<Field> fields, @Nullable Throwable cause) {
-    return new AssertionErrorWithFields(messages, fields, cause);
+final class AssertionErrorWithFacts extends AssertionError implements ErrorWithFacts {
+  static AssertionErrorWithFacts create(
+      ImmutableList<String> messages, ImmutableList<Fact> facts, @Nullable Throwable cause) {
+    return new AssertionErrorWithFacts(messages, facts, cause);
   }
 
-  final ImmutableList<Field> fields;
+  final ImmutableList<Fact> facts;
 
   /** Separate cause field, in case initCause() fails. */
   @Nullable private final Throwable cause;
 
-  private AssertionErrorWithFields(
-      ImmutableList<String> messages, ImmutableList<Field> fields, @Nullable Throwable cause) {
-    super(makeMessage(messages, fields));
-    this.fields = checkNotNull(fields);
+  private AssertionErrorWithFacts(
+      ImmutableList<String> messages, ImmutableList<Fact> facts, @Nullable Throwable cause) {
+    super(makeMessage(messages, facts));
+    this.facts = checkNotNull(facts);
 
     this.cause = cause;
     try {
@@ -61,7 +61,7 @@ final class AssertionErrorWithFields extends AssertionError implements ErrorWith
   }
 
   @Override
-  public ImmutableList<Field> fields() {
-    return fields;
+  public ImmutableList<Fact> facts() {
+    return facts;
   }
 }

--- a/core/src/main/java/com/google/common/truth/ComparisonFailureWithFacts.java
+++ b/core/src/main/java/com/google/common/truth/ComparisonFailureWithFacts.java
@@ -19,8 +19,8 @@ package com.google.common.truth;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.commonPrefix;
 import static com.google.common.base.Strings.commonSuffix;
-import static com.google.common.truth.Field.field;
-import static com.google.common.truth.Field.makeMessage;
+import static com.google.common.truth.Fact.fact;
+import static com.google.common.truth.Fact.makeMessage;
 import static com.google.common.truth.Platform.ComparisonFailureMessageStrategy.OMIT_COMPARISON_FAILURE_GENERATED_MESSAGE;
 import static com.google.common.truth.SubjectUtils.concat;
 import static java.lang.Character.isHighSurrogate;
@@ -34,68 +34,67 @@ import javax.annotation.Nullable;
 
 /**
  * An {@link AssertionError} (usually a JUnit {@code ComparisonFailure}, but not under GWT) composed
- * of structured {@link Field} instances and other string messages.
+ * of structured {@link Fact} instances and other string messages.
  *
  * <p>This class includes logic to format expected and actual values for easier reading.
  */
-final class ComparisonFailureWithFields extends PlatformComparisonFailure
-    implements ErrorWithFields {
-  static ComparisonFailureWithFields create(
+final class ComparisonFailureWithFacts extends PlatformComparisonFailure implements ErrorWithFacts {
+  static ComparisonFailureWithFacts create(
       ImmutableList<String> messages,
-      ImmutableList<Field> headFields,
-      ImmutableList<Field> tailFields,
+      ImmutableList<Fact> headFacts,
+      ImmutableList<Fact> tailFacts,
       String expected,
       String actual,
       @Nullable Throwable cause) {
-    ImmutableList<Field> fields = makeFields(headFields, tailFields, expected, actual);
-    return new ComparisonFailureWithFields(messages, fields, expected, actual, cause);
+    ImmutableList<Fact> facts = makeFacts(headFacts, tailFacts, expected, actual);
+    return new ComparisonFailureWithFacts(messages, facts, expected, actual, cause);
   }
 
-  final ImmutableList<Field> fields;
+  final ImmutableList<Fact> facts;
 
-  private ComparisonFailureWithFields(
+  private ComparisonFailureWithFacts(
       ImmutableList<String> messages,
-      ImmutableList<Field> fields,
+      ImmutableList<Fact> facts,
       String expected,
       String actual,
       @Nullable Throwable cause) {
     super(
-        makeMessage(messages, fields),
+        makeMessage(messages, facts),
         checkNotNull(expected),
         checkNotNull(actual),
         /* suffix= */ null,
         cause,
         OMIT_COMPARISON_FAILURE_GENERATED_MESSAGE);
-    this.fields = checkNotNull(fields);
+    this.facts = checkNotNull(facts);
   }
 
   @Override
-  public ImmutableList<Field> fields() {
-    return fields;
+  public ImmutableList<Fact> facts() {
+    return facts;
   }
 
-  private static ImmutableList<Field> makeFields(
-      ImmutableList<Field> headFields,
-      ImmutableList<Field> tailFields,
+  private static ImmutableList<Fact> makeFacts(
+      ImmutableList<Fact> headFacts,
+      ImmutableList<Fact> tailFacts,
       String expected,
       String actual) {
-    return concat(headFields, formatExpectedAndActual(expected, actual), tailFields);
+    return concat(headFacts, formatExpectedAndActual(expected, actual), tailFacts);
   }
 
   /**
-   * Returns one or more fields describing the difference between the given expected and actual
+   * Returns one or more facts describing the difference between the given expected and actual
    * values.
    *
-   * <p>Currently, that means either 2 fields (one each for expected and actual) or 1 field with a
+   * <p>Currently, that means either 2 facts (one each for expected and actual) or 1 fact with a
    * diff-like (but much simpler) view.
    *
-   * <p>In the case of 2 fields, the fields contain either the full expected and actual values or,
-   * if the values have a long prefix or suffix in common, abbreviated values with "…" at the
-   * beginning or end.
+   * <p>In the case of 2 facts, the facts contain either the full expected and actual values or, if
+   * the values have a long prefix or suffix in common, abbreviated values with "…" at the beginning
+   * or end.
    */
   @VisibleForTesting
-  static ImmutableList<Field> formatExpectedAndActual(String expected, String actual) {
-    ImmutableList<Field> result;
+  static ImmutableList<Fact> formatExpectedAndActual(String expected, String actual) {
+    ImmutableList<Fact> result;
 
     // TODO(cpovirk): Call attention to differences in trailing whitespace.
     // TODO(cpovirk): And changes in the *kind* of whitespace characters in the middle of the line.
@@ -110,11 +109,11 @@ final class ComparisonFailureWithFields extends PlatformComparisonFailure
       return result;
     }
 
-    return ImmutableList.of(field("expected", expected), field("but was", actual));
+    return ImmutableList.of(fact("expected", expected), fact("but was", actual));
   }
 
   @Nullable
-  private static ImmutableList<Field> removeCommonPrefixAndSuffix(String expected, String actual) {
+  private static ImmutableList<Fact> removeCommonPrefixAndSuffix(String expected, String actual) {
     int originalExpectedLength = expected.length();
 
     // TODO(cpovirk): Use something like BreakIterator where available.
@@ -152,7 +151,7 @@ final class ComparisonFailureWithFields extends PlatformComparisonFailure
       return null;
     }
 
-    return ImmutableList.of(field("expected", expected), field("but was", actual));
+    return ImmutableList.of(fact("expected", expected), fact("but was", actual));
   }
 
   private static final int CONTEXT = 20;

--- a/core/src/main/java/com/google/common/truth/ErrorWithFacts.java
+++ b/core/src/main/java/com/google/common/truth/ErrorWithFacts.java
@@ -20,8 +20,8 @@ import com.google.common.collect.ImmutableList;
 
 /**
  * Supertype of Truth's {@link AssertionError} subclasses that are created from a list of {@link
- * Field} instances.
+ * Fact} instances.
  */
-interface ErrorWithFields {
-  ImmutableList<Field> fields();
+interface ErrorWithFacts {
+  ImmutableList<Fact> facts();
 }

--- a/core/src/main/java/com/google/common/truth/Fact.java
+++ b/core/src/main/java/com/google/common/truth/Fact.java
@@ -24,35 +24,35 @@ import com.google.common.collect.ImmutableList;
 import javax.annotation.Nullable;
 
 /** A string key-value pair in a failure message, such as "expected: abc" or "but was: xyz." */
-final class Field {
+final class Fact {
   /**
-   * Creates a field with the given key and value, which will be printed in a format like "key:
+   * Creates a fact with the given key and value, which will be printed in a format like "key:
    * value." The value is converted to a string by calling {@code String.valueOf} on it.
    */
-  static Field field(String key, Object value) {
-    return new Field(key, String.valueOf(value));
+  static Fact fact(String key, Object value) {
+    return new Fact(key, String.valueOf(value));
   }
 
   /**
-   * Creates a field with no value, which will be printed in the format "key" (with no colon or
+   * Creates a fact with no value, which will be printed in the format "key" (with no colon or
    * value).
    */
-  static Field fieldWithoutValue(String key) {
-    return new Field(key, null);
+  static Fact factWithoutValue(String key) {
+    return new Fact(key, null);
   }
 
   final String key;
   @Nullable final String value;
 
-  private Field(String key, @Nullable String value) {
+  private Fact(String key, @Nullable String value) {
     this.key = checkNotNull(key);
     this.value = value;
   }
 
   /**
-   * Returns a simple string representation for the field. While this is used by the old-style
+   * Returns a simple string representation for the fact. While this is used by the old-style
    * messages and {@code TruthFailureSubject} output, we're moving away from the old-style messages
-   * and onto {@link #makeMessage}, which aligns fields horizontally and indents multiline values.
+   * and onto {@link #makeMessage}, which aligns facts horizontally and indents multiline values.
    */
   @Override
   public String toString() {
@@ -60,17 +60,17 @@ final class Field {
   }
 
   /**
-   * Formats the given messages and fields into a string for use as the message of a test failure.
-   * In particular, this method horizontally aligns the beginning of field values.
+   * Formats the given messages and facts into a string for use as the message of a test failure. In
+   * particular, this method horizontally aligns the beginning of fact values.
    */
-  static String makeMessage(ImmutableList<String> messages, ImmutableList<Field> fields) {
+  static String makeMessage(ImmutableList<String> messages, ImmutableList<Fact> facts) {
     int longestKeyLength = 0;
     boolean seenNewlineInValue = false;
-    for (Field field : fields) {
-      if (field.value != null) {
-        longestKeyLength = max(longestKeyLength, field.key.length());
+    for (Fact fact : facts) {
+      if (fact.value != null) {
+        longestKeyLength = max(longestKeyLength, fact.key.length());
         // TODO(cpovirk): Look for other kinds of newlines.
-        seenNewlineInValue |= field.value.contains("\n");
+        seenNewlineInValue |= fact.value.contains("\n");
       }
     }
 
@@ -81,7 +81,7 @@ final class Field {
     }
 
     /*
-     * *Usually* the first field is printed at the beginning of a new line. However, when this
+     * *Usually* the first fact is printed at the beginning of a new line. However, when this
      * exception is the cause of another exception, that exception will print it starting after
      * "Caused by: " on the same line. The other exception sometimes also reuses this message as its
      * own message. In both of those scenarios, the first line doesn't start at column 0, so the
@@ -90,18 +90,18 @@ final class Field {
      * There's not much we can do about this, short of always starting with a newline (which would
      * leave a blank line at the beginning of the message in the normal case).
      */
-    for (Field field : fields) {
+    for (Fact fact : facts) {
       if (seenNewlineInValue) {
-        builder.append(field.key);
-        if (field.value != null) {
+        builder.append(fact.key);
+        if (fact.value != null) {
           builder.append(":\n");
-          builder.append(indent(field.value));
+          builder.append(indent(fact.value));
         }
       } else {
-        builder.append(padEnd(field.key, longestKeyLength, ' '));
-        if (field.value != null) {
+        builder.append(padEnd(fact.key, longestKeyLength, ' '));
+        if (fact.value != null) {
           builder.append(": ");
-          builder.append(field.value);
+          builder.append(fact.value);
         }
       }
       builder.append('\n');

--- a/core/src/main/java/com/google/common/truth/FailureMetadata.java
+++ b/core/src/main/java/com/google/common/truth/FailureMetadata.java
@@ -20,7 +20,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verifyNotNull;
-import static com.google.common.truth.Field.field;
+import static com.google.common.truth.Fact.fact;
 import static com.google.common.truth.StackTraceCleaner.cleanStackTrace;
 import static com.google.common.truth.SubjectUtils.concat;
 
@@ -79,7 +79,7 @@ public final class FailureMetadata {
      * which lets subjects customize display through actualCustomStringRepresentation(). Why not
      * call actualAsString() immediately? First, it might be expensive, and second, the Subject
      * isn't initialized at the time we receive it. We *might* be able to make it safe to call if it
-     * looks only at actual(), but it might try to look at fields initialized by a subclass, which
+     * looks only at actual(), but it might try to look at facts initialized by a subclass, which
      * aren't ready yet.
      */
     @Nullable final Subject<?, ?> subject;
@@ -251,7 +251,7 @@ public final class FailureMetadata {
    * root's exact relationship to the final object, but we know it's some object "different enough"
    * to be worth displaying.)
    */
-  private Optional<Field> description() {
+  private Optional<Fact> description() {
     String description = null;
     boolean descriptionWasDerived = false;
     for (Step step : steps) {
@@ -273,8 +273,8 @@ public final class FailureMetadata {
       }
     }
     return descriptionWasDerived
-        ? Optional.of(field("value of", description))
-        : Optional.<Field>absent();
+        ? Optional.of(fact("value of", description))
+        : Optional.<Fact>absent();
   }
 
   private Set<String> descriptionAsStrings() {
@@ -301,7 +301,7 @@ public final class FailureMetadata {
    * are some edge cases that we're not sure how to handle yet, for which we might introduce
    * additional {@code check}-like methods someday.)
    */
-  private Optional<Field> rootUnlessThrowable() {
+  private Optional<Fact> rootUnlessThrowable() {
     Step rootSubject = null;
     boolean seenDerivation = false;
     for (Step step : steps) {
@@ -338,10 +338,10 @@ public final class FailureMetadata {
      */
     return seenDerivation
         ? Optional.of(
-            field(
+            fact(
                 rootSubject.subject.typeDescription() + " was",
                 rootSubject.subject.actualAsStringNoBrackets()))
-        : Optional.<Field>absent();
+        : Optional.<Fact>absent();
   }
 
   @Nullable

--- a/core/src/main/java/com/google/common/truth/Platform.java
+++ b/core/src/main/java/com/google/common/truth/Platform.java
@@ -15,7 +15,7 @@
  */
 package com.google.common.truth;
 
-import static com.google.common.truth.Field.field;
+import static com.google.common.truth.Fact.fact;
 import static com.google.common.truth.Platform.ComparisonFailureMessageStrategy.INCLUDE_COMPARISON_FAILURE_GENERATED_MESSAGE;
 import static com.google.common.truth.Truth.appendSuffixIfNotNull;
 import static difflib.DiffUtils.diff;
@@ -96,7 +96,7 @@ final class Platform {
   }
 
   @Nullable
-  static ImmutableList<Field> makeDiff(String expected, String actual) {
+  static ImmutableList<Fact> makeDiff(String expected, String actual) {
     ImmutableList<String> expectedLines = splitLines(expected);
     ImmutableList<String> actualLines = splitLines(actual);
     Patch<String> diff = diff(expectedLines, actualLines);
@@ -104,7 +104,7 @@ final class Platform {
         generateUnifiedDiff("expected", "actual", expectedLines, diff, /* contextSize= */ 3);
     if (unifiedDiff.isEmpty()) {
       return ImmutableList.of(
-          field("diff", "(line contents match, but line-break characters differ)"));
+          fact("diff", "(line contents match, but line-break characters differ)"));
       // TODO(cpovirk): Possibly include the expected/actual value, too?
     }
     unifiedDiff = unifiedDiff.subList(2, unifiedDiff.size()); // remove "--- expected," "+++ actual"
@@ -112,7 +112,7 @@ final class Platform {
     if (result.length() > expected.length() && result.length() > actual.length()) {
       return null;
     }
-    return ImmutableList.of(field("diff", result));
+    return ImmutableList.of(fact("diff", result));
   }
   private static ImmutableList<String> splitLines(String s) {
     // splitToList is @Beta, so we avoid it.

--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -19,8 +19,8 @@ import static com.google.common.base.CaseFormat.LOWER_CAMEL;
 import static com.google.common.base.CaseFormat.UPPER_CAMEL;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.truth.Field.field;
-import static com.google.common.truth.Field.fieldWithoutValue;
+import static com.google.common.truth.Fact.fact;
+import static com.google.common.truth.Fact.factWithoutValue;
 import static com.google.common.truth.Platform.doubleToString;
 import static com.google.common.truth.Platform.floatToString;
 import static com.google.common.truth.StringUtil.format;
@@ -478,7 +478,7 @@ public class Subject<S extends Subject<S, T>, T> {
 
   /**
    * The result of comparing two objects for equality. This includes both the "equal"/"not-equal"
-   * bit and, in the case of "not equal," optional fields describing the difference.
+   * bit and, in the case of "not equal," optional facts describing the difference.
    */
   private static final class ComparisonResult {
     /**
@@ -490,8 +490,8 @@ public class Subject<S extends Subject<S, T>, T> {
     }
 
     /** Returns a non-equal result with the given description. */
-    static ComparisonResult differentWithDescription(Field... fields) {
-      return new ComparisonResult(ImmutableList.copyOf(fields));
+    static ComparisonResult differentWithDescription(Fact... facts) {
+      return new ComparisonResult(ImmutableList.copyOf(facts));
     }
 
     /** Returns an equal result. */
@@ -506,20 +506,20 @@ public class Subject<S extends Subject<S, T>, T> {
 
     private static final ComparisonResult EQUAL = new ComparisonResult(null);
     private static final ComparisonResult DIFFERENT_NO_DESCRIPTION =
-        new ComparisonResult(ImmutableList.<Field>of());
+        new ComparisonResult(ImmutableList.<Fact>of());
 
-    @Nullable private final ImmutableList<Field> fields;
+    @Nullable private final ImmutableList<Fact> facts;
 
-    private ComparisonResult(ImmutableList<Field> fields) {
-      this.fields = fields;
+    private ComparisonResult(ImmutableList<Fact> facts) {
+      this.facts = facts;
     }
 
     boolean valuesAreEqual() {
-      return fields == null;
+      return facts == null;
     }
 
-    ImmutableList<Field> fieldsOrEmpty() {
-      return firstNonNull(fields, ImmutableList.<Field>of());
+    ImmutableList<Fact> factsOrEmpty() {
+      return firstNonNull(facts, ImmutableList.<Fact>of());
     }
   }
 
@@ -533,7 +533,7 @@ public class Subject<S extends Subject<S, T>, T> {
       return ComparisonResult.equal();
     }
     return ComparisonResult.differentWithDescription(
-        field("expected", Arrays.toString(expected)), field("but was", Arrays.toString(actual)));
+        fact("expected", Arrays.toString(expected)), fact("but was", Arrays.toString(actual)));
   }
 
   /**
@@ -551,22 +551,22 @@ public class Subject<S extends Subject<S, T>, T> {
     String expectedType = arrayType(expectedArray);
     String actualType = arrayType(actualArray);
     if (!expectedType.equals(actualType)) {
-      Field indexField =
+      Fact indexFact =
           lastIndex.isEmpty()
-              ? fieldWithoutValue("wrong type")
-              : field("wrong type for index", lastIndex);
+              ? factWithoutValue("wrong type")
+              : fact("wrong type for index", lastIndex);
       return ComparisonResult.differentWithDescription(
-          indexField, field("expected", expectedType), field("but was", actualType));
+          indexFact, fact("expected", expectedType), fact("but was", actualType));
     }
     int actualLength = Array.getLength(actualArray);
     int expectedLength = Array.getLength(expectedArray);
     if (expectedLength != actualLength) {
-      Field indexField =
+      Fact indexFact =
           lastIndex.isEmpty()
-              ? fieldWithoutValue("wrong length")
-              : field("wrong length for index", lastIndex);
+              ? factWithoutValue("wrong length")
+              : fact("wrong length for index", lastIndex);
       return ComparisonResult.differentWithDescription(
-          indexField, field("expected", expectedLength), field("but was", actualLength));
+          indexFact, fact("expected", expectedLength), fact("but was", actualLength));
     }
     for (int i = 0; i < actualLength || i < expectedLength; i++) {
       String index = lastIndex + "[" + i + "]";
@@ -586,7 +586,7 @@ public class Subject<S extends Subject<S, T>, T> {
           continue;
         }
       }
-      return ComparisonResult.differentWithDescription(field("differs at index", index));
+      return ComparisonResult.differentWithDescription(fact("differs at index", index));
     }
     return ComparisonResult.equal();
   }
@@ -751,7 +751,7 @@ public class Subject<S extends Subject<S, T>, T> {
     if (actual() instanceof byte[] && expected instanceof byte[]) {
       // TODO(cpovirk): Expand this to cover more types.
       failComparing(
-          Joiner.on("; ").join(difference.fieldsOrEmpty()),
+          Joiner.on("; ").join(difference.factsOrEmpty()),
           formatActualOrExpected(expected),
           formatActualOrExpected(actual()));
       return;
@@ -775,9 +775,9 @@ public class Subject<S extends Subject<S, T>, T> {
     if (!needsClassDisambiguation && sameToStrings) {
       message.append(" (although their toString() representations are the same)");
     }
-    if (!difference.fieldsOrEmpty().isEmpty()) {
+    if (!difference.factsOrEmpty().isEmpty()) {
       message.append(". ");
-      Joiner.on("; ").appendTo(message, difference.fieldsOrEmpty());
+      Joiner.on("; ").appendTo(message, difference.factsOrEmpty());
     }
     metadata.fail(message.toString());
   }

--- a/core/src/main/java/com/google/common/truth/SubjectUtils.java
+++ b/core/src/main/java/com/google/common/truth/SubjectUtils.java
@@ -245,6 +245,10 @@ final class SubjectUtils {
     return new ImmutableList.Builder<E>().add(array).add(object).build();
   }
 
+  static <E> ImmutableList<E> sandwich(E first, E[] array, E last) {
+    return new ImmutableList.Builder<E>().add(first).add(array).add(last).build();
+  }
+
   static <E> ImmutableList<E> append(ImmutableList<? extends E> list, E object) {
     return new ImmutableList.Builder<E>().addAll(list).add(object).build();
   }

--- a/core/src/main/java/com/google/common/truth/TruthFailureSubject.java
+++ b/core/src/main/java/com/google/common/truth/TruthFailureSubject.java
@@ -20,6 +20,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.Fact.fact;
+import static com.google.common.truth.Fact.factWithoutValue;
 
 import com.google.common.collect.ImmutableList;
 import javax.annotation.Nullable;
@@ -70,7 +71,7 @@ final class TruthFailureSubject extends ThrowableSubject {
   /** Returns a subject for the list of fact keys. */
   public IterableSubject factKeys() {
     if (!(actual() instanceof ErrorWithFacts)) {
-      failWithRawMessage("expected a failure thrown by Truth's new failure API");
+      fail(factWithoutValue("expected a failure thrown by Truth's new failure API"));
       return ignoreCheck().that(ImmutableList.of());
     }
     ErrorWithFacts error = (ErrorWithFacts) actual();
@@ -116,7 +117,7 @@ final class TruthFailureSubject extends ThrowableSubject {
   private StringSubject doFactValue(String key, @Nullable Integer index) {
     checkNotNull(key);
     if (!(actual() instanceof ErrorWithFacts)) {
-      failWithRawMessage("expected a failure thrown by Truth's new failure API");
+      fail(factWithoutValue("expected a failure thrown by Truth's new failure API"));
       return ignoreCheck().that("");
     }
     ErrorWithFacts error = (ErrorWithFacts) actual();
@@ -127,26 +128,21 @@ final class TruthFailureSubject extends ThrowableSubject {
      */
     ImmutableList<Fact> factsWithName = factsWithName(error, key);
     if (factsWithName.isEmpty()) {
-      failWithRawMessage(
-          fact("expected to contain fact", key)
-              + "\n"
-              + fact("but contained only", getFactKeys(error)));
+      failWithoutActual(
+          fact("expected to contain fact", key), fact("but contained only", getFactKeys(error)));
       return ignoreCheck().that("");
     }
     if (index == null && factsWithName.size() > 1) {
-      failWithRawMessage(
-          fact("expected to contain a single fact with key", key)
-              + "\n"
-              + fact("but contained multiple", factsWithName));
+      failWithoutActual(
+          fact("expected to contain a single fact with key", key),
+          fact("but contained multiple", factsWithName));
       return ignoreCheck().that("");
     }
     if (index != null && index > factsWithName.size()) {
-      failWithRawMessage(
-          fact("for key", key)
-              + "\n"
-              + fact("index too high", index)
-              + "\n"
-              + fact("fact count was", factsWithName.size()));
+      failWithoutActual(
+          fact("for key", key),
+          fact("index too high", index),
+          fact("fact count was", factsWithName.size()));
       return ignoreCheck().that("");
     }
     StandardSubjectBuilder check =

--- a/core/src/main/java/com/google/common/truth/super/com/google/common/truth/Platform.java
+++ b/core/src/main/java/com/google/common/truth/super/com/google/common/truth/Platform.java
@@ -124,7 +124,7 @@ final class Platform {
   }
 
   @Nullable
-  static ImmutableList<Field> makeDiff(String expected, String actual) {
+  static ImmutableList<Fact> makeDiff(String expected, String actual) {
     /*
      * IIUC, GWT messages lose their newlines by the time users see them. Given that, users are
      * likely better served by showing the expected and actual values with mangled newlines than by

--- a/core/src/test/java/com/google/common/truth/BaseSubjectTestCase.java
+++ b/core/src/test/java/com/google/common/truth/BaseSubjectTestCase.java
@@ -15,5 +15,23 @@
  */
 package com.google.common.truth;
 
+import static com.google.common.truth.ExpectFailure.assertThat;
+
 /** Base class for truth subject tests to extend. */
-abstract class BaseSubjectTestCase extends PlatformBaseSubjectTestCase {}
+abstract class BaseSubjectTestCase extends PlatformBaseSubjectTestCase {
+  final void assertFailureKeys(String... keys) {
+    assertThatFailure().factKeys().containsExactlyElementsIn(keys).inOrder();
+  }
+
+  final void assertFailureValue(String key, String value) {
+    assertThatFailure().factValue(key).isEqualTo(value);
+  }
+
+  final void assertFailureValue(String key, int index, String value) {
+    assertThatFailure().factValue(key, index).isEqualTo(value);
+  }
+
+  private TruthFailureSubject assertThatFailure() {
+    return assertThat(expectFailure.getFailure());
+  }
+}

--- a/core/src/test/java/com/google/common/truth/ComparisonFailureWithFactsTest.java
+++ b/core/src/test/java/com/google/common/truth/ComparisonFailureWithFactsTest.java
@@ -17,7 +17,7 @@
 package com.google.common.truth;
 
 import static com.google.common.base.Strings.repeat;
-import static com.google.common.truth.ComparisonFailureWithFields.formatExpectedAndActual;
+import static com.google.common.truth.ComparisonFailureWithFacts.formatExpectedAndActual;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.annotations.GwtIncompatible;
@@ -27,9 +27,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Test for {@link ComparisonFailureWithFields}. */
+/** Test for {@link ComparisonFailureWithFacts}. */
 @RunWith(JUnit4.class)
-public class ComparisonFailureWithFieldsTest {
+public class ComparisonFailureWithFactsTest {
   @Test
   public void formatAllDifferent() {
     runFormatTest(
@@ -264,19 +264,19 @@ public class ComparisonFailureWithFieldsTest {
 
   private static void runFormatTest(
       String expected, String actual, String expectedExpected, String expectedActual) {
-    ImmutableList<Field> fields = formatExpectedAndActual(expected, actual);
-    assertThat(fields).hasSize(2);
-    assertThat(fields.get(0).key).isEqualTo("expected");
-    assertThat(fields.get(1).key).isEqualTo("but was");
-    assertThat(fields.get(0).value).isEqualTo(expectedExpected);
-    assertThat(fields.get(1).value).isEqualTo(expectedActual);
+    ImmutableList<Fact> facts = formatExpectedAndActual(expected, actual);
+    assertThat(facts).hasSize(2);
+    assertThat(facts.get(0).key).isEqualTo("expected");
+    assertThat(facts.get(1).key).isEqualTo("but was");
+    assertThat(facts.get(0).value).isEqualTo(expectedExpected);
+    assertThat(facts.get(1).value).isEqualTo(expectedActual);
   }
 
   @GwtIncompatible
   private static void runFormatTest(String expected, String actual, String expectedDiff) {
-    ImmutableList<Field> fields = formatExpectedAndActual(expected, actual);
-    assertThat(fields).hasSize(1);
-    assertThat(fields.get(0).key).isEqualTo("diff");
-    assertThat(fields.get(0).value).isEqualTo(expectedDiff);
+    ImmutableList<Fact> facts = formatExpectedAndActual(expected, actual);
+    assertThat(facts).hasSize(1);
+    assertThat(facts.get(0).key).isEqualTo("diff");
+    assertThat(facts.get(0).value).isEqualTo(expectedDiff);
   }
 }

--- a/core/src/test/java/com/google/common/truth/DoubleSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/DoubleSubjectTest.java
@@ -545,7 +545,15 @@ public class DoubleSubjectTest extends BaseSubjectTestCase {
     assertThat(-1.0 * Double.MIN_VALUE).isNotNaN();
     assertThat(Double.POSITIVE_INFINITY).isNotNaN();
     assertThat(Double.NEGATIVE_INFINITY).isNotNaN();
+  }
+
+  @Test
+  public void isNotNaNIsNaN() {
     assertThatIsNotNaNFails(Double.NaN);
+  }
+
+  @Test
+  public void isNotNaNIsNull() {
     assertThatIsNotNaNFails(null);
   }
 

--- a/core/src/test/java/com/google/common/truth/ExpectFailureRuleTest.java
+++ b/core/src/test/java/com/google/common/truth/ExpectFailureRuleTest.java
@@ -33,8 +33,8 @@ public class ExpectFailureRuleTest {
 
   @Test
   public void expectFail_captureFailureAsExpected() {
-    expectFailure.whenTesting().that(4).isNotEqualTo(4);
-    assertThat(expectFailure.getFailure()).hasMessageThat().contains("<4> is not equal to <4>");
+    expectFailure.whenTesting().fail("abc");
+    assertThat(expectFailure.getFailure()).hasMessageThat().isEqualTo("abc");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/ExpectFailureTest.java
+++ b/core/src/test/java/com/google/common/truth/ExpectFailureTest.java
@@ -33,15 +33,9 @@ public class ExpectFailureTest {
   }
 
   @Test
-  public void expectFail_notEquals() {
-    expectFailure.whenTesting().that(4).isNotEqualTo(4);
-    assertThat(expectFailure.getFailure()).hasMessageThat().contains("<4> is not equal to <4>");
-  }
-
-  @Test
-  public void expectFail_stringContains() {
-    expectFailure.whenTesting().that("abc").contains("x");
-    assertThat(expectFailure.getFailure()).hasMessageThat().contains("contains <\"x\">");
+  public void expectFail() {
+    expectFailure.whenTesting().fail("abc");
+    assertThat(expectFailure.getFailure()).hasMessageThat().isEqualTo("abc");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/ExpectTest.java
+++ b/core/src/test/java/com/google/common/truth/ExpectTest.java
@@ -92,28 +92,28 @@ public class ExpectTest {
   @Test
   public void singleExpectationFails() {
     thrown.expectMessage("1 expectation failed:");
-    thrown.expectMessage("1. Not true that <\"abc\"> contains <\"x\">");
-    expect.that("abc").contains("x");
+    thrown.expectMessage("1. x");
+    expect.fail("x");
   }
 
   @Test
   public void expectFail() {
     thrown.expectMessage("3 expectations failed:");
-    thrown.expectMessage("1. Not true that <\"abc\"> contains <\"x\">");
-    thrown.expectMessage("2. Not true that <\"abc\"> contains <\"y\">");
-    thrown.expectMessage("3. Not true that <\"abc\"> contains <\"z\">");
-    expect.that("abc").contains("x");
-    expect.that("abc").contains("y");
-    expect.that("abc").contains("z");
+    thrown.expectMessage("1. x");
+    thrown.expectMessage("2. y");
+    thrown.expectMessage("3. z");
+    expect.fail("x");
+    expect.fail("y");
+    expect.fail("z");
   }
 
   @Test
   public void expectFail10Aligned() {
     thrown.expectMessage("10 expectations failed:");
-    thrown.expectMessage(" 1. Not true that <\"abc\"> contains <\"x\">");
-    thrown.expectMessage("10. Not true that <\"abc\"> contains <\"x\">");
+    thrown.expectMessage(" 1. x");
+    thrown.expectMessage("10. x");
     for (int i = 0; i < 10; i++) {
-      expect.that("abc").contains("x");
+      expect.fail("x");
     }
   }
 
@@ -130,26 +130,26 @@ public class ExpectTest {
   @Test
   public void expectFailWithExceptionNoMessage() {
     thrown.expectMessage("3 expectations failed:");
-    thrown.expectMessage("1. Not true that <\"abc\"> contains <\"x\">");
-    thrown.expectMessage("2. Not true that <\"abc\"> contains <\"y\">");
+    thrown.expectMessage("1. x");
+    thrown.expectMessage("2. y");
     thrown.expectMessage(
         "3. Also, after those failures, an exception was thrown: "
             + "java.lang.IllegalStateException");
-    expect.that("abc").contains("x");
-    expect.that("abc").contains("y");
+    expect.fail("x");
+    expect.fail("y");
     throw new IllegalStateException();
   }
 
   @Test
   public void expectFailWithExceptionWithMessage() {
     thrown.expectMessage("3 expectations failed:");
-    thrown.expectMessage("1. Not true that <\"abc\"> contains <\"x\">");
-    thrown.expectMessage("2. Not true that <\"abc\"> contains <\"y\">");
+    thrown.expectMessage("1. x");
+    thrown.expectMessage("2. y");
     thrown.expectMessage(
         "3. Also, after those failures, an exception was thrown: "
             + "java.lang.IllegalStateException: testing");
-    expect.that("abc").contains("x");
-    expect.that("abc").contains("y");
+    expect.fail("x");
+    expect.fail("y");
     throw new IllegalStateException("testing");
   }
 
@@ -158,8 +158,8 @@ public class ExpectTest {
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("testing");
     throwException();
-    expect.that("abc").contains("x");
-    expect.that("abc").contains("y");
+    expect.fail("x");
+    expect.fail("y");
   }
 
   private void throwException() {
@@ -169,21 +169,21 @@ public class ExpectTest {
   @Test
   public void expectFailWithFailuresBeforeAssume() {
     thrown.expectMessage("3 expectations failed:");
-    thrown.expectMessage("1. Not true that <\"abc\"> contains <\"x\">");
-    thrown.expectMessage("2. Not true that <\"abc\"> contains <\"y\">");
+    thrown.expectMessage("1. x");
+    thrown.expectMessage("2. y");
     thrown.expectMessage(
         "3. Also, after those failures, an assumption was violated: "
             + "com.google.common.truth.TruthJUnit$ThrowableAssumptionViolatedException: testing");
-    expect.that("abc").contains("x");
-    expect.that("abc").contains("y");
+    expect.fail("x");
+    expect.fail("y");
     assume().fail("testing");
   }
 
   @Test
   public void expectSuccessWithFailuresAfterAssume() {
     assume().fail("testing");
-    expect.that("abc").contains("x");
-    expect.that("abc").contains("y");
+    expect.fail("x");
+    expect.fail("y");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/FactTest.java
+++ b/core/src/test/java/com/google/common/truth/FactTest.java
@@ -16,9 +16,9 @@
 
 package com.google.common.truth;
 
-import static com.google.common.truth.Field.field;
-import static com.google.common.truth.Field.fieldWithoutValue;
-import static com.google.common.truth.Field.makeMessage;
+import static com.google.common.truth.Fact.fact;
+import static com.google.common.truth.Fact.factWithoutValue;
+import static com.google.common.truth.Fact.makeMessage;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
@@ -26,52 +26,52 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests for {@link Field}. */
+/** Tests for {@link Fact}. */
 @RunWith(JUnit4.class)
-public class FieldTest {
+public class FactTest {
   @Test
   public void string() {
-    assertThat(field("foo", "bar").toString()).isEqualTo("foo: bar");
+    assertThat(fact("foo", "bar").toString()).isEqualTo("foo: bar");
   }
 
   @Test
   public void stringWithoutValue() {
-    assertThat(fieldWithoutValue("foo").toString()).isEqualTo("foo");
+    assertThat(factWithoutValue("foo").toString()).isEqualTo("foo");
   }
 
   @Test
-  public void oneFields() {
-    assertThat(makeMessage(ImmutableList.<String>of(), ImmutableList.of(field("foo", "bar"))))
+  public void oneFacts() {
+    assertThat(makeMessage(ImmutableList.<String>of(), ImmutableList.of(fact("foo", "bar"))))
         .isEqualTo("foo: bar");
   }
 
   @Test
-  public void twoFields() {
+  public void twoFacts() {
     assertThat(
             makeMessage(
                 ImmutableList.<String>of(),
-                ImmutableList.of(field("foo", "bar"), field("longer name", "other value"))))
+                ImmutableList.of(fact("foo", "bar"), fact("longer name", "other value"))))
         .isEqualTo("foo        : bar\nlonger name: other value");
   }
 
   @Test
-  public void oneFieldWithoutValue() {
-    assertThat(makeMessage(ImmutableList.<String>of(), ImmutableList.of(fieldWithoutValue("foo"))))
+  public void oneFactWithoutValue() {
+    assertThat(makeMessage(ImmutableList.<String>of(), ImmutableList.of(factWithoutValue("foo"))))
         .isEqualTo("foo");
   }
 
   @Test
-  public void twoFieldsOneWithoutValue() {
+  public void twoFactsOneWithoutValue() {
     assertThat(
             makeMessage(
                 ImmutableList.<String>of(),
-                ImmutableList.of(field("foo", "bar"), fieldWithoutValue("hello"))))
+                ImmutableList.of(fact("foo", "bar"), factWithoutValue("hello"))))
         .isEqualTo("foo: bar\nhello");
   }
 
   @Test
   public void newline() {
-    assertThat(makeMessage(ImmutableList.<String>of(), ImmutableList.of(field("foo", "bar\nbaz"))))
+    assertThat(makeMessage(ImmutableList.<String>of(), ImmutableList.of(fact("foo", "bar\nbaz"))))
         .isEqualTo("foo:\n    bar\n    baz");
   }
 
@@ -80,14 +80,13 @@ public class FieldTest {
     assertThat(
             makeMessage(
                 ImmutableList.<String>of(),
-                ImmutableList.of(field("foo", "bar\nbaz"), fieldWithoutValue("xyz"))))
+                ImmutableList.of(fact("foo", "bar\nbaz"), factWithoutValue("xyz"))))
         .isEqualTo("foo:\n    bar\n    baz\nxyz");
   }
 
   @Test
   public void withMessage() {
-    assertThat(
-            makeMessage(ImmutableList.<String>of("hello"), ImmutableList.of(field("foo", "bar"))))
+    assertThat(makeMessage(ImmutableList.<String>of("hello"), ImmutableList.of(fact("foo", "bar"))))
         .isEqualTo("hello\nfoo: bar");
   }
 }

--- a/core/src/test/java/com/google/common/truth/FloatSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/FloatSubjectTest.java
@@ -545,7 +545,15 @@ public class FloatSubjectTest extends BaseSubjectTestCase {
     assertThat(-1.0 * Float.MIN_VALUE).isNotNaN();
     assertThat(Float.POSITIVE_INFINITY).isNotNaN();
     assertThat(Float.NEGATIVE_INFINITY).isNotNaN();
+  }
+
+  @Test
+  public void isNotNaNIsNaN() {
     assertThatIsNotNaNFails(Float.NaN);
+  }
+
+  @Test
+  public void isNotNaNIsNull() {
     assertThatIsNotNaNFails(null);
   }
 

--- a/core/src/test/java/com/google/common/truth/SubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/SubjectTest.java
@@ -111,13 +111,10 @@ public class SubjectTest extends BaseSubjectTestCase {
         }
 
         subject.isEqualTo(null);
-        // TODO(cpovirk): Enable this test after fixing this and other null bugs in array subjects.
-        if (!(subject instanceof AbstractArraySubject)) {
-          try {
-            subject.isNotEqualTo(null); // should throw
-            throw new Error("assertThat(null).isNotEqualTo(null) should throw an exception!");
-          } catch (AssertionError expected) {
-          }
+        try {
+          subject.isNotEqualTo(null); // should throw
+          throw new Error("assertThat(null).isNotEqualTo(null) should throw an exception!");
+        } catch (AssertionError expected) {
         }
 
         subject.isSameAs(null);
@@ -133,14 +130,11 @@ public class SubjectTest extends BaseSubjectTestCase {
           assertThat(expected).hasMessageThat().contains("is equal to any element in");
         }
 
-        // This is a hack...but we have to skip DoubleSubject (requires a tolerance)
-        // and array-based subjects (they require a primitive array for the actual value).
-        if (subject instanceof DoubleSubject || subject instanceof AbstractArraySubject) {
-          continue;
+        // TODO(cpovirk): Fix bug.
+        if (!(subject instanceof AbstractArraySubject)) {
+          // check all public assertion methods for correct null handling
+          npTester.testAllPublicInstanceMethods(subject);
         }
-
-        // check all public assertion methods for correct null handling
-        npTester.testAllPublicInstanceMethods(subject);
 
         subject.isNotEqualTo(new Object());
         subject.isEqualTo(null);

--- a/core/src/test/java/com/google/common/truth/TruthFailureSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/TruthFailureSubjectTest.java
@@ -28,8 +28,6 @@ import org.junit.runners.JUnit4;
 /** Tests for {@link TruthFailureSubject}. */
 @RunWith(JUnit4.class)
 public class TruthFailureSubjectTest extends BaseSubjectTestCase {
-  // TODO(cpovirk): Switch to using fact-based assertions once Truth generates fact-based errors.
-
   // factKeys()
 
   @Test
@@ -43,6 +41,7 @@ public class TruthFailureSubjectTest extends BaseSubjectTestCase {
     Truth.assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .contains("value of: failure.factKeys()");
+    // TODO(cpovirk): Switch to using fact-based assertions once IterableSubject uses them.
   }
 
   // factValue(String)
@@ -58,12 +57,15 @@ public class TruthFailureSubjectTest extends BaseSubjectTestCase {
     Truth.assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .contains("value of: failure.factValue(foo)");
+    // TODO(cpovirk): Switch to using fact-based assertions once Subject uses them.
   }
 
   @Test
   public void factValueFailNoSuchKey() {
     Object unused = expectFailureWhenTestingThat(fact("foo", "the foo")).factValue("bar");
-    assertMessage("expected to contain fact: bar\nbut contained only: [foo]");
+    assertFailureKeys("expected to contain fact", "but contained only");
+    assertFailureValue("expected to contain fact", "bar");
+    assertFailureValue("but contained only", "[foo]");
   }
 
   @Test
@@ -71,9 +73,9 @@ public class TruthFailureSubjectTest extends BaseSubjectTestCase {
     Object unused =
         expectFailureWhenTestingThat(fact("foo", "the foo"), fact("foo", "the other foo"))
             .factValue("foo");
-    assertMessage(
-        "expected to contain a single fact with key: foo\n"
-            + "but contained multiple: [foo: the foo, foo: the other foo]");
+    assertFailureKeys("expected to contain a single fact with key", "but contained multiple");
+    assertFailureValue("expected to contain a single fact with key", "foo");
+    assertFailureValue("but contained multiple", "[foo: the foo, foo: the other foo]");
   }
 
   // factValue(String, int)
@@ -105,18 +107,24 @@ public class TruthFailureSubjectTest extends BaseSubjectTestCase {
     Truth.assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .contains("value of: failure.factValue(foo, 0)");
+    // TODO(cpovirk): Switch to using fact-based assertions once Subject uses them.
   }
 
   @Test
   public void factValueIntFailNoSuchKey() {
     Object unused = expectFailureWhenTestingThat(fact("foo", "the foo")).factValue("bar", 0);
-    assertMessage("expected to contain fact: bar\nbut contained only: [foo]");
+    assertFailureKeys("expected to contain fact", "but contained only");
+    assertFailureValue("expected to contain fact", "bar");
+    assertFailureValue("but contained only", "[foo]");
   }
 
   @Test
   public void factValueIntFailNotEnoughWithKey() {
     Object unused = expectFailureWhenTestingThat(fact("foo", "the foo")).factValue("foo", 5);
-    assertMessage("for key: foo\nindex too high: 5\nfact count was: 1");
+    assertFailureKeys("for key", "index too high", "fact count was");
+    assertFailureValue("for key", "foo");
+    assertFailureValue("index too high", "5");
+    assertFailureValue("fact count was", "1");
   }
 
   // other tests
@@ -124,13 +132,13 @@ public class TruthFailureSubjectTest extends BaseSubjectTestCase {
   @Test
   public void nonTruthErrorFactKeys() {
     Object unused = expectFailureWhenTestingThat(new AssertionError()).factKeys();
-    assertMessage("expected a failure thrown by Truth's new failure API");
+    assertFailureKeys("expected a failure thrown by Truth's new failure API", "but was");
   }
 
   @Test
   public void nonTruthErrorFactValue() {
     Object unused = expectFailureWhenTestingThat(new AssertionError()).factValue("foo");
-    assertMessage("expected a failure thrown by Truth's new failure API");
+    assertFailureKeys("expected a failure thrown by Truth's new failure API", "but was");
   }
 
   private TruthFailureSubject assertThat(Fact... facts) {
@@ -148,9 +156,5 @@ public class TruthFailureSubjectTest extends BaseSubjectTestCase {
   private AssertionErrorWithFacts failure(Fact... facts) {
     return AssertionErrorWithFacts.create(
         ImmutableList.<String>of(), ImmutableList.copyOf(facts), /* cause= */ null);
-  }
-
-  private void assertMessage(String expected) {
-    ExpectFailure.assertThat(expectFailure.getFailure()).hasMessageThat().isEqualTo(expected);
   }
 }

--- a/core/src/test/java/com/google/common/truth/TruthFailureSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/TruthFailureSubjectTest.java
@@ -16,7 +16,7 @@
 
 package com.google.common.truth;
 
-import static com.google.common.truth.Field.field;
+import static com.google.common.truth.Fact.fact;
 import static com.google.common.truth.TruthFailureSubject.truthFailures;
 import static org.junit.Assert.fail;
 
@@ -28,126 +28,126 @@ import org.junit.runners.JUnit4;
 /** Tests for {@link TruthFailureSubject}. */
 @RunWith(JUnit4.class)
 public class TruthFailureSubjectTest extends BaseSubjectTestCase {
-  // TODO(cpovirk): Switch to using field-based assertions once Truth generates field-based errors.
+  // TODO(cpovirk): Switch to using fact-based assertions once Truth generates fact-based errors.
 
-  // fieldKeys()
+  // factKeys()
 
   @Test
-  public void fieldKeys() {
-    assertThat(field("foo", "the foo")).fieldKeys().containsExactly("foo");
+  public void factKeys() {
+    assertThat(fact("foo", "the foo")).factKeys().containsExactly("foo");
   }
 
   @Test
-  public void fieldKeysFail() {
-    expectFailureWhenTestingThat(field("foo", "the foo")).fieldKeys().containsExactly("bar");
+  public void factKeysFail() {
+    expectFailureWhenTestingThat(fact("foo", "the foo")).factKeys().containsExactly("bar");
     Truth.assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .contains("value of: failure.fieldKeys()");
+        .contains("value of: failure.factKeys()");
   }
 
-  // fieldValue(String)
+  // factValue(String)
 
   @Test
-  public void fieldValue() {
-    assertThat(field("foo", "the foo")).fieldValue("foo").isEqualTo("the foo");
+  public void factValue() {
+    assertThat(fact("foo", "the foo")).factValue("foo").isEqualTo("the foo");
   }
 
   @Test
-  public void fieldValueFailWrongValue() {
-    expectFailureWhenTestingThat(field("foo", "the foo")).fieldValue("foo").isEqualTo("the bar");
+  public void factValueFailWrongValue() {
+    expectFailureWhenTestingThat(fact("foo", "the foo")).factValue("foo").isEqualTo("the bar");
     Truth.assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .contains("value of: failure.fieldValue(foo)");
+        .contains("value of: failure.factValue(foo)");
   }
 
   @Test
-  public void fieldValueFailNoSuchKey() {
-    Object unused = expectFailureWhenTestingThat(field("foo", "the foo")).fieldValue("bar");
-    assertMessage("expected to contain field: bar\nbut contained only: [foo]");
+  public void factValueFailNoSuchKey() {
+    Object unused = expectFailureWhenTestingThat(fact("foo", "the foo")).factValue("bar");
+    assertMessage("expected to contain fact: bar\nbut contained only: [foo]");
   }
 
   @Test
-  public void fieldValueFailMultipleKeys() {
+  public void factValueFailMultipleKeys() {
     Object unused =
-        expectFailureWhenTestingThat(field("foo", "the foo"), field("foo", "the other foo"))
-            .fieldValue("foo");
+        expectFailureWhenTestingThat(fact("foo", "the foo"), fact("foo", "the other foo"))
+            .factValue("foo");
     assertMessage(
-        "expected to contain a single field with key: foo\n"
+        "expected to contain a single fact with key: foo\n"
             + "but contained multiple: [foo: the foo, foo: the other foo]");
   }
 
-  // fieldValue(String, int)
+  // factValue(String, int)
 
   @Test
-  public void fieldValueInt() {
-    assertThat(field("foo", "the foo")).fieldValue("foo", 0).isEqualTo("the foo");
+  public void factValueInt() {
+    assertThat(fact("foo", "the foo")).factValue("foo", 0).isEqualTo("the foo");
   }
 
   @Test
-  public void fieldValueIntMultipleKeys() {
-    assertThat(field("foo", "the foo"), field("foo", "the other foo"))
-        .fieldValue("foo", 1)
+  public void factValueIntMultipleKeys() {
+    assertThat(fact("foo", "the foo"), fact("foo", "the other foo"))
+        .factValue("foo", 1)
         .isEqualTo("the other foo");
   }
 
   @Test
-  public void fieldValueIntFailNegative() {
+  public void factValueIntFailNegative() {
     try {
-      assertThat(field("foo", "the foo")).fieldValue("foo", -1);
+      assertThat(fact("foo", "the foo")).factValue("foo", -1);
       fail();
     } catch (IllegalArgumentException expected) {
     }
   }
 
   @Test
-  public void fieldValueIntFailWrongValue() {
-    expectFailureWhenTestingThat(field("foo", "the foo")).fieldValue("foo", 0).isEqualTo("the bar");
+  public void factValueIntFailWrongValue() {
+    expectFailureWhenTestingThat(fact("foo", "the foo")).factValue("foo", 0).isEqualTo("the bar");
     Truth.assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .contains("value of: failure.fieldValue(foo, 0)");
+        .contains("value of: failure.factValue(foo, 0)");
   }
 
   @Test
-  public void fieldValueIntFailNoSuchKey() {
-    Object unused = expectFailureWhenTestingThat(field("foo", "the foo")).fieldValue("bar", 0);
-    assertMessage("expected to contain field: bar\nbut contained only: [foo]");
+  public void factValueIntFailNoSuchKey() {
+    Object unused = expectFailureWhenTestingThat(fact("foo", "the foo")).factValue("bar", 0);
+    assertMessage("expected to contain fact: bar\nbut contained only: [foo]");
   }
 
   @Test
-  public void fieldValueIntFailNotEnoughWithKey() {
-    Object unused = expectFailureWhenTestingThat(field("foo", "the foo")).fieldValue("foo", 5);
-    assertMessage("for key: foo\nindex too high: 5\nfield count was: 1");
+  public void factValueIntFailNotEnoughWithKey() {
+    Object unused = expectFailureWhenTestingThat(fact("foo", "the foo")).factValue("foo", 5);
+    assertMessage("for key: foo\nindex too high: 5\nfact count was: 1");
   }
 
   // other tests
 
   @Test
-  public void nonTruthErrorFieldKeys() {
-    Object unused = expectFailureWhenTestingThat(new AssertionError()).fieldKeys();
+  public void nonTruthErrorFactKeys() {
+    Object unused = expectFailureWhenTestingThat(new AssertionError()).factKeys();
     assertMessage("expected a failure thrown by Truth's new failure API");
   }
 
   @Test
-  public void nonTruthErrorFieldValue() {
-    Object unused = expectFailureWhenTestingThat(new AssertionError()).fieldValue("foo");
+  public void nonTruthErrorFactValue() {
+    Object unused = expectFailureWhenTestingThat(new AssertionError()).factValue("foo");
     assertMessage("expected a failure thrown by Truth's new failure API");
   }
 
-  private TruthFailureSubject assertThat(Field... fields) {
-    return ExpectFailure.assertThat(failure(fields));
+  private TruthFailureSubject assertThat(Fact... facts) {
+    return ExpectFailure.assertThat(failure(facts));
   }
 
-  private TruthFailureSubject expectFailureWhenTestingThat(Field... fields) {
-    return expectFailureWhenTestingThat(failure(fields));
+  private TruthFailureSubject expectFailureWhenTestingThat(Fact... facts) {
+    return expectFailureWhenTestingThat(failure(facts));
   }
 
   private TruthFailureSubject expectFailureWhenTestingThat(AssertionError failure) {
     return (TruthFailureSubject) expectFailure.whenTesting().about(truthFailures()).that(failure);
   }
 
-  private AssertionErrorWithFields failure(Field... fields) {
-    return AssertionErrorWithFields.create(
-        ImmutableList.<String>of(), ImmutableList.copyOf(fields), /* cause= */ null);
+  private AssertionErrorWithFacts failure(Fact... facts) {
+    return AssertionErrorWithFacts.create(
+        ImmutableList.<String>of(), ImmutableList.copyOf(facts), /* cause= */ null);
   }
 
   private void assertMessage(String expected) {

--- a/extensions/java8/src/test/java/com/google/common/truth/IntStreamSubjectTest.java
+++ b/extensions/java8/src/test/java/com/google/common/truth/IntStreamSubjectTest.java
@@ -15,6 +15,7 @@
  */
 package com.google.common.truth;
 
+import static com.google.common.truth.IntStreamSubject.intStreams;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static java.util.Arrays.asList;
@@ -44,16 +45,13 @@ public final class IntStreamSubjectTest {
   public void testIsEqualToList() throws Exception {
     IntStream stream = IntStream.of(42);
     List<Integer> list = asList(42);
-    try {
-      assertThat(stream).isEqualTo(list);
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Not true that <[42]> (java.util.stream.IntPipeline$Head) "
-                  + "is equal to <[42]> (java.util.Arrays$ArrayList)");
-    }
+    AssertionError expected =
+        expectFailure(whenTesting -> whenTesting.that(stream).isEqualTo(list));
+    assertThat(expected)
+        .hasMessageThat()
+        .isEqualTo(
+            "Not true that <[42]> (java.util.stream.IntPipeline$Head) "
+                + "is equal to <[42]> (java.util.Arrays$ArrayList)");
   }
 
   @Test
@@ -85,12 +83,9 @@ public final class IntStreamSubjectTest {
 
   @Test
   public void testIsEmpty_fails() throws Exception {
-    try {
-      assertThat(IntStream.of(42)).isEmpty();
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Not true that <[42]> is empty");
-    }
+    AssertionError expected =
+        expectFailure(whenTesting -> whenTesting.that(IntStream.of(42)).isEmpty());
+    assertThat(expected).hasMessageThat().isEqualTo("Not true that <[42]> is empty");
   }
 
   @Test
@@ -100,12 +95,9 @@ public final class IntStreamSubjectTest {
 
   @Test
   public void testIsNotEmpty_fails() throws Exception {
-    try {
-      assertThat(IntStream.of()).isNotEmpty();
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Not true that <[]> is not empty");
-    }
+    AssertionError expected =
+        expectFailure(whenTesting -> whenTesting.that(IntStream.of()).isNotEmpty());
+    assertThat(expected).hasMessageThat().isEqualTo("Not true that <[]> is not empty");
   }
 
   @Test
@@ -115,14 +107,11 @@ public final class IntStreamSubjectTest {
 
   @Test
   public void testHasSize_fails() throws Exception {
-    try {
-      assertThat(IntStream.of(42)).hasSize(2);
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Not true that <[42]> has a size of <2>. It is <1>");
-    }
+    AssertionError expected =
+        expectFailure(whenTesting -> whenTesting.that(IntStream.of(42)).hasSize(2));
+    assertThat(expected)
+        .hasMessageThat()
+        .isEqualTo("Not true that <[42]> has a size of <2>. It is <1>");
   }
 
   @Test
@@ -389,5 +378,10 @@ public final class IntStreamSubjectTest {
   @Test
   public void testContainsExactlyElementsIn_inOrder_intStream() throws Exception {
     assertThat(IntStream.of(1, 2, 3, 4)).containsExactly(1, 2, 3, 4).inOrder();
+  }
+
+  private static AssertionError expectFailure(
+      ExpectFailure.SimpleSubjectBuilderCallback<IntStreamSubject, IntStream> assertionCallback) {
+    return ExpectFailure.expectFailureAbout(intStreams(), assertionCallback);
   }
 }

--- a/extensions/java8/src/test/java/com/google/common/truth/LongStreamSubjectTest.java
+++ b/extensions/java8/src/test/java/com/google/common/truth/LongStreamSubjectTest.java
@@ -15,6 +15,7 @@
  */
 package com.google.common.truth;
 
+import static com.google.common.truth.LongStreamSubject.longStreams;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static java.util.Arrays.asList;
@@ -44,16 +45,13 @@ public final class LongStreamSubjectTest {
   public void testIsEqualToList() throws Exception {
     LongStream stream = LongStream.of(42);
     List<Long> list = asList(42L);
-    try {
-      assertThat(stream).isEqualTo(list);
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Not true that <[42]> (java.util.stream.LongPipeline$Head) "
-                  + "is equal to <[42]> (java.util.Arrays$ArrayList)");
-    }
+    AssertionError expected =
+        expectFailure(whenTesting -> whenTesting.that(stream).isEqualTo(list));
+    assertThat(expected)
+        .hasMessageThat()
+        .isEqualTo(
+            "Not true that <[42]> (java.util.stream.LongPipeline$Head) "
+                + "is equal to <[42]> (java.util.Arrays$ArrayList)");
   }
 
   @Test
@@ -85,12 +83,9 @@ public final class LongStreamSubjectTest {
 
   @Test
   public void testIsEmpty_fails() throws Exception {
-    try {
-      assertThat(LongStream.of(42)).isEmpty();
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Not true that <[42]> is empty");
-    }
+    AssertionError expected =
+        expectFailure(whenTesting -> whenTesting.that(LongStream.of(42)).isEmpty());
+    assertThat(expected).hasMessageThat().isEqualTo("Not true that <[42]> is empty");
   }
 
   @Test
@@ -100,12 +95,9 @@ public final class LongStreamSubjectTest {
 
   @Test
   public void testIsNotEmpty_fails() throws Exception {
-    try {
-      assertThat(LongStream.of()).isNotEmpty();
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Not true that <[]> is not empty");
-    }
+    AssertionError expected =
+        expectFailure(whenTesting -> whenTesting.that(LongStream.of()).isNotEmpty());
+    assertThat(expected).hasMessageThat().isEqualTo("Not true that <[]> is not empty");
   }
 
   @Test
@@ -115,14 +107,11 @@ public final class LongStreamSubjectTest {
 
   @Test
   public void testHasSize_fails() throws Exception {
-    try {
-      assertThat(LongStream.of(42)).hasSize(2);
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Not true that <[42]> has a size of <2>. It is <1>");
-    }
+    AssertionError expected =
+        expectFailure(whenTesting -> whenTesting.that(LongStream.of(42)).hasSize(2));
+    assertThat(expected)
+        .hasMessageThat()
+        .isEqualTo("Not true that <[42]> has a size of <2>. It is <1>");
   }
 
   @Test
@@ -449,5 +438,10 @@ public final class LongStreamSubjectTest {
   @Test
   public void testContainsExactlyElementsIn_inOrder_LongStream() throws Exception {
     assertThat(LongStream.of(1, 2, 3, 4)).containsExactly(1, 2, 3, 4).inOrder();
+  }
+
+  private static AssertionError expectFailure(
+      ExpectFailure.SimpleSubjectBuilderCallback<LongStreamSubject, LongStream> assertionCallback) {
+    return ExpectFailure.expectFailureAbout(longStreams(), assertionCallback);
   }
 }

--- a/extensions/java8/src/test/java/com/google/common/truth/OptionalDoubleSubjectTest.java
+++ b/extensions/java8/src/test/java/com/google/common/truth/OptionalDoubleSubjectTest.java
@@ -82,6 +82,11 @@ public class OptionalDoubleSubjectTest {
   }
 
   @Test
+  public void isEmptyFailingNull() {
+    AssertionError unused = expectFailure(whenTesting -> whenTesting.that(null).isEmpty());
+  }
+
+  @Test
   public void hasValue() {
     assertThat(OptionalDouble.of(1337.0)).hasValue(1337.0);
   }
@@ -109,7 +114,7 @@ public class OptionalDoubleSubjectTest {
     AssertionError expected =
         expectFailure(
             whenTesting -> {
-              DoubleSubject ignored = whenTesting.that(OptionalDouble.empty()).hasValueThat();
+              DoubleSubject unused = whenTesting.that(OptionalDouble.empty()).hasValueThat();
             });
     assertThat(expected).hasMessageThat().isEqualTo("Not true that the subject is present");
   }

--- a/extensions/java8/src/test/java/com/google/common/truth/OptionalIntSubjectTest.java
+++ b/extensions/java8/src/test/java/com/google/common/truth/OptionalIntSubjectTest.java
@@ -80,6 +80,11 @@ public class OptionalIntSubjectTest {
   }
 
   @Test
+  public void isEmptyFailingNull() {
+    AssertionError unused = expectFailure(whenTesting -> whenTesting.that(null).isEmpty());
+  }
+
+  @Test
   public void hasValue() {
     assertThat(OptionalInt.of(1337)).hasValue(1337);
   }

--- a/extensions/java8/src/test/java/com/google/common/truth/OptionalLongSubjectTest.java
+++ b/extensions/java8/src/test/java/com/google/common/truth/OptionalLongSubjectTest.java
@@ -80,6 +80,11 @@ public class OptionalLongSubjectTest {
   }
 
   @Test
+  public void isEmptyFailingNull() {
+    AssertionError unused = expectFailure(whenTesting -> whenTesting.that(null).isEmpty());
+  }
+
+  @Test
   public void hasValue() {
     assertThat(OptionalLong.of(1337L)).hasValue(1337L);
   }

--- a/extensions/java8/src/test/java/com/google/common/truth/StreamSubjectTest.java
+++ b/extensions/java8/src/test/java/com/google/common/truth/StreamSubjectTest.java
@@ -15,6 +15,7 @@
  */
 package com.google.common.truth;
 
+import static com.google.common.truth.StreamSubject.streams;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static java.util.Arrays.asList;
@@ -44,16 +45,13 @@ public final class StreamSubjectTest {
   public void testIsEqualToList() throws Exception {
     Stream<String> stream = Stream.of("hello");
     List<String> list = asList("hello");
-    try {
-      assertThat(stream).isEqualTo(list);
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Not true that <[hello]> (java.util.stream.ReferencePipeline$Head) "
-                  + "is equal to <[hello]> (java.util.Arrays$ArrayList)");
-    }
+    AssertionError expected =
+        expectFailure(whenTesting -> whenTesting.that(stream).isEqualTo(list));
+    assertThat(expected)
+        .hasMessageThat()
+        .isEqualTo(
+            "Not true that <[hello]> (java.util.stream.ReferencePipeline$Head) "
+                + "is equal to <[hello]> (java.util.Arrays$ArrayList)");
   }
 
   @Test
@@ -85,12 +83,9 @@ public final class StreamSubjectTest {
 
   @Test
   public void testIsEmpty_fails() throws Exception {
-    try {
-      assertThat(Stream.of("hello")).isEmpty();
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Not true that <[hello]> is empty");
-    }
+    AssertionError expected =
+        expectFailure(whenTesting -> whenTesting.that(Stream.of("hello")).isEmpty());
+    assertThat(expected).hasMessageThat().isEqualTo("Not true that <[hello]> is empty");
   }
 
   @Test
@@ -100,12 +95,9 @@ public final class StreamSubjectTest {
 
   @Test
   public void testIsNotEmpty_fails() throws Exception {
-    try {
-      assertThat(Stream.of()).isNotEmpty();
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Not true that <[]> is not empty");
-    }
+    AssertionError expected =
+        expectFailure(whenTesting -> whenTesting.that(Stream.of()).isNotEmpty());
+    assertThat(expected).hasMessageThat().isEqualTo("Not true that <[]> is not empty");
   }
 
   @Test
@@ -115,14 +107,11 @@ public final class StreamSubjectTest {
 
   @Test
   public void testHasSize_fails() throws Exception {
-    try {
-      assertThat(Stream.of("hello")).hasSize(2);
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Not true that <[hello]> has a size of <2>. It is <1>");
-    }
+    AssertionError expected =
+        expectFailure(whenTesting -> whenTesting.that(Stream.of("hello")).hasSize(2));
+    assertThat(expected)
+        .hasMessageThat()
+        .isEqualTo("Not true that <[hello]> has a size of <2>. It is <1>");
   }
 
   @Test
@@ -399,5 +388,10 @@ public final class StreamSubjectTest {
               "Not true that <[hell, hello]> contains exactly "
                   + "these elements in order <[hello, hell]>");
     }
+  }
+
+  private static AssertionError expectFailure(
+      ExpectFailure.SimpleSubjectBuilderCallback<StreamSubject, Stream<?>> assertionCallback) {
+    return ExpectFailure.expectFailureAbout(streams(), assertionCallback);
   }
 }

--- a/extensions/liteproto/src/main/java/com/google/common/truth/extensions/proto/LiteProtoSubject.java
+++ b/extensions/liteproto/src/main/java/com/google/common/truth/extensions/proto/LiteProtoSubject.java
@@ -85,12 +85,9 @@ public class LiteProtoSubject<S extends LiteProtoSubject<S, M>, M extends Messag
     return subjectString.isEmpty() ? "[empty proto]" : subjectString;
   }
 
-  protected String getTrimmedDisplaySubject() {
-    if (internalCustomName() != null) {
-      return internalCustomName() + " (<" + getTrimmedToString(actual()) + ">)";
-    } else {
-      return "<" + getTrimmedToString(actual()) + ">";
-    }
+  @Override
+  protected String actualCustomStringRepresentation() {
+    return getTrimmedToString(actual());
   }
 
   /**
@@ -163,11 +160,10 @@ public class LiteProtoSubject<S extends LiteProtoSubject<S, M>, M extends Messag
   public void isEqualToDefaultInstance() {
     if (actual() == null) {
       failWithRawMessage(
-          "Not true that %s is a default proto instance. It is null.", getTrimmedDisplaySubject());
+          "Not true that %s is a default proto instance. It is null.", actualAsString());
     } else if (!actual().equals(actual().getDefaultInstanceForType())) {
       failWithRawMessage(
-          "Not true that %s is a default proto instance. It has set values.",
-          getTrimmedDisplaySubject());
+          "Not true that %s is a default proto instance. It has set values.", actualAsString());
     }
   }
 
@@ -176,7 +172,7 @@ public class LiteProtoSubject<S extends LiteProtoSubject<S, M>, M extends Messag
     if (actual() != null && actual().equals(actual().getDefaultInstanceForType())) {
       failWithRawMessage(
           "Not true that (%s) %s is not a default proto instance. It has no set values.",
-          actual().getClass().getName(), getTrimmedDisplaySubject());
+          actual().getClass().getName(), actualAsString());
     }
   }
 
@@ -190,7 +186,7 @@ public class LiteProtoSubject<S extends LiteProtoSubject<S, M>, M extends Messag
       failWithRawMessage(
           "Not true that %s has all required fields set. "
               + "(Lite runtime could not determine which fields were missing.)",
-          getTrimmedDisplaySubject());
+          actualAsString());
     }
   }
 
@@ -201,9 +197,7 @@ public class LiteProtoSubject<S extends LiteProtoSubject<S, M>, M extends Messag
    * assertThat(myProto).serializedSize().isAtLeast(16)}, etc.
    */
   public IntegerSubject serializedSize() {
-    return check()
-        .that(actual().getSerializedSize())
-        .named("sizeOf(" + getTrimmedDisplaySubject() + ")");
+    return check().that(actual().getSerializedSize()).named("sizeOf(" + actualAsString() + ")");
   }
 
   static final class MessageLiteSubject extends LiteProtoSubject<MessageLiteSubject, MessageLite> {

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoSubject.java
@@ -183,7 +183,7 @@ public class ProtoSubject<S extends ProtoSubject<S, M>, M extends Message>
     if (!actual().isInitialized()) {
       failWithRawMessage(
           "Not true that %s has all required fields set. Missing: %s",
-          getTrimmedDisplaySubject(), actual().findInitializationErrors());
+          actualAsString(), actual().findInitializationErrors());
     }
   }
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Rename "field" to "fact."

b32aa7593daf9698123b7d2f670255a614aa2281

-------

<p> Override actualCustomStringRepresentation(), and call actualAsString().

This makes for slightly less code and API, and it also lets Truth use the custom formatting even for its built-in assertions (e.g., isNull()).
(And, more important to me at the moment, it lets Truth continue to use the custom formatting once I change serializedSize() to call check("getSerializedSize()") instead of plain check().)

f615b20cf1a273c614f9a90d6cf031feb075a2e8

-------

<p> Implement a package-private Fact-based failure API.

We still have some API questions to resolve, but we'd settled enough to get started.

Also, demo the new API on TruthFailureSubject.

fe1f8297059a952b4d0c3808f2bed4cbc8a0f12b

-------

<p> Enable some tests that I fixed a while back.

2329ab5501fbcd1e223cb3192538f791f9800e9f

-------

<p> Make tests of Expect and ExpectFailure stop depending on the format of specific assertions.

That gives us one less thing to update when we change the format of those assertions.

f7bb14036036157288c0e3fb25bcb7857eb11f80

-------

<p> Migrate *StreamSubjectTest to ExpectFailure.

e1dc765ab07e74530bab7541ec4439d354bc0540

-------

<p> Add tests for Optional*Subject.isEmpty() when the value under test is null.

I didn't include any assertions about the failure message yet, since it's going to change soon.
For now, all we're testing is that we don't NPE.

d956c37a158af07262d5d36c0a1d583f37e2523c

-------

<p> Split tests of isNotNaN() failures into their own methods.

This will let me start using expectFailure.whenTesting() with them (since that method is possible to use only once per test method).

313232bca9125733fea3ecf1315430fef82107b3