### PR TITLE
Moe Sync

### DIFF
--- a/_sass/themes/_teal.scss
+++ b/_sass/themes/_teal.scss
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ==========================================================================
+   Teal Theme
+   ========================================================================== */
+
+.t-teal {
+
+  .c-navigation,
+  .c-header {
+    background: $c__teal;
+  }
+
+  .c-article__main a:not(.c-btn) {
+    color: $c__teal;
+  }
+
+  .c-footer a {
+    color: $c__teal;
+  }
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -46,7 +46,8 @@
   'themes/green',
   'themes/grey',
   'themes/orange',
-  'themes/purple';
+  'themes/purple',
+  'themes/teal';
 
 // Vendor
 @import

--- a/fuzzy.md
+++ b/fuzzy.md
@@ -16,9 +16,12 @@ framework is quite general.
 
 The primary concept of Fuzzy Truth is a `Correspondence`. A correspondence
 determines whether an instance of type `A` corresponds in some way to an
-instance of type `E`. The instances of type `A` are typically actual values from
-a collection returned by the code under test; the instances of type `E` are
-typically expected values with which the actual values are compared by the test.
+instance of type `E`. Optionally, it can also [describe the
+difference](#formatDiff) between two instances that do not correspond. A
+`Correspondence<A, E>` is used in an assertion about a collection of elements of
+type `A` (typically the collection actually returned by the code under test),
+checking that it contains (or, occasionally, does not contain) certain expected
+elements of type `E`.
 
 Here's an example correspondence between strings and integers, which tests
 whether the string parses as the integer.
@@ -43,10 +46,11 @@ private static final Correspondence<String, Integer> STRING_PARSES_TO_INTEGER_CO
       }
       @Override
       public String toString() {
-        return "parse to";
+        return "parses to";
       }
     };
 ```
+
 
 ## Iterable Example {#iterable}
 
@@ -60,6 +64,10 @@ assertThat(actual)
 
 ## Map Example {#map}
 
+N.B. The `Correspondence` applies to the values, not the keys, of the map. You
+should almost always make assertions using equality of map keys, since equality
+semantics are used for lookups.
+
 ```java
 Map<String, String> actual = ImmutableMap.of("abc", "123", "def", "456");
 assertThat(actual)
@@ -69,6 +77,10 @@ assertThat(actual)
 
 ## Multimap Example {#multimap}
 
+N.B. The `Correspondence` applies to the values, not the keys, of the multimap.
+You should almost always make assertions using equality of multimap keys, since
+equality semantics are used for lookups.
+
 ```java
 Multimap<String, String> actual =
     ImmutableListMultimap.of("abc", "123", "def", "456", "def", "789");
@@ -77,9 +89,59 @@ assertThat(actual)
     .containsEntry("def", 789);
 ```
 
-<!-- TODO(b/32960783): Document pairing & diffing support. -->
+## Getting better failure messages
+
+When an assertion involving collections of objects with verbose `toString()`
+representations (such as [value types]) fails, the failure messages can often be
+hard to understand. There are a couple of things you can do to make debugging
+failing tests easier.
+
+### Enabling pairing of `Iterable` elements {#displayingDiffsPairedBy}
+
+If you are making an assertion about an `Iterable`, and you know of key some
+function which uniquely indexes the expected elements, then you can use the
+`displayingDiffsPairedBy` method to tell Fuzzy Truth about it. For example, if
+you have a type called `Record`, and you're making an assertion about an
+`Iterable<Record>` using a `Correspondence` called `RECORD_EQUIVALENCE`, and the
+expected records have unique IDs returned by a `getId()` method, then you could
+write this:
+
+```java
+assertThat(actualRecords)
+    .comparingElementsUsing(RECORD_EQUIVALENCE)
+    .displayingDiffsPairedBy(Record::getId)
+    .containsExactlyElementsIn(expectedRecords);
+```
+
+If this assertion fails, the failure message will pair up any missing and
+unexpected elements by their IDs. For example, it might tell you that the actual
+`Iterable` was missing an element with ID 2, that it had an unexpected element
+with ID 3, or that the element with ID 4 wasn't equivalent to the one it
+expected.
+
+(If an assertion about a `Map` fails, the failure message will automatically
+miss up any missing and unexpected entries using their keys. You can think of
+the `displayingDiffsPairedBy` method as providing an equivalent for an assertion
+about an `Iterable`. Note that this won't affect whether the test passes or
+fails.)
+
+### Enabling formatted diffs between elements {#formatDiff}
+
+Your `Correspondence` subclass may optionally implement the `formatDiff` method,
+which takes an actual and an expected element and returns a `String` describing
+how they differ. For example, a `Correspondence` that describes whether two
+instances of a value type are equivalent might implement `formatDiff` to
+describe which properties of the value types are different.
+
+When you do this, Fuzzy Truth will include these formatted diffs in failure
+messages whenever it can usefully do so. For example, when an assertion about a
+`Map` fails, and there is an entry which has the right key but the wrong value,
+it will show a diff between the value it got and the one it expected. For this
+to work for an assertion about an `Iterable` (with more than one missing value)
+you need to [enable pairing, as shown above](#displayingDiffsPairedBy).
 
 
 [protocol buffers]: https://developers.google.com/protocol-buffers/
 [correspondence-tostring]: http://google.github.io/truth/api/latest/com/google/common/truth/Correspondence.html#toString()
+[value types]: https://github.com/google/auto/blob/master/value/userguide/index.md
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update the Fuzzy Truth and Proto Truth g3doc to reflect some recent changes.

Adds documentation for:
 - displayingDiffsPairedBy
 - formatDiff
 - MoreCorrespondences (internal-only)
 - f.p. tolerance support in Proto Truth (internal-only, at least the docs are)

Adds an (internal-only) section on future work plans to fuzzy.md.

Removes the (internal-only) "More information" section from fuzzy.md as I'm not sure that the design doc is useful (and I'm too modest to leave it there just to call me a rockstar).

Fixes a few little issues with links & formatting.

RELNOTES=Add support for improved failure messages to Fuzzy Truth, via `displayingDiffsPairedBy` and `formatDiff`: see fuzzy.md for details.

957216350d5f81117854fb0b17fdf9a333a75862