### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/IterableSubject.java
+++ b/core/src/main/java/com/google/common/truth/IterableSubject.java
@@ -133,17 +133,19 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
   /** Checks (with a side-effect failure) that the subject contains the supplied item. */
   public final void contains(@NullableDecl Object element) {
     if (!Iterables.contains(actual(), element)) {
-      List<Object> elementList = Lists.newArrayList(element);
+      List<Object> elementList = newArrayList(element);
       if (hasMatchingToStringPair(actual(), elementList)) {
-        failWithRawMessage(
-            "%s should have contained <%s (%s)> but doesn't. However, it does contain <%s>.",
-            actualAsString(),
-            element,
-            objectToTypeName(element),
-            countDuplicatesAndAddTypeInfo(
-                retainMatchingToString(actual(), elementList /* itemsToCheck */)));
+        failWithoutActual(
+            fact("expected to contain", element),
+            fact("an instance of", objectToTypeName(element)),
+            factWithoutValue("but did not"),
+            fact(
+                "though it did contain",
+                countDuplicatesAndAddTypeInfo(
+                    retainMatchingToString(actual(), elementList /* itemsToCheck */))),
+            fullContents());
       } else {
-        failWithRawMessage("%s should have contained <%s>", actualAsString(), element);
+        failWithFact("expected to contain", element);
       }
     }
   }
@@ -151,7 +153,7 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
   /** Checks (with a side-effect failure) that the subject does not contain the supplied item. */
   public final void doesNotContain(@NullableDecl Object element) {
     if (Iterables.contains(actual(), element)) {
-      failWithRawMessage("%s should not have contained <%s>", actualAsString(), element);
+      failWithFact("expected not to contain", element);
     }
   }
 
@@ -694,6 +696,10 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
               + "containsNoneOf(...)/containsNoneIn(...) instead. Non-iterables: %s",
           nonIterables);
     }
+  }
+
+  private Fact fullContents() {
+    return fact("full contents", actualCustomStringRepresentationForPackageMembersToCall());
   }
 
   /**

--- a/core/src/main/java/com/google/common/truth/IterableSubject.java
+++ b/core/src/main/java/com/google/common/truth/IterableSubject.java
@@ -159,14 +159,17 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
 
   /** Checks that the subject does not contain duplicate elements. */
   public final void containsNoDuplicates() {
-    List<Entry<?>> duplicates = Lists.newArrayList();
+    List<Entry<?>> duplicates = newArrayList();
     for (Multiset.Entry<?> entry : LinkedHashMultiset.create(actual()).entrySet()) {
       if (entry.getCount() > 1) {
         duplicates.add(entry);
       }
     }
     if (!duplicates.isEmpty()) {
-      failWithRawMessage("%s has the following duplicates: <%s>", actualAsString(), duplicates);
+      failWithoutActual(
+          factWithoutValue("expected not to contain duplicates"),
+          fact("but contained", duplicates),
+          fullContents());
     }
   }
 
@@ -554,11 +557,10 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       }
     }
     if (!present.isEmpty()) {
-      failWithBadResults(
-          "contains none of",
-          annotateEmptyStrings(excluded),
-          "contains",
-          annotateEmptyStrings(present));
+      failWithoutActual(
+          fact("expected not to contain any of", annotateEmptyStrings(excluded)),
+          fact("but contained", annotateEmptyStrings(present)),
+          fullContents());
     }
   }
 
@@ -608,7 +610,7 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
   public final void isStrictlyOrdered(final Comparator<?> comparator) {
     checkNotNull(comparator);
     pairwiseCheck(
-        "is strictly ordered",
+        "expected to be strictly ordered",
         new PairwiseChecker() {
           @Override
           public boolean check(Object prev, Object next) {
@@ -639,7 +641,7 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
   public final void isOrdered(final Comparator<?> comparator) {
     checkNotNull(comparator);
     pairwiseCheck(
-        "is ordered",
+        "expected to be ordered",
         new PairwiseChecker() {
           @Override
           public boolean check(Object prev, Object next) {
@@ -652,14 +654,18 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
     boolean check(Object prev, Object next);
   }
 
-  private void pairwiseCheck(String verb, PairwiseChecker checker) {
+  private void pairwiseCheck(String expectedFact, PairwiseChecker checker) {
     Iterator<?> iterator = actual().iterator();
     if (iterator.hasNext()) {
       Object prev = iterator.next();
       while (iterator.hasNext()) {
         Object next = iterator.next();
         if (!checker.check(prev, next)) {
-          fail(verb, prev, next);
+          failWithoutActual(
+              factWithoutValue(expectedFact),
+              fact("but contained", prev),
+              fact("followed by", next),
+              fullContents());
           return;
         }
         prev = next;

--- a/core/src/main/java/com/google/common/truth/MapSubject.java
+++ b/core/src/main/java/com/google/common/truth/MapSubject.java
@@ -17,6 +17,7 @@ package com.google.common.truth;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Maps.immutableEntry;
 import static com.google.common.truth.Fact.factWithoutValue;
 import static com.google.common.truth.SubjectUtils.countDuplicatesAndAddTypeInfo;
 import static com.google.common.truth.SubjectUtils.hasMatchingToStringPair;
@@ -92,33 +93,17 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
   /** Fails if the map does not have the given size. */
   public void hasSize(int expectedSize) {
     checkArgument(expectedSize >= 0, "expectedSize (%s) must be >= 0", expectedSize);
-    int actualSize = actual().size();
     check("size()").that(actual().size()).isEqualTo(expectedSize);
   }
 
   /** Fails if the map does not contain the given key. */
   public void containsKey(@NullableDecl Object key) {
-    if (!actual().containsKey(key)) {
-      List<Object> keyList = Lists.newArrayList(key);
-      if (hasMatchingToStringPair(actual().keySet(), keyList)) {
-        failWithRawMessage(
-            "Not true that %s contains key <%s (%s)>. However, it does contain keys <%s>.",
-            actualAsString(),
-            key,
-            objectToTypeName(key),
-            countDuplicatesAndAddTypeInfo(
-                retainMatchingToString(actual().keySet(), keyList /* itemsToCheck */)));
-      } else {
-        fail("contains key", key);
-      }
-    }
+    check("keySet()").that(actual().keySet()).contains(key);
   }
 
   /** Fails if the map contains the given key. */
   public void doesNotContainKey(@NullableDecl Object key) {
-    if (actual().containsKey(key)) {
-      fail("does not contain key", key);
-    }
+    check("keySet()").that(actual().keySet()).doesNotContain(key);
   }
 
   /** Fails if the map does not contain the given entry. */
@@ -175,10 +160,9 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
 
   /** Fails if the map contains the given entry. */
   public void doesNotContainEntry(@NullableDecl Object key, @NullableDecl Object value) {
-    Entry<Object, Object> entry = Maps.immutableEntry(key, value);
-    if (actual().entrySet().contains(entry)) {
-      fail("does not contain entry", entry);
-    }
+    checkNoNeedToDisplayBothValues("entrySet()")
+        .that(actual().entrySet())
+        .doesNotContain(immutableEntry(key, value));
   }
 
   /** Fails if the map is not empty. */

--- a/core/src/main/java/com/google/common/truth/MultimapSubject.java
+++ b/core/src/main/java/com/google/common/truth/MultimapSubject.java
@@ -17,6 +17,7 @@ package com.google.common.truth;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Maps.immutableEntry;
 import static com.google.common.truth.Fact.factWithoutValue;
 import static com.google.common.truth.SubjectUtils.HUMAN_UNDERSTANDABLE_EMPTY_STRING;
 import static com.google.common.truth.SubjectUtils.countDuplicatesAndAddTypeInfo;
@@ -90,27 +91,12 @@ public class MultimapSubject extends Subject<MultimapSubject, Multimap<?, ?>> {
 
   /** Fails if the multimap does not contain the given key. */
   public void containsKey(@NullableDecl Object key) {
-    if (!actual().containsKey(key)) {
-      List<Object> keyList = Lists.newArrayList(key);
-      if (hasMatchingToStringPair(actual().keySet(), keyList)) {
-        failWithRawMessage(
-            "Not true that %s contains key <%s (%s)>. However, it does contain keys <%s>.",
-            actualAsString(),
-            key,
-            objectToTypeName(key),
-            countDuplicatesAndAddTypeInfo(
-                retainMatchingToString(actual().keySet(), keyList /* itemsToCheck */)));
-      } else {
-        fail("contains key", key);
-      }
-    }
+    check("keySet()").that(actual().keySet()).contains(key);
   }
 
   /** Fails if the multimap contains the given key. */
   public void doesNotContainKey(@NullableDecl Object key) {
-    if (actual().containsKey(key)) {
-      fail("does not contain key", key);
-    }
+    check("keySet()").that(actual().keySet()).doesNotContain(key);
   }
 
   /** Fails if the multimap does not contain the given entry. */
@@ -150,9 +136,9 @@ public class MultimapSubject extends Subject<MultimapSubject, Multimap<?, ?>> {
 
   /** Fails if the multimap contains the given entry. */
   public void doesNotContainEntry(@NullableDecl Object key, @NullableDecl Object value) {
-    if (actual().containsEntry(key, value)) {
-      fail("does not contain entry", Maps.immutableEntry(key, value));
-    }
+    checkNoNeedToDisplayBothValues("entries()")
+        .that(actual().entries())
+        .doesNotContain(immutableEntry(key, value));
   }
 
   /**

--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -939,6 +939,11 @@ public class Subject<S extends Subject<S, T>, T> {
     doFail(ImmutableList.copyOf(Lists.asList(first, rest)));
   }
 
+  // TODO(cpovirk): Consider making this public after names are settled (if there's a need for it).
+  final void failWithoutActual(Iterable<Fact> facts) {
+    doFail(ImmutableList.copyOf(facts));
+  }
+
   /**
    * Assembles a failure message without a given subject and passes it to the FailureStrategy
    *

--- a/core/src/main/java/com/google/common/truth/SubjectUtils.java
+++ b/core/src/main/java/com/google/common/truth/SubjectUtils.java
@@ -223,6 +223,7 @@ final class SubjectUtils {
   }
 
   static String objectToTypeName(Object item) {
+    // TODO(cpovirk): Merge this with the code in Subject.failEqualityCheck().
     if (item == null) {
       // The name "null type" comes from the interface javax.lang.model.type.NullType.
       return "null type";

--- a/core/src/main/java/com/google/common/truth/TableSubject.java
+++ b/core/src/main/java/com/google/common/truth/TableSubject.java
@@ -77,9 +77,7 @@ public final class TableSubject extends Subject<TableSubject, Table<?, ?, ?>> {
   /** Fails if the table does not contain the given cell. */
   public void containsCell(Cell<?, ?, ?> cell) {
     checkNotNull(cell);
-    if (!actual().cellSet().contains(cell)) {
-      fail("contains cell", cell);
-    }
+    checkNoNeedToDisplayBothValues("cellSet()").that(actual().cellSet()).contains(cell);
   }
 
   /** Fails if the table contains the given cell. */
@@ -91,29 +89,21 @@ public final class TableSubject extends Subject<TableSubject, Table<?, ?, ?>> {
   /** Fails if the table contains the given cell. */
   public void doesNotContainCell(Cell<?, ?, ?> cell) {
     checkNotNull(cell);
-    if (actual().cellSet().contains(cell)) {
-      fail("does not contain cell", cell);
-    }
+    checkNoNeedToDisplayBothValues("cellSet()").that(actual().cellSet()).doesNotContain(cell);
   }
 
   /** Fails if the table does not contain the given row key. */
   public void containsRow(@NullableDecl Object rowKey) {
-    if (!actual().containsRow(rowKey)) {
-      fail("contains row", rowKey);
-    }
+    check("rowKeySet()").that(actual().rowKeySet()).contains(rowKey);
   }
 
   /** Fails if the table does not contain the given column key. */
   public void containsColumn(@NullableDecl Object columnKey) {
-    if (!actual().containsColumn(columnKey)) {
-      fail("contains column", columnKey);
-    }
+    check("columnKeySet()").that(actual().columnKeySet()).contains(columnKey);
   }
 
   /** Fails if the table does not contain the given value. */
   public void containsValue(@NullableDecl Object value) {
-    if (!actual().containsValue(value)) {
-      fail("contains value", value);
-    }
+    check("values()").that(actual().values()).contains(value);
   }
 }

--- a/core/src/test/java/com/google/common/truth/AtomicLongMapSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/AtomicLongMapSubjectTest.java
@@ -137,9 +137,9 @@ public final class AtomicLongMapSubjectTest extends BaseSubjectTestCase {
     AtomicLongMap<String> actual = AtomicLongMap.create();
     actual.getAndIncrement("kurt");
     expectFailureWhenTestingThat(actual).containsKey("greg");
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{kurt=1}> contains key <greg>");
+    assertFailureKeys("value of", "expected to contain", "but was", "atomicLongMap was");
+    assertFailureValue("value of", "atomicLongMap.asMap().keySet()");
+    assertFailureValue("expected to contain", "greg");
   }
 
   @Test
@@ -154,9 +154,9 @@ public final class AtomicLongMapSubjectTest extends BaseSubjectTestCase {
     AtomicLongMap<String> actual = AtomicLongMap.create();
     actual.getAndIncrement("kurt");
     expectFailureWhenTestingThat(actual).doesNotContainKey("kurt");
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{kurt=1}> does not contain key <kurt>");
+    assertFailureKeys("value of", "expected not to contain", "but was", "atomicLongMap was");
+    assertFailureValue("value of", "atomicLongMap.asMap().keySet()");
+    assertFailureValue("expected not to contain", "kurt");
   }
 
   @Test
@@ -178,6 +178,13 @@ public final class AtomicLongMapSubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
+  public void containsEntryZeroDoesNotContain() {
+    AtomicLongMap<String> actual = AtomicLongMap.create();
+    // This passes, which is maybe surprising or maybe not. See the TODO in AtomicLongMapSubject.
+    assertThat(actual).containsEntry("kurt", 0);
+  }
+
+  @Test
   public void containsEntryFailure() {
     AtomicLongMap<String> actual = AtomicLongMap.create();
     actual.getAndIncrement("kurt");
@@ -192,7 +199,17 @@ public final class AtomicLongMapSubjectTest extends BaseSubjectTestCase {
     AtomicLongMap<String> actual = AtomicLongMap.create();
     actual.getAndIncrement("kurt");
     assertThat(actual).doesNotContainEntry("greg", 2);
-    assertThat(actual).doesNotContainEntry(null, 2);
+  }
+
+  @Test
+  public void doesNotContainEntryNullKey() {
+    AtomicLongMap<String> actual = AtomicLongMap.create();
+    try {
+      assertThat(actual).doesNotContainEntry(null, 2);
+      fail();
+    } catch (NullPointerException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo("AtomicLongMap does not support null keys");
+    }
   }
 
   @Test
@@ -210,9 +227,9 @@ public final class AtomicLongMapSubjectTest extends BaseSubjectTestCase {
     AtomicLongMap<String> actual = AtomicLongMap.create();
     actual.getAndIncrement("kurt");
     expectFailureWhenTestingThat(actual).containsKey("greg");
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{kurt=1}> contains key <greg>");
+    assertFailureKeys("value of", "expected to contain", "but was", "atomicLongMap was");
+    assertFailureValue("value of", "atomicLongMap.asMap().keySet()");
+    assertFailureValue("expected to contain", "greg");
   }
 
   @Test
@@ -220,9 +237,9 @@ public final class AtomicLongMapSubjectTest extends BaseSubjectTestCase {
     AtomicLongMap<String> actual = AtomicLongMap.create();
     actual.getAndIncrement("kurt");
     expectFailureWhenTestingThat(actual).doesNotContainKey("kurt");
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{kurt=1}> does not contain key <kurt>");
+    assertFailureKeys("value of", "expected not to contain", "but was", "atomicLongMap was");
+    assertFailureValue("value of", "atomicLongMap.asMap().keySet()");
+    assertFailureValue("expected not to contain", "kurt");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/IterableSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/IterableSubjectTest.java
@@ -133,9 +133,9 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void doesNotContainDuplicatesFailure() {
     expectFailureWhenTestingThat(asList(1, 2, 2, 3)).containsNoDuplicates();
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("<[1, 2, 2, 3]> has the following duplicates: <[2 x 2]>");
+    assertFailureKeys("expected not to contain duplicates", "but contained", "full contents");
+    assertFailureValue("but contained", "[2 x 2]");
+    assertFailureValue("full contents", "[1, 2, 2, 3]");
   }
 
   @Test
@@ -493,56 +493,47 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void iterableContainsNoneOfFailure() {
     expectFailureWhenTestingThat(asList(1, 2, 3)).containsNoneOf(1, 2, 4);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <[1, 2, 3]> contains none of <[1, 2, 4]>. It contains <[1, 2]>");
+    assertFailureKeys("expected not to contain any of", "but contained", "full contents");
+    assertFailureValue("expected not to contain any of", "[1, 2, 4]");
+    assertFailureValue("but contained", "[1, 2]");
+    assertFailureValue("full contents", "[1, 2, 3]");
   }
 
   @Test
   public void iterableContainsNoneOfFailureWithDuplicateInSubject() {
     expectFailureWhenTestingThat(asList(1, 2, 2, 3)).containsNoneOf(1, 2, 4);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2, 2, 3]> contains none of <[1, 2, 4]>. It contains <[1, 2]>");
+    assertFailureValue("but contained", "[1, 2]");
   }
 
   @Test
   public void iterableContainsNoneOfFailureWithDuplicateInExpected() {
     expectFailureWhenTestingThat(asList(1, 2, 3)).containsNoneOf(1, 2, 2, 4);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2, 3]> contains none of <[1, 2, 2, 4]>. It contains <[1, 2]>");
+    assertFailureValue("but contained", "[1, 2]");
   }
 
   @Test
   public void iterableContainsNoneOfFailureWithEmptyString() {
     expectFailureWhenTestingThat(asList("")).containsNoneOf("", null);
-
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[]> contains none of <[\"\" (empty String), null]>. "
-                + "It contains <[\"\" (empty String)]>");
+    assertFailureKeys("expected not to contain any of", "but contained", "full contents");
+    assertFailureValue("expected not to contain any of", "[\"\" (empty String), null]");
+    assertFailureValue("but contained", "[\"\" (empty String)]");
+    assertFailureValue("full contents", "[]");
   }
 
   @Test
   public void iterableContainsNoneInIterable() {
     assertThat(asList(1, 2, 3)).containsNoneIn(asList(4, 5, 6));
     expectFailureWhenTestingThat(asList(1, 2, 3)).containsNoneIn(asList(1, 2, 4));
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <[1, 2, 3]> contains none of <[1, 2, 4]>. It contains <[1, 2]>");
+    assertFailureKeys("expected not to contain any of", "but contained", "full contents");
+    assertFailureValue("expected not to contain any of", "[1, 2, 4]");
+    assertFailureValue("but contained", "[1, 2]");
+    assertFailureValue("full contents", "[1, 2, 3]");
   }
 
   @Test
   public void iterableContainsNoneInArray() {
     assertThat(asList(1, 2, 3)).containsNoneIn(new Integer[] {4, 5, 6});
     expectFailureWhenTestingThat(asList(1, 2, 3)).containsNoneIn(new Integer[] {1, 2, 4});
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <[1, 2, 3]> contains none of <[1, 2, 4]>. It contains <[1, 2]>");
   }
 
   @Test
@@ -1038,8 +1029,11 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void isStrictlyOrderedFailure() {
     expectFailureWhenTestingThat(asList(1, 2, 2, 4)).isStrictlyOrdered();
-    assertThat(expectFailure.getFailure()).hasMessageThat().contains("is strictly ordered");
-    assertThat(expectFailure.getFailure()).hasMessageThat().contains("<2> <2>");
+    assertFailureKeys(
+        "expected to be strictly ordered", "but contained", "followed by", "full contents");
+    assertFailureValue("but contained", "2");
+    assertFailureValue("followed by", "2");
+    assertFailureValue("full contents", "[1, 2, 2, 4]");
   }
 
   @Test
@@ -1061,15 +1055,15 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void isOrderedFailure() {
     expectFailureWhenTestingThat(asList(1, 3, 2, 4)).isOrdered();
-    assertThat(expectFailure.getFailure()).hasMessageThat().contains("is ordered");
-    assertThat(expectFailure.getFailure()).hasMessageThat().contains("<3> <2>");
+    assertFailureKeys("expected to be ordered", "but contained", "followed by", "full contents");
+    assertFailureValue("but contained", "3");
+    assertFailureValue("followed by", "2");
+    assertFailureValue("full contents", "[1, 3, 2, 4]");
   }
 
   @Test
   public void isOrderedMultipleFailures() {
     expectFailureWhenTestingThat(asList(1, 3, 2, 4, 0)).isOrdered();
-    assertThat(expectFailure.getFailure()).hasMessageThat().contains("is ordered");
-    assertThat(expectFailure.getFailure()).hasMessageThat().contains("<3> <2>");
   }
 
   @Test
@@ -1093,8 +1087,11 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void iterableIsStrictlyOrderedWithComparatorFailure() {
     expectFailureWhenTestingThat(asList("1", "2", "2", "10")).isStrictlyOrdered(COMPARE_AS_DECIMAL);
-    assertThat(expectFailure.getFailure()).hasMessageThat().contains("is strictly ordered");
-    assertThat(expectFailure.getFailure()).hasMessageThat().contains("<2> <2>");
+    assertFailureKeys(
+        "expected to be strictly ordered", "but contained", "followed by", "full contents");
+    assertFailureValue("but contained", "2");
+    assertFailureValue("followed by", "2");
+    assertFailureValue("full contents", "[1, 2, 2, 10]");
   }
 
   @Test
@@ -1108,8 +1105,10 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void iterableIsOrderedWithComparatorFailure() {
     expectFailureWhenTestingThat(asList("1", "10", "2", "20")).isOrdered(COMPARE_AS_DECIMAL);
-    assertThat(expectFailure.getFailure()).hasMessageThat().contains("is ordered");
-    assertThat(expectFailure.getFailure()).hasMessageThat().contains("<10> <2>");
+    assertFailureKeys("expected to be ordered", "but contained", "followed by", "full contents");
+    assertFailureValue("but contained", "10");
+    assertFailureValue("followed by", "2");
+    assertFailureValue("full contents", "[1, 10, 2, 20]");
   }
 
   private static final Comparator<String> COMPARE_AS_DECIMAL =

--- a/core/src/test/java/com/google/common/truth/IterableSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/IterableSubjectTest.java
@@ -78,45 +78,29 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void iterableContainsFailsWithSameToString() {
     expectFailureWhenTestingThat(asList(1L, 2L, 3L, 2L)).contains(2);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "<[1, 2, 3, 2]> should have contained <2 (java.lang.Integer)> but doesn't. However, "
-                + "it does contain <[2 [2 copies]] (java.lang.Long)>.");
+    assertFailureKeys(
+        "expected to contain",
+        "an instance of",
+        "but did not",
+        "though it did contain",
+        "full contents");
+    assertFailureValue("expected to contain", "2");
+    assertFailureValue("an instance of", "java.lang.Integer");
+    assertFailureValue("though it did contain", "[2 [2 copies]] (java.lang.Long)");
+    assertFailureValue("full contents", "[1, 2, 3, 2]");
   }
 
   @Test
   public void iterableContainsFailsWithSameToStringAndNull() {
     expectFailureWhenTestingThat(asList(1, "null")).contains(null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "<[1, null]> should have contained <null (null type)> but doesn't. However, it does "
-                + "contain <[null] (java.lang.String)>.");
+    assertFailureValue("an instance of", "null type");
   }
 
   @Test
   public void iterableContainsFailure() {
     expectFailureWhenTestingThat(asList(1, 2, 3)).contains(5);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("<[1, 2, 3]> should have contained <5>");
-  }
-
-  @Test
-  public void namedIterableContainsFailure() {
-    expectFailureWhenTestingThat(asList(1, 2, 3)).named("numbers").contains(5);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("numbers (<[1, 2, 3]>) should have contained <5>");
-  }
-
-  @Test
-  public void failureMessageIterableContainsFailure() {
-    expectFailure.whenTesting().withMessage("custom msg").that(asList(1, 2, 3)).contains(5);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("custom msg\n<[1, 2, 3]> should have contained <5>");
+    assertFailureKeys("expected to contain", "but was");
+    assertFailureValue("expected to contain", "5");
   }
 
   @Test
@@ -132,9 +116,8 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void iterableDoesNotContainFailure() {
     expectFailureWhenTestingThat(asList(1, 2, 3)).doesNotContain(2);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("<[1, 2, 3]> should not have contained <2>");
+    assertFailureKeys("expected not to contain", "but was");
+    assertFailureValue("expected not to contain", "2");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/MapSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/MapSubjectTest.java
@@ -550,29 +550,36 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   public void containsKeyFailure() {
     ImmutableMap<String, String> actual = ImmutableMap.of("kurt", "kluever");
     expectFailureWhenTestingThat(actual).containsKey("greg");
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{kurt=kluever}> contains key <greg>");
+    assertFailureKeys("value of", "expected to contain", "but was", "map was");
+    assertFailureValue("value of", "map.keySet()");
+    assertFailureValue("expected to contain", "greg");
+    assertFailureValue("but was", "[kurt]");
   }
 
   @Test
   public void containsKeyNullFailure() {
     ImmutableMap<String, String> actual = ImmutableMap.of("kurt", "kluever");
     expectFailureWhenTestingThat(actual).containsKey(null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{kurt=kluever}> contains key <null>");
+    assertFailureKeys("value of", "expected to contain", "but was", "map was");
+    assertFailureValue("value of", "map.keySet()");
+    assertFailureValue("expected to contain", "null");
+    assertFailureValue("but was", "[kurt]");
   }
 
   @Test
   public void containsKey_failsWithSameToString() {
     expectFailureWhenTestingThat(ImmutableMap.of(1L, "value1", 2L, "value2", "1", "value3"))
         .containsKey(1);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <{1=value1, 2=value2, 1=value3}> contains key <1 (java.lang.Integer)>. "
-                + "However, it does contain keys <[1 (java.lang.Long), 1 (java.lang.String)]>.");
+    assertFailureKeys(
+        "value of",
+        "expected to contain",
+        "an instance of",
+        "but did not",
+        "though it did contain",
+        "full contents",
+        "map was");
+    assertFailureValue("value of", "map.keySet()");
+    assertFailureValue("expected to contain", "1");
   }
 
   @Test
@@ -581,11 +588,16 @@ public class MapSubjectTest extends BaseSubjectTestCase {
     actual.put("null", "value1");
 
     expectFailureWhenTestingThat(actual).containsKey(null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <{null=value1}> contains key <null (null type)>. However, "
-                + "it does contain keys <[null] (java.lang.String)>.");
+    assertFailureKeys(
+        "value of",
+        "expected to contain",
+        "an instance of",
+        "but did not",
+        "though it did contain",
+        "full contents",
+        "map was");
+    assertFailureValue("value of", "map.keySet()");
+    assertFailureValue("expected to contain", "null");
   }
 
   @Test
@@ -606,9 +618,10 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   public void doesNotContainKeyFailure() {
     ImmutableMap<String, String> actual = ImmutableMap.of("kurt", "kluever");
     expectFailureWhenTestingThat(actual).doesNotContainKey("kurt");
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{kurt=kluever}> does not contain key <kurt>");
+    assertFailureKeys("value of", "expected not to contain", "but was", "map was");
+    assertFailureValue("value of", "map.keySet()");
+    assertFailureValue("expected not to contain", "kurt");
+    assertFailureValue("but was", "[kurt]");
   }
 
   @Test
@@ -616,9 +629,10 @@ public class MapSubjectTest extends BaseSubjectTestCase {
     Map<String, String> actual = Maps.newHashMap();
     actual.put(null, "null");
     expectFailureWhenTestingThat(actual).doesNotContainKey(null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{null=null}> does not contain key <null>");
+    assertFailureKeys("value of", "expected not to contain", "but was", "map was");
+    assertFailureValue("value of", "map.keySet()");
+    assertFailureValue("expected not to contain", "null");
+    assertFailureValue("but was", "[null]");
   }
 
   @Test
@@ -719,9 +733,10 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   public void doesNotContainEntryFailure() {
     ImmutableMap<String, String> actual = ImmutableMap.of("kurt", "kluever");
     expectFailureWhenTestingThat(actual).doesNotContainEntry("kurt", "kluever");
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{kurt=kluever}> does not contain entry <kurt=kluever>");
+    assertFailureKeys("value of", "expected not to contain", "but was");
+    assertFailureValue("value of", "map.entrySet()");
+    assertFailureValue("expected not to contain", "kurt=kluever");
+    assertFailureValue("but was", "[kurt=kluever]");
   }
 
   @Test
@@ -737,36 +752,40 @@ public class MapSubjectTest extends BaseSubjectTestCase {
     Map<String, String> actual = Maps.newHashMap();
     actual.put(null, null);
     expectFailureWhenTestingThat(actual).doesNotContainEntry(null, null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{null=null}> does not contain entry <null=null>");
+    assertFailureKeys("value of", "expected not to contain", "but was");
+    assertFailureValue("value of", "map.entrySet()");
+    assertFailureValue("expected not to contain", "null=null");
+    assertFailureValue("but was", "[null=null]");
   }
 
   @Test
   public void failMapContainsKey() {
     ImmutableMap<String, String> actual = ImmutableMap.of("a", "A");
     expectFailureWhenTestingThat(actual).containsKey("b");
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{a=A}> contains key <b>");
+    assertFailureKeys("value of", "expected to contain", "but was", "map was");
+    assertFailureValue("value of", "map.keySet()");
+    assertFailureValue("expected to contain", "b");
+    assertFailureValue("but was", "[a]");
   }
 
   @Test
   public void failMapContainsKeyWithNull() {
     ImmutableMap<String, String> actual = ImmutableMap.of("a", "A");
     expectFailureWhenTestingThat(actual).containsKey(null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{a=A}> contains key <null>");
+    assertFailureKeys("value of", "expected to contain", "but was", "map was");
+    assertFailureValue("value of", "map.keySet()");
+    assertFailureValue("expected to contain", "null");
+    assertFailureValue("but was", "[a]");
   }
 
   @Test
   public void failMapLacksKey() {
     ImmutableMap<String, String> actual = ImmutableMap.of("a", "A");
     expectFailureWhenTestingThat(actual).doesNotContainKey("a");
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{a=A}> does not contain key <a>");
+    assertFailureKeys("value of", "expected not to contain", "but was", "map was");
+    assertFailureValue("value of", "map.keySet()");
+    assertFailureValue("expected not to contain", "a");
+    assertFailureValue("but was", "[a]");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/MultimapSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/MultimapSubjectTest.java
@@ -231,9 +231,10 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   public void containsKeyFailure() {
     ImmutableMultimap<String, String> multimap = ImmutableMultimap.of("kurt", "kluever");
     expectFailureWhenTestingThat(multimap).containsKey("daniel");
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{kurt=[kluever]}> contains key <daniel>");
+    assertFailureKeys("value of", "expected to contain", "but was", "multimap was");
+    assertFailureValue("value of", "multimap.keySet()");
+    assertFailureValue("expected to contain", "daniel");
+    assertFailureValue("but was", "[kurt]");
   }
 
   @Test
@@ -247,9 +248,10 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   public void containsKeyNullFailure() {
     ImmutableMultimap<String, String> multimap = ImmutableMultimap.of("kurt", "kluever");
     expectFailureWhenTestingThat(multimap).containsKey(null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{kurt=[kluever]}> contains key <null>");
+    assertFailureKeys("value of", "expected to contain", "but was", "multimap was");
+    assertFailureValue("value of", "multimap.keySet()");
+    assertFailureValue("expected to contain", "null");
+    assertFailureValue("but was", "[kurt]");
   }
 
   @Test
@@ -257,12 +259,16 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(
             ImmutableMultimap.of(1L, "value1a", 1L, "value1b", 2L, "value2", "1", "value3"))
         .containsKey(1);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <{1=[value1a, value1b], 2=[value2], 1=[value3]}> contains key "
-                + "<1 (java.lang.Integer)>. However, it does contain keys "
-                + "<[1 (java.lang.Long), 1 (java.lang.String)]>.");
+    assertFailureKeys(
+        "value of",
+        "expected to contain",
+        "an instance of",
+        "but did not",
+        "though it did contain",
+        "full contents",
+        "multimap was");
+    assertFailureValue("value of", "multimap.keySet()");
+    assertFailureValue("expected to contain", "1");
   }
 
   @Test
@@ -276,9 +282,10 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   public void doesNotContainKeyFailure() {
     ImmutableMultimap<String, String> multimap = ImmutableMultimap.of("kurt", "kluever");
     expectFailureWhenTestingThat(multimap).doesNotContainKey("kurt");
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{kurt=[kluever]}> does not contain key <kurt>");
+    assertFailureKeys("value of", "expected not to contain", "but was", "multimap was");
+    assertFailureValue("value of", "multimap.keySet()");
+    assertFailureValue("expected not to contain", "kurt");
+    assertFailureValue("but was", "[kurt]");
   }
 
   @Test
@@ -286,9 +293,10 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
     Multimap<String, String> multimap = HashMultimap.create();
     multimap.put(null, "null");
     expectFailureWhenTestingThat(multimap).doesNotContainKey(null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{null=[null]}> does not contain key <null>");
+    assertFailureKeys("value of", "expected not to contain", "but was", "multimap was");
+    assertFailureValue("value of", "multimap.keySet()");
+    assertFailureValue("expected not to contain", "null");
+    assertFailureValue("but was", "[null]");
   }
 
   @Test
@@ -372,9 +380,10 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   public void doesNotContainEntryFailure() {
     ImmutableMultimap<String, String> multimap = ImmutableMultimap.of("kurt", "kluever");
     expectFailureWhenTestingThat(multimap).doesNotContainEntry("kurt", "kluever");
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{kurt=[kluever]}> does not contain entry <kurt=kluever>");
+    assertFailureKeys("value of", "expected not to contain", "but was");
+    assertFailureValue("value of", "multimap.entries()");
+    assertFailureValue("expected not to contain", "kurt=kluever");
+    assertFailureValue("but was", "[kurt=kluever]");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/MultisetSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/MultisetSubjectTest.java
@@ -16,9 +16,7 @@
 package com.google.common.truth;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.fail;
 
-import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.Multiset;
 import org.junit.Test;
@@ -32,51 +30,6 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class MultisetSubjectTest extends BaseSubjectTestCase {
-
-  @Test
-  public void multisetIsEmpty() {
-    ImmutableMultiset<String> multiset = ImmutableMultiset.of();
-    assertThat(multiset).isEmpty();
-  }
-
-  @Test
-  public void multisetIsEmptyWithFailure() {
-    ImmutableMultiset<Integer> multiset = ImmutableMultiset.of(1, 5);
-    expectFailureWhenTestingThat(multiset).isEmpty();
-    assertFailureKeys("expected to be empty", "but was");
-  }
-
-  @Test
-  public void multisetIsNotEmpty() {
-    ImmutableMultiset<Integer> multiset = ImmutableMultiset.of(1, 5);
-    assertThat(multiset).isNotEmpty();
-  }
-
-  @Test
-  public void multisetIsNotEmptyWithFailure() {
-    ImmutableMultiset<Integer> multiset = ImmutableMultiset.of();
-    expectFailureWhenTestingThat(multiset).isNotEmpty();
-    assertFailureKeys("expected not to be empty");
-  }
-
-  @Test
-  public void hasSize() {
-    assertThat(ImmutableMultiset.of(1, 2, 3, 4)).hasSize(4);
-  }
-
-  @Test
-  public void hasSizeZero() {
-    assertThat(ImmutableMultiset.of()).hasSize(0);
-  }
-
-  @Test
-  public void hasSizeNegative() {
-    try {
-      assertThat(ImmutableMultiset.of(1, 2)).hasSize(-1);
-      fail();
-    } catch (IllegalArgumentException expected) {
-    }
-  }
 
   @Test
   public void hasCount() {
@@ -93,63 +46,6 @@ public class MultisetSubjectTest extends BaseSubjectTestCase {
     ImmutableMultiset<String> multiset = ImmutableMultiset.of("kurt", "kurt", "kluever");
     expectFailureWhenTestingThat(multiset).hasCount("kurt", 3);
     assertFailureValue("value of", "multiset.count(kurt)");
-  }
-
-  @Test
-  public void contains() {
-    ImmutableMultiset<String> multiset = ImmutableMultiset.of("kurt", "kluever");
-    assertThat(multiset).contains("kurt");
-  }
-
-  @Test
-  public void containsFailure() {
-    ImmutableMultiset<String> multiset = ImmutableMultiset.of("kurt", "kluever");
-    expectFailureWhenTestingThat(multiset).contains("greg");
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("<[kurt, kluever]> should have contained <greg>");
-  }
-
-  @Test
-  public void containsNullFailure() {
-    ImmutableMultiset<String> multiset = ImmutableMultiset.of("kurt", "kluever");
-    expectFailureWhenTestingThat(multiset).contains(null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("<[kurt, kluever]> should have contained <null>");
-  }
-
-  @Test
-  public void containsNull() {
-    Multiset<String> multiset = HashMultiset.create();
-    multiset.add(null);
-    assertThat(multiset).contains(null);
-  }
-
-  @Test
-  public void doesNotContain() {
-    ImmutableMultiset<String> multiset = ImmutableMultiset.of("kurt", "kluever");
-    assertThat(multiset).doesNotContain("greg");
-    assertThat(multiset).doesNotContain(null);
-  }
-
-  @Test
-  public void doesNotContainFailure() {
-    ImmutableMultiset<String> multiset = ImmutableMultiset.of("kurt", "kluever");
-    expectFailureWhenTestingThat(multiset).doesNotContain("kurt");
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("<[kurt, kluever]> should not have contained <kurt>");
-  }
-
-  @Test
-  public void doesNotContainNull() {
-    Multiset<String> multiset = HashMultiset.create();
-    multiset.add(null);
-    expectFailureWhenTestingThat(multiset).doesNotContain(null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("<[null]> should not have contained <null>");
   }
 
   private MultisetSubject expectFailureWhenTestingThat(Multiset<?> actual) {

--- a/core/src/test/java/com/google/common/truth/TableSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/TableSubjectTest.java
@@ -125,9 +125,10 @@ public class TableSubjectTest extends BaseSubjectTestCase {
   public void containsCellFailure() {
     ImmutableTable<String, String, String> table = ImmutableTable.of("row", "col", "val");
     expectFailureWhenTestingThat(table).containsCell("row", "row", "val");
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{row={col=val}}> contains cell <(row,row)=val>");
+    assertFailureKeys("value of", "expected to contain", "but was");
+    assertFailureValue("value of", "table.cellSet()");
+    assertFailureValue("expected to contain", "(row,row)=val");
+    assertFailureValue("but was", "[(row,col)=val]");
   }
 
   @Test
@@ -147,9 +148,10 @@ public class TableSubjectTest extends BaseSubjectTestCase {
   public void doesNotContainCellFailure() {
     ImmutableTable<String, String, String> table = ImmutableTable.of("row", "col", "val");
     expectFailureWhenTestingThat(table).doesNotContainCell("row", "col", "val");
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{row={col=val}}> does not contain cell <(row,col)=val>");
+    assertFailureKeys("value of", "expected not to contain", "but was");
+    assertFailureValue("value of", "table.cellSet()");
+    assertFailureValue("expected not to contain", "(row,col)=val");
+    assertFailureValue("but was", "[(row,col)=val]");
   }
 
   private static <R, C, V> Cell<R, C, V> cell(R row, C col, V val) {

--- a/extensions/java8/src/test/java/com/google/common/truth/IntStreamSubjectTest.java
+++ b/extensions/java8/src/test/java/com/google/common/truth/IntStreamSubjectTest.java
@@ -112,14 +112,8 @@ public final class IntStreamSubjectTest {
 
   @Test
   public void testContainsNoDuplicates_fails() throws Exception {
-    try {
-      assertThat(IntStream.of(42, 42)).containsNoDuplicates();
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("<[42, 42]> has the following duplicates: <[42 x 2]>");
-    }
+    AssertionError unused =
+        expectFailure(whenTesting -> whenTesting.that(IntStream.of(42, 42)).containsNoDuplicates());
   }
 
   @Test
@@ -185,14 +179,8 @@ public final class IntStreamSubjectTest {
 
   @Test
   public void testContainsNoneOf_fails() throws Exception {
-    try {
-      assertThat(IntStream.of(42)).containsNoneOf(42, 43);
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Not true that <[42]> contains none of <[42, 43]>. It contains <[42]>");
-    }
+    AssertionError unused =
+        expectFailure(whenTesting -> whenTesting.that(IntStream.of(42)).containsNoneOf(42, 43));
   }
 
   @Test
@@ -202,14 +190,9 @@ public final class IntStreamSubjectTest {
 
   @Test
   public void testContainsNoneIn_fails() throws Exception {
-    try {
-      assertThat(IntStream.of(42)).containsNoneIn(asList(42, 43));
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Not true that <[42]> contains none of <[42, 43]>. It contains <[42]>");
-    }
+    AssertionError unused =
+        expectFailure(
+            whenTesting -> whenTesting.that(IntStream.of(42)).containsNoneIn(asList(42, 43)));
   }
 
   @Test

--- a/extensions/java8/src/test/java/com/google/common/truth/IntStreamSubjectTest.java
+++ b/extensions/java8/src/test/java/com/google/common/truth/IntStreamSubjectTest.java
@@ -129,12 +129,8 @@ public final class IntStreamSubjectTest {
 
   @Test
   public void testContains_fails() throws Exception {
-    try {
-      assertThat(IntStream.of(42)).contains(100);
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("<[42]> should have contained <100>");
-    }
+    AssertionError unused =
+        expectFailure(whenTesting -> whenTesting.that(IntStream.of(42)).contains(100));
   }
 
   @Test
@@ -178,12 +174,8 @@ public final class IntStreamSubjectTest {
 
   @Test
   public void testDoesNotContain_fails() throws Exception {
-    try {
-      assertThat(IntStream.of(42)).doesNotContain(42);
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("<[42]> should not have contained <42>");
-    }
+    AssertionError unused =
+        expectFailure(whenTesting -> whenTesting.that(IntStream.of(42)).doesNotContain(42));
   }
 
   @Test

--- a/extensions/java8/src/test/java/com/google/common/truth/LongStreamSubjectTest.java
+++ b/extensions/java8/src/test/java/com/google/common/truth/LongStreamSubjectTest.java
@@ -129,12 +129,8 @@ public final class LongStreamSubjectTest {
 
   @Test
   public void testContains_fails() throws Exception {
-    try {
-      assertThat(LongStream.of(42)).contains(100);
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("<[42]> should have contained <100>");
-    }
+    AssertionError unused =
+        expectFailure(whenTesting -> whenTesting.that(LongStream.of(42)).contains(100));
   }
 
   @Test
@@ -178,12 +174,8 @@ public final class LongStreamSubjectTest {
 
   @Test
   public void testDoesNotContain_fails() throws Exception {
-    try {
-      assertThat(LongStream.of(42)).doesNotContain(42);
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("<[42]> should not have contained <42>");
-    }
+    AssertionError unused =
+        expectFailure(whenTesting -> whenTesting.that(LongStream.of(42)).doesNotContain(42));
   }
 
   @Test

--- a/extensions/java8/src/test/java/com/google/common/truth/LongStreamSubjectTest.java
+++ b/extensions/java8/src/test/java/com/google/common/truth/LongStreamSubjectTest.java
@@ -112,14 +112,9 @@ public final class LongStreamSubjectTest {
 
   @Test
   public void testContainsNoDuplicates_fails() throws Exception {
-    try {
-      assertThat(LongStream.of(42, 42)).containsNoDuplicates();
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("<[42, 42]> has the following duplicates: <[42 x 2]>");
-    }
+    AssertionError unused =
+        expectFailure(
+            whenTesting -> whenTesting.that(LongStream.of(42, 42)).containsNoDuplicates());
   }
 
   @Test
@@ -185,14 +180,8 @@ public final class LongStreamSubjectTest {
 
   @Test
   public void testContainsNoneOf_fails() throws Exception {
-    try {
-      assertThat(LongStream.of(42)).containsNoneOf(42, 43);
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Not true that <[42]> contains none of <[42, 43]>. It contains <[42]>");
-    }
+    AssertionError unused =
+        expectFailure(whenTesting -> whenTesting.that(LongStream.of(42)).containsNoneOf(42, 43));
   }
 
   @Test
@@ -202,14 +191,9 @@ public final class LongStreamSubjectTest {
 
   @Test
   public void testContainsNoneIn_fails() throws Exception {
-    try {
-      assertThat(LongStream.of(42)).containsNoneIn(asList(42L, 43L));
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Not true that <[42]> contains none of <[42, 43]>. It contains <[42]>");
-    }
+    AssertionError unused =
+        expectFailure(
+            whenTesting -> whenTesting.that(LongStream.of(42)).containsNoneIn(asList(42L, 43L)));
   }
 
   @Test

--- a/extensions/java8/src/test/java/com/google/common/truth/StreamSubjectTest.java
+++ b/extensions/java8/src/test/java/com/google/common/truth/StreamSubjectTest.java
@@ -129,12 +129,8 @@ public final class StreamSubjectTest {
 
   @Test
   public void testContains_fails() throws Exception {
-    try {
-      assertThat(Stream.of("hello")).contains("goodbye");
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("<[hello]> should have contained <goodbye>");
-    }
+    AssertionError unused =
+        expectFailure(whenTesting -> whenTesting.that(Stream.of("hello")).contains("goodbye"));
   }
 
   @Test
@@ -178,14 +174,8 @@ public final class StreamSubjectTest {
 
   @Test
   public void testDoesNotContain_fails() throws Exception {
-    try {
-      assertThat(Stream.of("hello")).doesNotContain("hello");
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("<[hello]> should not have contained <hello>");
-    }
+    AssertionError unused =
+        expectFailure(whenTesting -> whenTesting.that(Stream.of("hello")).doesNotContain("hello"));
   }
 
   @Test

--- a/extensions/java8/src/test/java/com/google/common/truth/StreamSubjectTest.java
+++ b/extensions/java8/src/test/java/com/google/common/truth/StreamSubjectTest.java
@@ -112,14 +112,9 @@ public final class StreamSubjectTest {
 
   @Test
   public void testContainsNoDuplicates_fails() throws Exception {
-    try {
-      assertThat(Stream.of("hello", "hello")).containsNoDuplicates();
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("<[hello, hello]> has the following duplicates: <[hello x 2]>");
-    }
+    AssertionError unused =
+        expectFailure(
+            whenTesting -> whenTesting.that(Stream.of("hello", "hello")).containsNoDuplicates());
   }
 
   @Test
@@ -185,15 +180,9 @@ public final class StreamSubjectTest {
 
   @Test
   public void testContainsNoneOf_fails() throws Exception {
-    try {
-      assertThat(Stream.of("hello")).containsNoneOf("hello", "hell");
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Not true that <[hello]> contains none of <[hello, hell]>. It contains <[hello]>");
-    }
+    AssertionError unused =
+        expectFailure(
+            whenTesting -> whenTesting.that(Stream.of("hello")).containsNoneOf("hello", "hell"));
   }
 
   @Test
@@ -203,16 +192,10 @@ public final class StreamSubjectTest {
 
   @Test
   public void testContainsNoneIn_fails() throws Exception {
-    try {
-      assertThat(Stream.of("hello")).containsNoneIn(asList("hello", "hell"));
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Not true that <[hello]> contains none of <[hello, hell]>. "
-                  + "It contains <[hello]>");
-    }
+    AssertionError unused =
+        expectFailure(
+            whenTesting ->
+                whenTesting.that(Stream.of("hello")).containsNoneIn(asList("hello", "hell")));
   }
 
   @Test


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Migrate single-element contains/doesNotContains failure messages to the new format.

Also, make AtomicLongMapSubject.doesNotContainEntry() reject null keys, as the other methods in the class do.

Update tests as usual, including deleting most MultisetSubjectTest methods, which test methods inherited from IterableSubject.

1fec1a9682ac70491ca444a1bcc8bf9733eae852

-------

<p> Migrate containsNoDuplicates, containsNone{Of,In}, and is{Strictly,}Ordered failure messages to the new format.

f28e8acfe46245d774a6ca07cebc816293ad5b4b