### PR TITLE
Moe Sync

### DIFF
--- a/core/src/test/java/com/google/common/truth/IterableSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/IterableSubjectTest.java
@@ -645,6 +645,17 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
+  public void iterableContainsExactlyWithEmptyStringAmongMissingItems() {
+    expectFailureWhenTestingThat(asList("a")).containsExactly("", "b");
+
+    assertFailureKeys(
+        "missing (2)", "#1", "#2", "", "unexpected (1)", "#1", "---", "expected", "but was");
+    assertFailureValueIndexed("#1", 0, "");
+    assertFailureValueIndexed("#2", 0, "b");
+    assertFailureValueIndexed("#1", 1, "a");
+  }
+
+  @Test
   public void iterableContainsExactlySingleElement() {
     assertThat(asList(1)).containsExactly(1);
 
@@ -790,6 +801,16 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(asList(1, 2, 3, 3)).containsExactly(1, 2, 4, 4);
     assertFailureValue("missing (2)", "4 [2 copies]");
     assertFailureValue("unexpected (2)", "3 [2 copies]");
+  }
+
+  @Test
+  public void iterableContainsExactlyWithCommaSeparatedVsIndividual() {
+    expectFailureWhenTestingThat(asList("a, b")).containsExactly("a", "b");
+    assertFailureKeys(
+        "missing (2)", "#1", "#2", "", "unexpected (1)", "#1", "---", "expected", "but was");
+    assertFailureValueIndexed("#1", 0, "a");
+    assertFailureValueIndexed("#2", 0, "b");
+    assertFailureValueIndexed("#1", 1, "a, b");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/IterableSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/IterableSubjectTest.java
@@ -624,33 +624,24 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
   public void iterableContainsExactlyWithEmptyString() {
     expectFailureWhenTestingThat(asList()).containsExactly("");
 
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[]> contains exactly <[\"\" (empty String)]>. "
-                + "It is missing <[\"\" (empty String)]>");
+    assertFailureValue("missing (1)", "");
   }
 
   @Test
   public void iterableContainsExactlyWithEmptyStringAndUnexpectedItem() {
     expectFailureWhenTestingThat(asList("a", null)).containsExactly("");
 
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[a, null]> contains exactly <[\"\" (empty String)]>. "
-                + "It is missing <[\"\" (empty String)]> and has unexpected items <[a, null]>");
+    assertFailureKeys("missing (1)", "unexpected (2)", "---", "expected", "but was");
+    assertFailureValue("missing (1)", "");
+    assertFailureValue("unexpected (2)", "a, null");
   }
 
   @Test
   public void iterableContainsExactlyWithEmptyStringAndMissingItem() {
     expectFailureWhenTestingThat(asList("")).containsExactly("a", null);
 
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[]> contains exactly <[a, null]>. "
-                + "It is missing <[a, null]> and has unexpected items <[\"\" (empty String)]>");
+    assertFailureValue("missing (2)", "a, null");
+    assertFailureValue("unexpected (1)", "");
   }
 
   @Test
@@ -679,11 +670,6 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
     assertThat(asList(one, two)).containsExactlyElementsIn(asList(one, two)).inOrder();
 
     expectFailureWhenTestingThat(asList(one, two)).containsExactly(one);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[HCT, HCT]> contains exactly <[HCT]>. "
-                + "It has unexpected items <[HCT]>");
   }
 
   private static class HashCodeThrower {
@@ -718,58 +704,62 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
   public void iterableContainsExactlyElementsInErrorMessageIsOrdered() {
     expectFailureWhenTestingThat(asList("foo OR bar"))
         .containsExactlyElementsIn(asList("foo", "bar"));
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[foo OR bar]> contains exactly <[foo, bar]>. "
-                + "It is missing <[foo, bar]> and has unexpected items <[foo OR bar]>");
+    assertFailureValue("missing (2)", "foo, bar");
+    assertFailureValue("unexpected (1)", "foo OR bar");
   }
 
   @Test
   public void iterableContainsExactlyMissingItemFailure() {
     expectFailureWhenTestingThat(asList(1, 2)).containsExactly(1, 2, 4);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <[1, 2]> contains exactly <[1, 2, 4]>. It is missing <[4]>");
+    assertFailureValue("missing (1)", "4");
   }
 
   @Test
   public void iterableContainsExactlyUnexpectedItemFailure() {
     expectFailureWhenTestingThat(asList(1, 2, 3)).containsExactly(1, 2);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2, 3]> contains exactly <[1, 2]>. It has unexpected items <[3]>");
+    assertFailureValue("unexpected (1)", "3");
   }
 
   @Test
   public void iterableContainsExactlyWithDuplicatesNotEnoughItemsFailure() {
     expectFailureWhenTestingThat(asList(1, 2, 3)).containsExactly(1, 2, 2, 2, 3);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2, 3]> contains exactly <[1, 2, 2, 2, 3]>. "
-                + "It is missing <[2 [2 copies]]>");
+    assertFailureValue("missing (2)", "2 [2 copies]");
   }
 
   @Test
   public void iterableContainsExactlyWithDuplicatesMissingItemFailure() {
     expectFailureWhenTestingThat(asList(1, 2, 3)).containsExactly(1, 2, 2, 2, 3, 4);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2, 3]> contains exactly <[1, 2, 2, 2, 3, 4]>. "
-                + "It is missing <[2 [2 copies], 4]>");
+    assertFailureValue("missing (3)", "2 [2 copies], 4");
+  }
+
+  @Test
+  public void iterableContainsExactlyWithDuplicatesMissingItemsWithNewlineFailure() {
+    expectFailureWhenTestingThat(asList("a", "b", "foo\nbar"))
+        .containsExactly("a", "b", "foo\nbar", "foo\nbar", "foo\nbar");
+    assertFailureKeys("missing (2)", "#1 [2 copies]", "---", "expected", "but was");
+    assertFailureValue("#1 [2 copies]", "foo\nbar");
+  }
+
+  @Test
+  public void iterableContainsExactlyWithDuplicatesMissingAndExtraItemsWithNewlineFailure() {
+    expectFailureWhenTestingThat(asList("a\nb", "a\nb")).containsExactly("foo\nbar", "foo\nbar");
+    assertFailureKeys(
+        "missing (2)",
+        "#1 [2 copies]",
+        "",
+        "unexpected (2)",
+        "#1 [2 copies]",
+        "---",
+        "expected",
+        "but was");
+    assertFailureValueIndexed("#1 [2 copies]", 0, "foo\nbar");
+    assertFailureValueIndexed("#1 [2 copies]", 1, "a\nb");
   }
 
   @Test
   public void iterableContainsExactlyWithDuplicatesUnexpectedItemFailure() {
     expectFailureWhenTestingThat(asList(1, 2, 2, 2, 2, 3)).containsExactly(1, 2, 2, 3);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2, 2, 2, 2, 3]> contains exactly <[1, 2, 2, 3]>. "
-                + "It has unexpected items <[2 [2 copies]]>");
+    assertFailureValue("unexpected (2)", "2 [2 copies]");
   }
 
   /*
@@ -779,96 +769,66 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void iterableContainsExactlyWithDuplicateMissingElements() {
     expectFailureWhenTestingThat(asList()).containsExactly(4, 4, 4);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[]> contains exactly <[4, 4, 4]>. It is missing <[4 [3 copies]]>");
+    assertFailureValue("missing (3)", "4 [3 copies]");
   }
 
   @Test
   public void iterableContainsExactlyWithNullFailure() {
     expectFailureWhenTestingThat(asList(1, null, 3)).containsExactly(1, null, null, 3);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, null, 3]> contains exactly <[1, null, null, 3]>. "
-                + "It is missing <[null]>");
+    assertFailureValue("missing (1)", "null");
   }
 
   @Test
   public void iterableContainsExactlyWithMissingAndExtraElements() {
     expectFailureWhenTestingThat(asList(1, 2, 3)).containsExactly(1, 2, 4);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2, 3]> contains exactly <[1, 2, 4]>. "
-                + "It is missing <[4]> and has unexpected items <[3]>");
+    assertFailureValue("missing (1)", "4");
+    assertFailureValue("unexpected (1)", "3");
   }
 
   @Test
   public void iterableContainsExactlyWithDuplicateMissingAndExtraElements() {
     expectFailureWhenTestingThat(asList(1, 2, 3, 3)).containsExactly(1, 2, 4, 4);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2, 3, 3]> contains exactly <[1, 2, 4, 4]>. "
-                + "It is missing <[4 [2 copies]]> and has unexpected items <[3 [2 copies]]>");
+    assertFailureValue("missing (2)", "4 [2 copies]");
+    assertFailureValue("unexpected (2)", "3 [2 copies]");
   }
 
   @Test
   public void iterableContainsExactlyFailsWithSameToStringAndHomogeneousList() {
     expectFailureWhenTestingThat(asList(1L, 2L)).containsExactly(1, 2);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2]> contains exactly <[1, 2]>. It is missing "
-                + "<[1, 2] (java.lang.Integer)> and has unexpected items "
-                + "<[1, 2] (java.lang.Long)>");
+    assertFailureValue("missing (2)", "1, 2 (java.lang.Integer)");
+    assertFailureValue("unexpected (2)", "1, 2 (java.lang.Long)");
   }
 
   @Test
   public void iterableContainsExactlyFailsWithSameToStringAndListWithNull() {
     expectFailureWhenTestingThat(asList(1L, 2L)).containsExactly(null, 1, 2);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2]> contains exactly <[null, 1, 2]>. It is missing "
-                + "<[null (null type), 1 (java.lang.Integer), 2 (java.lang.Integer)]> and has "
-                + "unexpected items <[1, 2] (java.lang.Long)>");
+    assertFailureValue(
+        "missing (3)", "null (null type), 1 (java.lang.Integer), 2 (java.lang.Integer)");
+    assertFailureValue("unexpected (2)", "1, 2 (java.lang.Long)");
   }
 
   @Test
   public void iterableContainsExactlyFailsWithSameToStringAndHeterogeneousList() {
     expectFailureWhenTestingThat(asList(1L, 2)).containsExactly(1, null, 2L);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2]> contains exactly <[1, null, 2]>. It is missing "
-                + "<[1 (java.lang.Integer), null (null type), 2 (java.lang.Long)]> and has "
-                + "unexpected items <[1 (java.lang.Long), 2 (java.lang.Integer)]>");
+    assertFailureValue(
+        "missing (3)", "1 (java.lang.Integer), null (null type), 2 (java.lang.Long)");
+    assertFailureValue("unexpected (2)", "1 (java.lang.Long), 2 (java.lang.Integer)");
   }
 
   @Test
   public void iterableContainsExactlyFailsWithSameToStringAndHomogeneousListWithDuplicates() {
     expectFailureWhenTestingThat(asList(1L, 2L)).containsExactly(1, 2, 2);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2]> contains exactly <[1, 2, 2]>. It is missing "
-                + "<[1, 2 [2 copies]] (java.lang.Integer)> and has unexpected items "
-                + "<[1, 2] (java.lang.Long)>");
+    assertFailureValue("missing (3)", "1, 2 [2 copies] (java.lang.Integer)");
+    assertFailureValue("unexpected (2)", "1, 2 (java.lang.Long)");
   }
 
   @Test
   public void iterableContainsExactlyFailsWithSameToStringAndHeterogeneousListWithDuplicates() {
     expectFailureWhenTestingThat(asList(1L, 2)).containsExactly(1, null, null, 2L, 2L);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2]> contains exactly <[1, null, null, 2, 2]>. It is missing "
-                + "<[1 (java.lang.Integer), null (null type) [2 copies], "
-                + "2 (java.lang.Long) [2 copies]]> and has unexpected items "
-                + "<[1 (java.lang.Long), 2 (java.lang.Integer)]>");
+    assertFailureValue(
+        "missing (5)",
+        "1 (java.lang.Integer), null (null type) [2 copies], 2 (java.lang.Long) [2 copies]");
+    assertFailureValue("unexpected (2)", "1 (java.lang.Long), 2 (java.lang.Integer)");
   }
 
   @Test
@@ -876,22 +836,13 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(asList(1, 2, 3, 4)).containsExactly(asList(1, 2, 3, 4));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2, 3, 4]> contains exactly <[[1, 2, 3, 4]]>. "
-                + "It is missing <[[1, 2, 3, 4]]> and has unexpected items <[1, 2, 3, 4]>. "
-                + "Passing an iterable to the varargs method containsExactly(Object...) is "
-                + "often not the correct thing to do. Did you mean to call "
-                + "containsExactlyElementsIn(Iterable) instead?");
+        .contains(CONTAINS_EXACTLY_ITERABLE_WARNING);
   }
 
   @Test
   public void iterableContainsExactlyElementsInWithOneIterableDoesNotGiveWarning() {
     expectFailureWhenTestingThat(asList(1, 2, 3, 4)).containsExactlyElementsIn(asList(1, 2, 3));
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2, 3, 4]> contains exactly <[1, 2, 3]>. "
-                + "It has unexpected items <[4]>");
+    assertFailureValue("unexpected (1)", "4");
   }
 
   @Test
@@ -899,19 +850,18 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(asList(1, 2, 3, 4)).containsExactly(asList(1, 2), asList(3, 4));
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2, 3, 4]> contains exactly <[[1, 2], [3, 4]]>. "
-                + "It is missing <[[1, 2], [3, 4]]> and has unexpected items <[1, 2, 3, 4]>");
+        .doesNotContain(CONTAINS_EXACTLY_ITERABLE_WARNING);
   }
+
+  private static final String CONTAINS_EXACTLY_ITERABLE_WARNING =
+      "Passing an iterable to the varargs method containsExactly(Object...) is "
+          + "often not the correct thing to do. Did you mean to call "
+          + "containsExactlyElementsIn(Iterable) instead?";
 
   @Test
   public void iterableContainsExactlyWithOneNonIterableDoesNotGiveWarning() {
     expectFailureWhenTestingThat(asList(1, 2, 3, 4)).containsExactly(1);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2, 3, 4]> contains exactly <[1]>. "
-                + "It has unexpected items <[2, 3, 4]>");
+    assertFailureValue("unexpected (3)", "2, 3, 4");
   }
 
   @Test
@@ -976,10 +926,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
         };
 
     expectFailureWhenTestingThat(iterable).containsExactly(1, 2).inOrder();
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2, 3]> contains exactly <[1, 2]>. It has unexpected items <[3]>");
+    assertFailureValue("but was", "[1, 2, 3]");
   }
 
   @Test
@@ -987,9 +934,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
     assertThat(asList(1, 2)).containsExactlyElementsIn(asList(1, 2));
 
     expectFailureWhenTestingThat(asList(1, 2)).containsExactlyElementsIn(asList(1, 2, 4));
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <[1, 2]> contains exactly <[1, 2, 4]>. It is missing <[4]>");
+    assertFailureValue("missing (1)", "4");
   }
 
   @Test
@@ -997,9 +942,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
     assertThat(asList(1, 2)).containsExactlyElementsIn(new Integer[] {1, 2});
 
     expectFailureWhenTestingThat(asList(1, 2)).containsExactlyElementsIn(new Integer[] {1, 2, 4});
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <[1, 2]> contains exactly <[1, 2, 4]>. It is missing <[4]>");
+    assertFailureValue("missing (1)", "4");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/MultimapSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/MultimapSubjectTest.java
@@ -193,14 +193,16 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   public void valuesForKeyNamedMultipleElements() {
     ImmutableMultimap<Integer, Integer> multimap = ImmutableMultimap.of(1, 5);
     expectFailureWhenTestingThat(multimap).valuesForKey(1).named("valuez").containsExactly(3, 4);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "value of    : multimap.valuesForKey(1)\n"
-                + "name        : valuez\n"
-                + "Not true that valuez (<[5]>) contains exactly <[3, 4]>. "
-                + "It is missing <[3, 4]> and has unexpected items <[5]>\n"
-                + "multimap was: {1=[5]}");
+    assertFailureKeys(
+        "value of",
+        "name",
+        "missing (2)",
+        "unexpected (1)",
+        "---",
+        "expected",
+        "but was",
+        "multimap was");
+    assertFailureValue("value of", "multimap.valuesForKey(1)");
   }
 
   @Test

--- a/extensions/java8/src/test/java/com/google/common/truth/IntStreamSubjectTest.java
+++ b/extensions/java8/src/test/java/com/google/common/truth/IntStreamSubjectTest.java
@@ -283,11 +283,8 @@ public final class IntStreamSubjectTest {
       assertThat(IntStream.of(42, 43)).containsExactly(42);
       fail();
     } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Not true that <[42, 43]> contains exactly <[42]>. "
-                  + "It has unexpected items <[43]>");
+      assertFailureKeys(expected, "unexpected (1)", "---", "expected", "but was");
+      assertFailureValue(expected, "expected", "[42]");
     }
   }
 
@@ -319,11 +316,8 @@ public final class IntStreamSubjectTest {
       assertThat(IntStream.of(42, 43)).containsExactlyElementsIn(asList(42));
       fail();
     } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Not true that <[42, 43]> contains exactly <[42]>. "
-                  + "It has unexpected items <[43]>");
+      assertFailureKeys(expected, "unexpected (1)", "---", "expected", "but was");
+      assertFailureValue(expected, "expected", "[42]");
     }
   }
 

--- a/extensions/java8/src/test/java/com/google/common/truth/LongStreamSubjectTest.java
+++ b/extensions/java8/src/test/java/com/google/common/truth/LongStreamSubjectTest.java
@@ -314,11 +314,8 @@ public final class LongStreamSubjectTest {
       assertThat(LongStream.of(42, 43)).containsExactly(42);
       fail();
     } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Not true that <[42, 43]> contains exactly <[42]>. "
-                  + "It has unexpected items <[43]>");
+      assertFailureKeys(expected, "unexpected (1)", "---", "expected", "but was");
+      assertFailureValue(expected, "expected", "[42]");
     }
   }
 
@@ -350,27 +347,17 @@ public final class LongStreamSubjectTest {
       assertThat(LongStream.of(42, 43)).containsExactlyElementsIn(asList(42L));
       fail();
     } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Not true that <[42, 43]> contains exactly <[42]>. "
-                  + "It has unexpected items <[43]>");
+      assertFailureKeys(expected, "unexpected (1)", "---", "expected", "but was");
+      assertFailureValue(expected, "expected", "[42]");
     }
   }
 
   @Test
   public void testContainsExactlyElementsIn_wrongType_fails() throws Exception {
-    try {
-      assertThat(LongStream.of(42, 43)).containsExactlyElementsIn(asList(42));
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Not true that <[42, 43]> contains exactly <[42]>. "
-                  + "It is missing <[42] (java.lang.Integer)> and "
-                  + "has unexpected items <[42, 43] (java.lang.Long)>");
-    }
+    AssertionError unused =
+        expectFailure(
+            whenTesting ->
+                whenTesting.that(LongStream.of(42, 43)).containsExactlyElementsIn(asList(42)));
   }
 
   @Test
@@ -391,17 +378,13 @@ public final class LongStreamSubjectTest {
 
   @Test
   public void testContainsExactlyElementsIn_inOrder_wrongType_fails() throws Exception {
-    try {
-      assertThat(LongStream.of(42, 43)).containsExactlyElementsIn(asList(43, 42)).inOrder();
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Not true that <[42, 43]> contains exactly <[43, 42]>. "
-                  + "It is missing <[43, 42] (java.lang.Integer)> and "
-                  + "has unexpected items <[42, 43] (java.lang.Long)>");
-    }
+    AssertionError unused =
+        expectFailure(
+            whenTesting ->
+                whenTesting
+                    .that(LongStream.of(42, 43))
+                    .containsExactlyElementsIn(asList(43, 42))
+                    .inOrder());
   }
 
   @Test

--- a/extensions/java8/src/test/java/com/google/common/truth/StreamSubjectTest.java
+++ b/extensions/java8/src/test/java/com/google/common/truth/StreamSubjectTest.java
@@ -288,11 +288,8 @@ public final class StreamSubjectTest {
       assertThat(Stream.of("hell", "hello")).containsExactly("hell");
       fail();
     } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Not true that <[hell, hello]> contains exactly <[hell]>. "
-                  + "It has unexpected items <[hello]>");
+      assertFailureKeys(expected, "unexpected (1)", "---", "expected", "but was");
+      assertFailureValue(expected, "expected", "[hell]");
     }
   }
 
@@ -324,11 +321,8 @@ public final class StreamSubjectTest {
       assertThat(Stream.of("hell", "hello")).containsExactlyElementsIn(asList("hell"));
       fail();
     } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Not true that <[hell, hello]> contains exactly <[hell]>. "
-                  + "It has unexpected items <[hello]>");
+      assertFailureKeys(expected, "unexpected (1)", "---", "expected", "but was");
+      assertFailureValue(expected, "expected", "[hell]");
     }
   }
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Migrate containsExactly failure messages to the new format.

784585cbdaabbb45a3f8e3e2568509ca65080b09

-------

<p> More explicitly differentiate 1 element "1, 2" from 2 elements "1" and "2".

(I would have done this in the original CL, but I only now figured out what I meant in the cryptic TODO I'd left myself on my phone last week :) I should be done tuning containsExactly for now, at least until I hear user feedback.)

Before:

missing (2)   : a, b
unexpected (1): a, b

After:

missing (2)

unexpected (1)

The current version is hopefully understandable already, but I figure it can't hurt to be more clear.

Also, add tests for this and another case.

1d6fe05101baaa45f31f6c008682ce8a2606a06c