### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/AbstractArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/AbstractArraySubject.java
@@ -16,7 +16,7 @@
 package com.google.common.truth;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.truth.Fact.factWithoutValue;
+import static com.google.common.truth.Fact.simpleFact;
 
 import java.lang.reflect.Array;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
@@ -35,14 +35,14 @@ abstract class AbstractArraySubject<S extends AbstractArraySubject<S, T>, T> ext
   /** Fails if the array is not empty (i.e. {@code array.length != 0}). */
   public final void isEmpty() {
     if (length() > 0) {
-      fail(factWithoutValue("expected to be empty"));
+      failWithActual(simpleFact("expected to be empty"));
     }
   }
 
   /** Fails if the array is empty (i.e. {@code array.length == 0}). */
   public final void isNotEmpty() {
     if (length() == 0) {
-      failWithoutActual(factWithoutValue("expected not to be empty"));
+      failWithoutActual(simpleFact("expected not to be empty"));
     }
   }
 

--- a/core/src/main/java/com/google/common/truth/AtomicLongMapSubject.java
+++ b/core/src/main/java/com/google/common/truth/AtomicLongMapSubject.java
@@ -18,7 +18,7 @@ package com.google.common.truth;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Maps.immutableEntry;
-import static com.google.common.truth.Fact.factWithoutValue;
+import static com.google.common.truth.Fact.simpleFact;
 
 import com.google.common.util.concurrent.AtomicLongMap;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
@@ -58,14 +58,14 @@ public final class AtomicLongMapSubject extends Subject<AtomicLongMapSubject, At
   /** Fails if the {@link AtomicLongMap} is not empty. */
   public void isEmpty() {
     if (!actual().isEmpty()) {
-      fail(factWithoutValue("expected to be empty"));
+      failWithActual(simpleFact("expected to be empty"));
     }
   }
 
   /** Fails if the {@link AtomicLongMap} is empty. */
   public void isNotEmpty() {
     if (actual().isEmpty()) {
-      failWithoutActual(factWithoutValue("expected not to be empty"));
+      failWithoutActual(simpleFact("expected not to be empty"));
     }
   }
 

--- a/core/src/main/java/com/google/common/truth/BigDecimalSubject.java
+++ b/core/src/main/java/com/google/common/truth/BigDecimalSubject.java
@@ -16,7 +16,7 @@
 package com.google.common.truth;
 
 import static com.google.common.truth.Fact.fact;
-import static com.google.common.truth.Fact.factWithoutValue;
+import static com.google.common.truth.Fact.simpleFact;
 
 import java.math.BigDecimal;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
@@ -91,8 +91,7 @@ public final class BigDecimalSubject extends ComparableSubject<BigDecimalSubject
 
   private void compareValues(BigDecimal expected) {
     if (actual().compareTo(expected) != 0) {
-      failWithoutActual(
-          fact("expected", expected), butWas(), factWithoutValue("(scale is ignored)"));
+      failWithoutActual(fact("expected", expected), butWas(), simpleFact("(scale is ignored)"));
     }
   }
 }

--- a/core/src/main/java/com/google/common/truth/BooleanSubject.java
+++ b/core/src/main/java/com/google/common/truth/BooleanSubject.java
@@ -15,7 +15,7 @@
  */
 package com.google.common.truth;
 
-import static com.google.common.truth.Fact.factWithoutValue;
+import static com.google.common.truth.Fact.simpleFact;
 
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
@@ -34,7 +34,7 @@ public final class BooleanSubject extends Subject<BooleanSubject, Boolean> {
     if (actual() == null) {
       isEqualTo(true); // fails
     } else if (!actual()) {
-      failWithoutActual(factWithoutValue("expected to be true"));
+      failWithoutActual(simpleFact("expected to be true"));
     }
   }
 
@@ -43,7 +43,7 @@ public final class BooleanSubject extends Subject<BooleanSubject, Boolean> {
     if (actual() == null) {
       isEqualTo(false); // fails
     } else if (actual()) {
-      failWithoutActual(factWithoutValue("expected to be false"));
+      failWithoutActual(simpleFact("expected to be false"));
     }
   }
 }

--- a/core/src/main/java/com/google/common/truth/ClassSubject.java
+++ b/core/src/main/java/com/google/common/truth/ClassSubject.java
@@ -35,7 +35,7 @@ public final class ClassSubject extends Subject<ClassSubject, Class<?>> {
    */
   public void isAssignableTo(Class<?> clazz) {
     if (!clazz.isAssignableFrom(actual())) {
-      failWithFact("expected to be assignable to", clazz.getName());
+      failWithActual("expected to be assignable to", clazz.getName());
     }
   }
 }

--- a/core/src/main/java/com/google/common/truth/ComparableSubject.java
+++ b/core/src/main/java/com/google/common/truth/ComparableSubject.java
@@ -36,14 +36,14 @@ public abstract class ComparableSubject<S extends ComparableSubject<S, T>, T ext
   /** Checks that the subject is in {@code range}. */
   public final void isIn(Range<T> range) {
     if (!range.contains(actual())) {
-      failWithFact("expected to be in range", range);
+      failWithActual("expected to be in range", range);
     }
   }
 
   /** Checks that the subject is <i>not</i> in {@code range}. */
   public final void isNotIn(Range<T> range) {
     if (range.contains(actual())) {
-      failWithFact("expected not to be in range", range);
+      failWithActual("expected not to be in range", range);
     }
   }
 
@@ -56,7 +56,7 @@ public abstract class ComparableSubject<S extends ComparableSubject<S, T>, T ext
    */
   public void isEquivalentAccordingToCompareTo(T expected) {
     if (actual().compareTo(expected) != 0) {
-      failWithFact("expected value that sorts equal to", expected);
+      failWithActual("expected value that sorts equal to", expected);
     }
   }
 
@@ -82,7 +82,7 @@ public abstract class ComparableSubject<S extends ComparableSubject<S, T>, T ext
    */
   public final void isGreaterThan(T other) {
     if (actual().compareTo(other) <= 0) {
-      failWithFact("expected to be greater than", other);
+      failWithActual("expected to be greater than", other);
     }
   }
 
@@ -94,7 +94,7 @@ public abstract class ComparableSubject<S extends ComparableSubject<S, T>, T ext
    */
   public final void isLessThan(T other) {
     if (actual().compareTo(other) >= 0) {
-      failWithFact("expected to be less than", other);
+      failWithActual("expected to be less than", other);
     }
   }
 
@@ -105,7 +105,7 @@ public abstract class ComparableSubject<S extends ComparableSubject<S, T>, T ext
    */
   public final void isAtMost(T other) {
     if (actual().compareTo(other) > 0) {
-      failWithFact("expected to be at most", other);
+      failWithActual("expected to be at most", other);
     }
   }
 
@@ -116,7 +116,7 @@ public abstract class ComparableSubject<S extends ComparableSubject<S, T>, T ext
    */
   public final void isAtLeast(T other) {
     if (actual().compareTo(other) < 0) {
-      failWithFact("expected to be at least", other);
+      failWithActual("expected to be at least", other);
     }
   }
 }

--- a/core/src/main/java/com/google/common/truth/DoubleSubject.java
+++ b/core/src/main/java/com/google/common/truth/DoubleSubject.java
@@ -19,7 +19,7 @@ package com.google.common.truth;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.Fact.fact;
-import static com.google.common.truth.Fact.factWithoutValue;
+import static com.google.common.truth.Fact.simpleFact;
 import static com.google.common.truth.MathUtil.equalWithinTolerance;
 import static com.google.common.truth.MathUtil.notEqualWithinTolerance;
 import static com.google.common.truth.Platform.doubleToString;
@@ -217,7 +217,7 @@ public final class DoubleSubject extends ComparableSubject<DoubleSubject, Double
   /** Asserts that the subject is zero (i.e. it is either {@code 0.0} or {@code -0.0}). */
   public final void isZero() {
     if (actual() == null || actual().doubleValue() != 0.0) {
-      fail(factWithoutValue("expected zero"));
+      failWithActual(simpleFact("expected zero"));
     }
   }
 
@@ -227,9 +227,9 @@ public final class DoubleSubject extends ComparableSubject<DoubleSubject, Double
    */
   public final void isNonZero() {
     if (actual() == null) {
-      fail(factWithoutValue("expected a double other than zero"));
+      failWithActual(simpleFact("expected a double other than zero"));
     } else if (actual().doubleValue() == 0.0) {
-      fail(factWithoutValue("expected not to be zero"));
+      failWithActual(simpleFact("expected not to be zero"));
     }
   }
 
@@ -254,7 +254,7 @@ public final class DoubleSubject extends ComparableSubject<DoubleSubject, Double
    */
   public final void isFinite() {
     if (actual() == null || actual().isNaN() || actual().isInfinite()) {
-      fail(factWithoutValue("expected to be finite"));
+      failWithActual(simpleFact("expected to be finite"));
     }
   }
 
@@ -264,7 +264,7 @@ public final class DoubleSubject extends ComparableSubject<DoubleSubject, Double
    */
   public final void isNotNaN() {
     if (actual() == null) {
-      fail(factWithoutValue("expected a double other than NaN"));
+      failWithActual(simpleFact("expected a double other than NaN"));
     } else {
       isNotEqualTo(NaN);
     }

--- a/core/src/main/java/com/google/common/truth/Fact.java
+++ b/core/src/main/java/com/google/common/truth/Fact.java
@@ -24,21 +24,38 @@ import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
-/** A string key-value pair in a failure message, such as "expected: abc" or "but was: xyz." */
-final class Fact implements Serializable {
+/**
+ * A string key-value pair in a failure message, such as "expected: abc" or "but was: xyz."
+ *
+ * <p>Most Truth users will never interact with this type. It appears in the Truth API only as a
+ * parameter to methods like {@link Subject#failWithActual(Fact, Fact...)}, which are used only by
+ * custom {@code Subject} implementations.
+ */
+public final class Fact implements Serializable {
   /**
    * Creates a fact with the given key and value, which will be printed in a format like "key:
    * value." The value is converted to a string by calling {@code String.valueOf} on it.
    */
-  static Fact fact(String key, Object value) {
+  public static Fact fact(String key, @NullableDecl Object value) {
     return new Fact(key, String.valueOf(value));
   }
 
   /**
    * Creates a fact with no value, which will be printed in the format "key" (with no colon or
    * value).
+   *
+   * <p>In most cases, prefer {@linkplain #fact key-value facts}, which give Truth more flexibility
+   * in how to format the fact for display. {@code simpleFact} is useful primarily for:
+   *
+   * <ul>
+   *   <li>messages from no-arg assertions. For example, {@code isNotEmpty()} would generate the
+   *       fact "expected not to be empty"
+   *   <li>prose that is part of a larger message. For example, {@code contains()} sometimes
+   *       displays facts like "expected to contain: ..." <i>"but did not"</i> "though it did
+   *       contain: ..."
+   * </ul>
    */
-  static Fact factWithoutValue(String key) {
+  public static Fact simpleFact(String key) {
     return new Fact(key, null);
   }
 

--- a/core/src/main/java/com/google/common/truth/FloatSubject.java
+++ b/core/src/main/java/com/google/common/truth/FloatSubject.java
@@ -19,7 +19,7 @@ package com.google.common.truth;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.Fact.fact;
-import static com.google.common.truth.Fact.factWithoutValue;
+import static com.google.common.truth.Fact.simpleFact;
 import static com.google.common.truth.MathUtil.equalWithinTolerance;
 import static com.google.common.truth.MathUtil.notEqualWithinTolerance;
 import static com.google.common.truth.Platform.floatToString;
@@ -215,7 +215,7 @@ public final class FloatSubject extends ComparableSubject<FloatSubject, Float> {
   /** Asserts that the subject is zero (i.e. it is either {@code 0.0f} or {@code -0.0f}). */
   public final void isZero() {
     if (actual() == null || actual().floatValue() != 0.0f) {
-      fail(factWithoutValue("expected zero"));
+      failWithActual(simpleFact("expected zero"));
     }
   }
 
@@ -225,9 +225,9 @@ public final class FloatSubject extends ComparableSubject<FloatSubject, Float> {
    */
   public final void isNonZero() {
     if (actual() == null) {
-      fail(factWithoutValue("expected a float other than zero"));
+      failWithActual(simpleFact("expected a float other than zero"));
     } else if (actual().floatValue() == 0.0f) {
-      fail(factWithoutValue("expected not to be zero"));
+      failWithActual(simpleFact("expected not to be zero"));
     }
   }
 
@@ -252,7 +252,7 @@ public final class FloatSubject extends ComparableSubject<FloatSubject, Float> {
    */
   public final void isFinite() {
     if (actual() == null || actual().isNaN() || actual().isInfinite()) {
-      fail(factWithoutValue("expected to be finite"));
+      failWithActual(simpleFact("expected to be finite"));
     }
   }
 
@@ -262,7 +262,7 @@ public final class FloatSubject extends ComparableSubject<FloatSubject, Float> {
    */
   public final void isNotNaN() {
     if (actual() == null) {
-      fail(factWithoutValue("expected a float other than NaN"));
+      failWithActual(simpleFact("expected a float other than NaN"));
     } else {
       isNotEqualTo(NaN);
     }

--- a/core/src/main/java/com/google/common/truth/GuavaOptionalSubject.java
+++ b/core/src/main/java/com/google/common/truth/GuavaOptionalSubject.java
@@ -16,7 +16,7 @@
 package com.google.common.truth;
 
 import static com.google.common.truth.Fact.fact;
-import static com.google.common.truth.Fact.factWithoutValue;
+import static com.google.common.truth.Fact.simpleFact;
 
 import com.google.common.base.Optional;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
@@ -40,20 +40,19 @@ public final class GuavaOptionalSubject extends Subject<GuavaOptionalSubject, Op
   /** Fails if the {@link Optional}{@code <T>} is absent or the subject is null. */
   public void isPresent() {
     if (actual() == null) {
-      fail(factWithoutValue("expected present optional"));
+      failWithActual(simpleFact("expected present optional"));
     } else if (!actual().isPresent()) {
-      failWithoutActual(factWithoutValue("expected to be present"));
+      failWithoutActual(simpleFact("expected to be present"));
     }
   }
 
   /** Fails if the {@link Optional}{@code <T>} is present or the subject is null. */
   public void isAbsent() {
     if (actual() == null) {
-      fail(factWithoutValue("expected absent optional"));
+      failWithActual(simpleFact("expected absent optional"));
     } else if (actual().isPresent()) {
       failWithoutActual(
-          factWithoutValue("expected to be absent"),
-          fact("but was present with value", actual().get()));
+          simpleFact("expected to be absent"), fact("but was present with value", actual().get()));
     }
   }
 
@@ -72,10 +71,9 @@ public final class GuavaOptionalSubject extends Subject<GuavaOptionalSubject, Op
       throw new NullPointerException("Optional cannot have a null value.");
     }
     if (actual() == null) {
-      failWithFact("expected an optional with value", expected);
+      failWithActual("expected an optional with value", expected);
     } else if (!actual().isPresent()) {
-      failWithoutActual(
-          fact("expected to have value", expected), factWithoutValue("but was absent"));
+      failWithoutActual(fact("expected to have value", expected), simpleFact("but was absent"));
     } else {
       checkNoNeedToDisplayBothValues("get()").that(actual().get()).isEqualTo(expected);
     }

--- a/core/src/main/java/com/google/common/truth/IterableSubject.java
+++ b/core/src/main/java/com/google/common/truth/IterableSubject.java
@@ -21,7 +21,7 @@ import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.size;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.truth.Fact.fact;
-import static com.google.common.truth.Fact.factWithoutValue;
+import static com.google.common.truth.Fact.simpleFact;
 import static com.google.common.truth.IterableSubject.ElementFactGrouping.ALL_IN_ONE_FACT;
 import static com.google.common.truth.IterableSubject.ElementFactGrouping.FACT_PER_ELEMENT;
 import static com.google.common.truth.StringUtil.format;
@@ -117,14 +117,14 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
   /** Fails if the subject is not empty. */
   public final void isEmpty() {
     if (!Iterables.isEmpty(actual())) {
-      fail(factWithoutValue("expected to be empty"));
+      failWithActual(simpleFact("expected to be empty"));
     }
   }
 
   /** Fails if the subject is empty. */
   public final void isNotEmpty() {
     if (Iterables.isEmpty(actual())) {
-      failWithoutActual(factWithoutValue("expected not to be empty"));
+      failWithoutActual(simpleFact("expected not to be empty"));
     }
   }
 
@@ -143,14 +143,14 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
         failWithoutActual(
             fact("expected to contain", element),
             fact("an instance of", objectToTypeName(element)),
-            factWithoutValue("but did not"),
+            simpleFact("but did not"),
             fact(
                 "though it did contain",
                 countDuplicatesAndAddTypeInfo(
                     retainMatchingToString(actual(), elementList /* itemsToCheck */))),
             fullContents());
       } else {
-        failWithFact("expected to contain", element);
+        failWithActual("expected to contain", element);
       }
     }
   }
@@ -158,7 +158,7 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
   /** Checks (with a side-effect failure) that the subject does not contain the supplied item. */
   public final void doesNotContain(@NullableDecl Object element) {
     if (Iterables.contains(actual(), element)) {
-      failWithFact("expected not to contain", element);
+      failWithActual("expected not to contain", element);
     }
   }
 
@@ -172,7 +172,7 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
     }
     if (!duplicates.isEmpty()) {
       failWithoutActual(
-          factWithoutValue("expected not to contain duplicates"),
+          simpleFact("expected not to contain duplicates"),
           fact("but contained", duplicates),
           fullContents());
     }
@@ -199,14 +199,14 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
     if (hasMatchingToStringPair(actual, expected)) {
       failWithoutActual(
           fact("expected to contain any of", countDuplicatesAndAddTypeInfo(expected)),
-          factWithoutValue("but did not"),
+          simpleFact("but did not"),
           fact(
               "though it did contain",
               countDuplicatesAndAddTypeInfo(
                   retainMatchingToString(actual(), expected /* itemsToCheck */))),
           fullContents());
     } else {
-      failWithFact("expected to contain any of", expected);
+      failWithActual("expected to contain any of", expected);
     }
   }
 
@@ -287,8 +287,8 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
         : new Ordered() {
           @Override
           public void inOrder() {
-            fail(
-                factWithoutValue("required elements were all found, but order was wrong"),
+            failWithActual(
+                simpleFact("required elements were all found, but order was wrong"),
                 fact("expected order for required elements", expected));
           }
         };
@@ -465,9 +465,8 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
           return new Ordered() {
             @Override
             public void inOrder() {
-              fail(
-                  factWithoutValue("contents match, but order was wrong"),
-                  fact("expected", required));
+              failWithActual(
+                  simpleFact("contents match, but order was wrong"), fact("expected", required));
             }
           };
         }
@@ -511,7 +510,7 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
     facts.add(butWas());
     if (addElementsInWarning) {
       facts.add(
-          factWithoutValue(
+          simpleFact(
               "Passing an iterable to the varargs method containsExactly(Object...) is "
                   + "often not the correct thing to do. Did you mean to call "
                   + "containsExactlyElementsIn(Iterable) instead?"));
@@ -540,10 +539,10 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
     ImmutableList<Fact> secondFacts = makeElementFacts(secondKey, second, grouping);
     facts.addAll(firstFacts);
     if (firstFacts.size() > 1 && secondFacts.size() > 1) {
-      facts.add(factWithoutValue(""));
+      facts.add(simpleFact(""));
     }
     facts.addAll(secondFacts);
-    facts.add(factWithoutValue("---"));
+    facts.add(simpleFact("---"));
     return facts.build();
   }
 
@@ -562,7 +561,7 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
     }
 
     ImmutableList.Builder<Fact> facts = ImmutableList.builder();
-    facts.add(factWithoutValue(keyToServeAsHeader(label, elements)));
+    facts.add(simpleFact(keyToServeAsHeader(label, elements)));
     int n = 1;
     for (Multiset.Entry<?> entry : elements.entrySet()) {
       int count = entry.getCount();
@@ -802,7 +801,7 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
         Object next = iterator.next();
         if (!checker.check(prev, next)) {
           failWithoutActual(
-              factWithoutValue(expectedFact),
+              simpleFact(expectedFact),
               fact("but contained", prev),
               fact("followed by", next),
               fullContents());
@@ -826,7 +825,7 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
   @Deprecated
   public void isNotIn(Iterable<?> iterable) {
     if (Iterables.contains(iterable, actual())) {
-      failWithFact("expected not to be any of", iterable);
+      failWithActual("expected not to be any of", iterable);
     }
     List<Object> nonIterables = new ArrayList<>();
     for (Object element : iterable) {
@@ -1091,9 +1090,9 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       return new Ordered() {
         @Override
         public void inOrder() {
-          subject.fail(
-              factWithoutValue("contents match, but order was wrong"),
-              factWithoutValue(
+          subject.failWithActual(
+              simpleFact("contents match, but order was wrong"),
+              simpleFact(
                   "comparing contents by testing that each element "
                       + correspondence
                       + " an expected value"),
@@ -1393,9 +1392,9 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       return new Ordered() {
         @Override
         public void inOrder() {
-          subject.fail(
-              factWithoutValue("required elements were all found, but order was wrong"),
-              factWithoutValue(
+          subject.failWithActual(
+              simpleFact("required elements were all found, but order was wrong"),
+              simpleFact(
                   "comparing contents by testing that each element "
                       + correspondence
                       + " an expected value"),

--- a/core/src/main/java/com/google/common/truth/MapSubject.java
+++ b/core/src/main/java/com/google/common/truth/MapSubject.java
@@ -18,7 +18,7 @@ package com.google.common.truth;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Maps.immutableEntry;
-import static com.google.common.truth.Fact.factWithoutValue;
+import static com.google.common.truth.Fact.simpleFact;
 import static com.google.common.truth.SubjectUtils.countDuplicatesAndAddTypeInfo;
 import static com.google.common.truth.SubjectUtils.hasMatchingToStringPair;
 import static com.google.common.truth.SubjectUtils.objectToTypeName;
@@ -79,14 +79,14 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
   /** Fails if the map is not empty. */
   public void isEmpty() {
     if (!actual().isEmpty()) {
-      fail(factWithoutValue("expected to be empty"));
+      failWithActual(simpleFact("expected to be empty"));
     }
   }
 
   /** Fails if the map is empty. */
   public void isNotEmpty() {
     if (actual().isEmpty()) {
-      failWithoutActual(factWithoutValue("expected not to be empty"));
+      failWithoutActual(simpleFact("expected not to be empty"));
     }
   }
 

--- a/core/src/main/java/com/google/common/truth/MultimapSubject.java
+++ b/core/src/main/java/com/google/common/truth/MultimapSubject.java
@@ -18,7 +18,7 @@ package com.google.common.truth;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Maps.immutableEntry;
-import static com.google.common.truth.Fact.factWithoutValue;
+import static com.google.common.truth.Fact.simpleFact;
 import static com.google.common.truth.SubjectUtils.HUMAN_UNDERSTANDABLE_EMPTY_STRING;
 import static com.google.common.truth.SubjectUtils.countDuplicatesAndAddTypeInfo;
 import static com.google.common.truth.SubjectUtils.hasMatchingToStringPair;
@@ -72,14 +72,14 @@ public class MultimapSubject extends Subject<MultimapSubject, Multimap<?, ?>> {
   /** Fails if the multimap is not empty. */
   public void isEmpty() {
     if (!actual().isEmpty()) {
-      fail(factWithoutValue("expected to be empty"));
+      failWithActual(simpleFact("expected to be empty"));
     }
   }
 
   /** Fails if the multimap is empty. */
   public void isNotEmpty() {
     if (actual().isEmpty()) {
-      failWithoutActual(factWithoutValue("expected not to be empty"));
+      failWithoutActual(simpleFact("expected not to be empty"));
     }
   }
 

--- a/core/src/main/java/com/google/common/truth/StringSubject.java
+++ b/core/src/main/java/com/google/common/truth/StringSubject.java
@@ -17,7 +17,7 @@ package com.google.common.truth;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.truth.Fact.factWithoutValue;
+import static com.google.common.truth.Fact.simpleFact;
 
 import com.google.common.annotations.GwtIncompatible;
 import java.util.regex.Pattern;
@@ -56,18 +56,18 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
   /** Fails if the string is not equal to the zero-length "empty string." */
   public void isEmpty() {
     if (actual() == null) {
-      fail(factWithoutValue("expected empty string"));
+      failWithActual(simpleFact("expected empty string"));
     } else if (!actual().isEmpty()) {
-      fail(factWithoutValue("expected to be empty"));
+      failWithActual(simpleFact("expected to be empty"));
     }
   }
 
   /** Fails if the string is equal to the zero-length "empty string." */
   public void isNotEmpty() {
     if (actual() == null) {
-      fail(factWithoutValue("expected nonempty string"));
+      failWithActual(simpleFact("expected nonempty string"));
     } else if (actual().isEmpty()) {
-      failWithoutActual(factWithoutValue("expected not to be empty"));
+      failWithoutActual(simpleFact("expected not to be empty"));
     }
   }
 
@@ -75,9 +75,9 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
   public void contains(CharSequence string) {
     checkNotNull(string);
     if (actual() == null) {
-      failWithFact("expected a string that contains", string);
+      failWithActual("expected a string that contains", string);
     } else if (!actual().contains(string)) {
-      failWithFact("expected to contain", string);
+      failWithActual("expected to contain", string);
     }
   }
 
@@ -85,9 +85,9 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
   public void doesNotContain(CharSequence string) {
     checkNotNull(string);
     if (actual() == null) {
-      failWithFact("expected a string that does not contain", string);
+      failWithActual("expected a string that does not contain", string);
     } else if (actual().contains(string)) {
-      failWithFact("expected not to contain", string);
+      failWithActual("expected not to contain", string);
     }
   }
 
@@ -95,9 +95,9 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
   public void startsWith(String string) {
     checkNotNull(string);
     if (actual() == null) {
-      failWithFact("expected a string that starts with", string);
+      failWithActual("expected a string that starts with", string);
     } else if (!actual().startsWith(string)) {
-      failWithFact("expected to start with", string);
+      failWithActual("expected to start with", string);
     }
   }
 
@@ -105,9 +105,9 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
   public void endsWith(String string) {
     checkNotNull(string);
     if (actual() == null) {
-      failWithFact("expected a string that ends with", string);
+      failWithActual("expected a string that ends with", string);
     } else if (!actual().endsWith(string)) {
-      failWithFact("expected to end with", string);
+      failWithActual("expected to end with", string);
     }
   }
 
@@ -116,7 +116,7 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
   /** Fails if the string does not match the given regex. */
   public void matches(String regex) {
     if (!actual().matches(regex)) {
-      failWithFact("expected to match", regex);
+      failWithActual("expected to match", regex);
     }
   }
 
@@ -124,14 +124,14 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
   @GwtIncompatible("java.util.regex.Pattern")
   public void matches(Pattern regex) {
     if (!regex.matcher(actual()).matches()) {
-      failWithFact("expected to match", regex);
+      failWithActual("expected to match", regex);
     }
   }
 
   /** Fails if the string matches the given regex. */
   public void doesNotMatch(String regex) {
     if (actual().matches(regex)) {
-      failWithFact("expected not to match", regex);
+      failWithActual("expected not to match", regex);
     }
   }
 
@@ -139,7 +139,7 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
   @GwtIncompatible("java.util.regex.Pattern")
   public void doesNotMatch(Pattern regex) {
     if (regex.matcher(actual()).matches()) {
-      failWithFact("expected not to match", regex);
+      failWithActual("expected not to match", regex);
     }
   }
 
@@ -147,14 +147,14 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
   @GwtIncompatible("java.util.regex.Pattern")
   public void containsMatch(Pattern regex) {
     if (!regex.matcher(actual()).find()) {
-      failWithFact("expected to contain a match for", regex);
+      failWithActual("expected to contain a match for", regex);
     }
   }
 
   /** Fails if the string does not contain a match on the given regex. */
   public void containsMatch(String regex) {
     if (!Platform.containsMatch(actual(), regex)) {
-      failWithFact("expected to contain a match for", regex);
+      failWithActual("expected to contain a match for", regex);
     }
   }
 
@@ -162,14 +162,14 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
   @GwtIncompatible("java.util.regex.Pattern")
   public void doesNotContainMatch(Pattern regex) {
     if (regex.matcher(actual()).find()) {
-      failWithFact("expected not to contain a match for", regex);
+      failWithActual("expected not to contain a match for", regex);
     }
   }
 
   /** Fails if the string contains a match on the given regex. */
   public void doesNotContainMatch(String regex) {
     if (Platform.containsMatch(actual(), regex)) {
-      failWithFact("expected not to contain a match for", regex);
+      failWithActual("expected not to contain a match for", regex);
     }
   }
 }

--- a/core/src/main/java/com/google/common/truth/SubjectUtils.java
+++ b/core/src/main/java/com/google/common/truth/SubjectUtils.java
@@ -74,6 +74,11 @@ final class SubjectUtils {
   }
 
   static String countDuplicates(Iterable<?> items) {
+    /*
+     * TODO(cpovirk): Remove brackets after migrating all callers to the new message format. But
+     * will that look OK when we put the result next to a homogeneous type name? If not, maybe move
+     * the homogeneous type name to a separate Fact?
+     */
     return countDuplicatesToMultiset(items).toStringWithBrackets();
   }
 
@@ -107,7 +112,7 @@ final class SubjectUtils {
 
     return homogeneousTypeName.isPresent()
         ? StringUtil.format("%s (%s)", countDuplicates(items), homogeneousTypeName.get())
-        : countDuplicates(addTypeInfoToEveryItem(items)).toString();
+        : countDuplicates(addTypeInfoToEveryItem(items));
   }
 
   /**
@@ -309,6 +314,11 @@ final class SubjectUtils {
     Optional<String> homogeneousTypeName = Optional.absent();
     for (Object item : items) {
       if (item == null) {
+        /*
+         * TODO(cpovirk): Why? We could have multiple nulls, which would be homogeneous. More
+         * likely, we could have exactly one null, which is still homogeneous. Arguably it's weird
+         * to call a single element "homogeneous" at all, but that's not specific to null.
+         */
         return Optional.absent();
       } else if (!homogeneousTypeName.isPresent()) {
         // This is the first item

--- a/core/src/main/java/com/google/common/truth/TableSubject.java
+++ b/core/src/main/java/com/google/common/truth/TableSubject.java
@@ -17,7 +17,7 @@ package com.google.common.truth;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.truth.Fact.factWithoutValue;
+import static com.google.common.truth.Fact.simpleFact;
 
 import com.google.common.collect.Table;
 import com.google.common.collect.Table.Cell;
@@ -37,14 +37,14 @@ public final class TableSubject extends Subject<TableSubject, Table<?, ?, ?>> {
   /** Fails if the table is not empty. */
   public void isEmpty() {
     if (!actual().isEmpty()) {
-      fail(factWithoutValue("expected to be empty"));
+      failWithActual(simpleFact("expected to be empty"));
     }
   }
 
   /** Fails if the table is empty. */
   public void isNotEmpty() {
     if (actual().isEmpty()) {
-      failWithoutActual(factWithoutValue("expected not to be empty"));
+      failWithoutActual(simpleFact("expected not to be empty"));
     }
   }
 

--- a/core/src/main/java/com/google/common/truth/TruthFailureSubject.java
+++ b/core/src/main/java/com/google/common/truth/TruthFailureSubject.java
@@ -20,7 +20,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.Fact.fact;
-import static com.google.common.truth.Fact.factWithoutValue;
+import static com.google.common.truth.Fact.simpleFact;
 
 import com.google.common.collect.ImmutableList;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
@@ -39,7 +39,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  */
 public final class TruthFailureSubject extends ThrowableSubject {
   static final Fact HOW_TO_TEST_KEYS_WITHOUT_VALUES =
-      factWithoutValue(
+      simpleFact(
           "To test that a key is present without a value, "
               + "use factKeys().contains(...) or a similar method.");
 
@@ -76,7 +76,7 @@ public final class TruthFailureSubject extends ThrowableSubject {
   /** Returns a subject for the list of fact keys. */
   public IterableSubject factKeys() {
     if (!(actual() instanceof ErrorWithFacts)) {
-      fail(factWithoutValue("expected a failure thrown by Truth's new failure API"));
+      failWithActual(simpleFact("expected a failure thrown by Truth's new failure API"));
       return ignoreCheck().that(ImmutableList.of());
     }
     ErrorWithFacts error = (ErrorWithFacts) actual();
@@ -100,8 +100,8 @@ public final class TruthFailureSubject extends ThrowableSubject {
    * <p>The value is never null:
    *
    * <ul>
-   *   <li>In the case of {@linkplain Fact#factWithoutValue facts that have no value}, {@code
-   *       factValue} throws an exception. To test for such facts, use {@link #factKeys()}{@code
+   *   <li>In the case of {@linkplain Fact#simpleFact facts that have no value}, {@code factValue}
+   *       throws an exception. To test for such facts, use {@link #factKeys()}{@code
    *       .contains(...)} or a similar method.
    *   <li>In the case of facts that have a value that is rendered as "null" (such as those created
    *       with {@code fact("key", null)}), {@code factValue} considers them have a string value,
@@ -129,7 +129,7 @@ public final class TruthFailureSubject extends ThrowableSubject {
   private StringSubject doFactValue(String key, @NullableDecl Integer index) {
     checkNotNull(key);
     if (!(actual() instanceof ErrorWithFacts)) {
-      fail(factWithoutValue("expected a failure thrown by Truth's new failure API"));
+      failWithActual(simpleFact("expected a failure thrown by Truth's new failure API"));
       return ignoreCheck().that("");
     }
     ErrorWithFacts error = (ErrorWithFacts) actual();
@@ -161,16 +161,16 @@ public final class TruthFailureSubject extends ThrowableSubject {
     if (value == null) {
       if (index == null) {
         failWithoutActual(
-            factWithoutValue("expected to have a value"),
+            simpleFact("expected to have a value"),
             fact("for key", key),
-            factWithoutValue("but the key was present with no value"),
+            simpleFact("but the key was present with no value"),
             HOW_TO_TEST_KEYS_WITHOUT_VALUES);
       } else {
         failWithoutActual(
-            factWithoutValue("expected to have a value"),
+            simpleFact("expected to have a value"),
             fact("for key", key),
             fact("and index", index),
-            factWithoutValue("but the key was present with no value"),
+            simpleFact("but the key was present with no value"),
             HOW_TO_TEST_KEYS_WITHOUT_VALUES);
       }
       return ignoreCheck().that("");

--- a/core/src/test/java/com/google/common/truth/ComparisonFailureWithFactsTest.java
+++ b/core/src/test/java/com/google/common/truth/ComparisonFailureWithFactsTest.java
@@ -20,7 +20,7 @@ import static com.google.common.base.Strings.repeat;
 import static com.google.common.testing.SerializableTester.reserialize;
 import static com.google.common.truth.ComparisonFailureWithFacts.formatExpectedAndActual;
 import static com.google.common.truth.Fact.fact;
-import static com.google.common.truth.Fact.factWithoutValue;
+import static com.google.common.truth.Fact.simpleFact;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.annotations.GwtIncompatible;
@@ -270,7 +270,7 @@ public class ComparisonFailureWithFactsTest {
   public void testSerialization_ComparisonFailureWithFacts() {
     ImmutableList<String> messages = ImmutableList.of("hello");
     ImmutableList<Fact> headFacts = ImmutableList.of(fact("head", "value"));
-    ImmutableList<Fact> tailFacts = ImmutableList.of(factWithoutValue("tail"));
+    ImmutableList<Fact> tailFacts = ImmutableList.of(simpleFact("tail"));
     String expected = "expected";
     String actual = "actual";
     Throwable cause = new Throwable("cause");
@@ -291,7 +291,7 @@ public class ComparisonFailureWithFactsTest {
   @Test
   public void testSerialization_AssertionErrorWithFacts() {
     ImmutableList<String> messages = ImmutableList.of("hello");
-    ImmutableList<Fact> facts = ImmutableList.of(fact("head", "value"), factWithoutValue("tail"));
+    ImmutableList<Fact> facts = ImmutableList.of(fact("head", "value"), simpleFact("tail"));
     Throwable cause = new Throwable("cause");
     AssertionErrorWithFacts original = AssertionErrorWithFacts.create(messages, facts, cause);
 
@@ -311,7 +311,7 @@ public class ComparisonFailureWithFactsTest {
     assertThat(reserialized.key).isEqualTo(original.key);
     assertThat(reserialized.value).isEqualTo(original.value);
 
-    original = factWithoutValue("tail");
+    original = simpleFact("tail");
     reserialized = reserialize(original);
     assertThat(reserialized.key).isEqualTo(original.key);
     assertThat(reserialized.value).isEqualTo(original.value);

--- a/core/src/test/java/com/google/common/truth/FactTest.java
+++ b/core/src/test/java/com/google/common/truth/FactTest.java
@@ -17,8 +17,8 @@
 package com.google.common.truth;
 
 import static com.google.common.truth.Fact.fact;
-import static com.google.common.truth.Fact.factWithoutValue;
 import static com.google.common.truth.Fact.makeMessage;
+import static com.google.common.truth.Fact.simpleFact;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
@@ -36,7 +36,7 @@ public class FactTest {
 
   @Test
   public void stringWithoutValue() {
-    assertThat(factWithoutValue("foo").toString()).isEqualTo("foo");
+    assertThat(simpleFact("foo").toString()).isEqualTo("foo");
   }
 
   @Test
@@ -56,7 +56,7 @@ public class FactTest {
 
   @Test
   public void oneFactWithoutValue() {
-    assertThat(makeMessage(ImmutableList.<String>of(), ImmutableList.of(factWithoutValue("foo"))))
+    assertThat(makeMessage(ImmutableList.<String>of(), ImmutableList.of(simpleFact("foo"))))
         .isEqualTo("foo");
   }
 
@@ -65,7 +65,7 @@ public class FactTest {
     assertThat(
             makeMessage(
                 ImmutableList.<String>of(),
-                ImmutableList.of(fact("hello", "there"), factWithoutValue("foo"))))
+                ImmutableList.of(fact("hello", "there"), simpleFact("foo"))))
         .isEqualTo("hello: there\nfoo");
   }
 
@@ -80,7 +80,7 @@ public class FactTest {
     assertThat(
             makeMessage(
                 ImmutableList.<String>of(),
-                ImmutableList.of(fact("hello", "there\neveryone"), factWithoutValue("xyz"))))
+                ImmutableList.of(fact("hello", "there\neveryone"), simpleFact("xyz"))))
         .isEqualTo("hello:\n    there\n    everyone\nxyz");
   }
 

--- a/core/src/test/java/com/google/common/truth/IterableSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/IterableSubjectTest.java
@@ -156,50 +156,48 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void iterableContainsAnyOfFailure() {
     expectFailureWhenTestingThat(asList(1, 2, 3)).containsAnyOf(5, 6, 0);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <[1, 2, 3]> contains any of <[5, 6, 0]>");
+    assertFailureKeys("expected to contain any of", "but was");
+    assertFailureValue("expected to contain any of", "[5, 6, 0]");
   }
 
   @Test
   public void iterableContainsAnyOfFailsWithSameToStringAndHomogeneousList() {
     expectFailureWhenTestingThat(asList(1L, 2L, 3L)).containsAnyOf(2, 3);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2, 3]> contains any of <[2, 3] (java.lang.Integer)>. "
-                + "However, it does contain <[2, 3] (java.lang.Long)>.");
+    assertFailureKeys(
+        "expected to contain any of", "but did not", "though it did contain", "full contents");
+    assertFailureValue("expected to contain any of", "[2, 3] (java.lang.Integer)");
+    assertFailureValue("though it did contain", "[2, 3] (java.lang.Long)");
+    assertFailureValue("full contents", "[1, 2, 3]");
   }
 
   @Test
   public void iterableContainsAnyOfFailsWithSameToStringAndHomogeneousListWithDuplicates() {
     expectFailureWhenTestingThat(asList(3L, 3L)).containsAnyOf(2, 3, 3);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[3, 3]> contains any of <[2, 3, 3] (java.lang.Integer)>. "
-                + "However, it does contain <[3 [2 copies]] (java.lang.Long)>.");
+    assertFailureKeys(
+        "expected to contain any of", "but did not", "though it did contain", "full contents");
+    assertFailureValue("expected to contain any of", "[2, 3 [2 copies]] (java.lang.Integer)");
+    assertFailureValue("though it did contain", "[3 [2 copies]] (java.lang.Long)");
+    assertFailureValue("full contents", "[3, 3]");
   }
 
   @Test
   public void iterableContainsAnyOfFailsWithSameToStringAndNullInSubject() {
     expectFailureWhenTestingThat(asList(null, "abc")).containsAnyOf("def", "null");
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[null, abc]> contains any of <[def, null] (java.lang.String)>. "
-                + "However, it does contain <[null (null type)]>.");
+    assertFailureKeys(
+        "expected to contain any of", "but did not", "though it did contain", "full contents");
+    assertFailureValue("expected to contain any of", "[def, null] (java.lang.String)");
+    assertFailureValue("though it did contain", "[null (null type)]");
+    assertFailureValue("full contents", "[null, abc]");
   }
 
   @Test
   public void iterableContainsAnyOfFailsWithSameToStringAndNullInExpectation() {
     expectFailureWhenTestingThat(asList("null", "abc")).containsAnyOf("def", null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[null, abc]> contains any of "
-                + "<[def (java.lang.String), null (null type)]>. "
-                + "However, it does contain <[null] (java.lang.String)>.");
+    assertFailureKeys(
+        "expected to contain any of", "but did not", "though it did contain", "full contents");
+    assertFailureValue("expected to contain any of", "[def (java.lang.String), null (null type)]");
+    assertFailureValue("though it did contain", "[null] (java.lang.String)");
+    assertFailureValue("full contents", "[null, abc]");
   }
 
   @Test
@@ -221,9 +219,8 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
     assertThat(asList(1, 2, 3)).containsAnyIn(asList(1, 10, 100));
 
     expectFailureWhenTestingThat(asList(1, 2, 3)).containsAnyIn(asList(5, 6, 0));
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <[1, 2, 3]> contains any of <[5, 6, 0]>");
+    assertFailureKeys("expected to contain any of", "but was");
+    assertFailureValue("expected to contain any of", "[5, 6, 0]");
   }
 
   @Test
@@ -231,9 +228,8 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
     assertThat(asList(1, 2, 3)).containsAnyIn(new Integer[] {1, 10, 100});
 
     expectFailureWhenTestingThat(asList(1, 2, 3)).containsAnyIn(new Integer[] {5, 6, 0});
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <[1, 2, 3]> contains any of <[5, 6, 0]>");
+    assertFailureKeys("expected to contain any of", "but was");
+    assertFailureValue("expected to contain any of", "[5, 6, 0]");
   }
 
   @Test
@@ -281,35 +277,27 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void iterableContainsAllOfFailure() {
     expectFailureWhenTestingThat(asList(1, 2, 3)).containsAllOf(1, 2, 4);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <[1, 2, 3]> contains at least <[1, 2, 4]>. It is missing <[4]>");
+    assertFailureKeys("missing (1)", "---", "expected to contain at least", "but was");
+    assertFailureValue("missing (1)", "4");
+    assertFailureValue("expected to contain at least", "[1, 2, 4]");
   }
 
   @Test
   public void iterableContainsAllOfWithExtras() {
     expectFailureWhenTestingThat(asList("y", "x")).containsAllOf("x", "y", "z");
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <[y, x]> contains at least <[x, y, z]>. It is missing <[z]>");
+    assertFailureValue("missing (1)", "z");
   }
 
   @Test
   public void iterableContainsAllOfWithExtraCopiesOfOutOfOrder() {
     expectFailureWhenTestingThat(asList("y", "x")).containsAllOf("x", "y", "y");
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <[y, x]> contains at least <[x, y, y]>. It is missing <[y]>");
+    assertFailureValue("missing (1)", "y");
   }
 
   @Test
   public void iterableContainsAllOfWithDuplicatesFailure() {
     expectFailureWhenTestingThat(asList(1, 2, 3)).containsAllOf(1, 2, 2, 2, 3, 4);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2, 3]> contains at least <[1, 2, 2, 2, 3, 4]>. "
-                + "It is missing <[2 [2 copies], 4]>");
+    assertFailureValue("missing (3)", "2 [2 copies], 4");
   }
 
   /*
@@ -319,74 +307,50 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
   @Test
   public void iterableContainsAllOfWithDuplicateMissingElements() {
     expectFailureWhenTestingThat(asList(1, 2)).containsAllOf(4, 4, 4);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2]> contains at least <[4, 4, 4]>. It is missing <[4 [3 copies]]>");
+    assertFailureValue("missing (3)", "4 [3 copies]");
   }
 
   @Test
   public void iterableContainsAllOfWithNullFailure() {
     expectFailureWhenTestingThat(asList(1, null, 3)).containsAllOf(1, null, null, 3);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, null, 3]> contains at least <[1, null, null, 3]>. "
-                + "It is missing <[null]>");
+    assertFailureValue("missing (1)", "null");
   }
 
   @Test
   public void iterableContainsAllOfFailsWithSameToStringAndHomogeneousList() {
     expectFailureWhenTestingThat(asList(1L, 2L)).containsAllOf(1, 2);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2]> contains at least <[1, 2]>. It is missing "
-                + "<[1, 2] (java.lang.Integer)>. However, it does contain "
-                + "<[1, 2] (java.lang.Long)>.");
+    assertFailureValue("missing (2)", "1, 2 (java.lang.Integer)");
+    assertFailureValue("though it did contain (2)", "1, 2 (java.lang.Long)");
   }
 
   @Test
   public void iterableContainsAllOfFailsWithSameToStringAndHomogeneousListWithDuplicates() {
     expectFailureWhenTestingThat(asList(1L, 2L, 2L)).containsAllOf(1, 1, 2);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2, 2]> contains at least <[1, 1, 2]>. It is missing "
-                + "<[1 [2 copies], 2] (java.lang.Integer)>. However, it does contain "
-                + "<[1, 2 [2 copies]] (java.lang.Long)>.");
+    assertFailureValue("missing (3)", "1 [2 copies], 2 (java.lang.Integer)");
+    assertFailureValue("though it did contain (3)", "1, 2 [2 copies] (java.lang.Long)");
   }
 
   @Test
   public void iterableContainsAllOfFailsWithSameToStringAndHomogeneousListWithNull() {
     expectFailureWhenTestingThat(asList("null", "abc")).containsAllOf("abc", null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[null, abc]> contains at least <[abc, null]>. It is missing "
-                + "<[null (null type)]>. However, it does contain <[null] (java.lang.String)>.");
+    assertFailureValue("missing (1)", "null (null type)");
+    assertFailureValue("though it did contain (1)", "null (java.lang.String)");
   }
 
   @Test
   public void iterableContainsAllOfFailsWithSameToStringAndHeterogeneousListWithDuplicates() {
     expectFailureWhenTestingThat(asList(1, 2, 2L, 3L, 3L)).containsAllOf(2L, 2L, 3, 3);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1, 2, 2, 3, 3]> contains at least <[2, 2, 3, 3]>. It is missing "
-                + "<[2 (java.lang.Long), 3 (java.lang.Integer) [2 copies]]>. However, it does "
-                + "contain <[2 (java.lang.Integer), 3 (java.lang.Long) [2 copies]]>.");
+    assertFailureValue("missing (3)", "2 (java.lang.Long), 3 (java.lang.Integer) [2 copies]");
+    assertFailureValue(
+        "though it did contain (3)", "2 (java.lang.Integer), 3 (java.lang.Long) [2 copies]");
   }
 
   @Test
   public void iterableContainsAllOfFailsWithEmptyString() {
     expectFailureWhenTestingThat(asList("a", null)).containsAllOf("", null);
 
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[a, null]> contains at least <[\"\" (empty String), null]>. "
-                + "It is missing <[\"\" (empty String)]>");
+    assertFailureKeys("missing (1)", "---", "expected to contain at least", "but was");
+    assertFailureValue("missing (1)", "");
   }
 
   @Test
@@ -475,9 +439,17 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
     assertThat(asList(1, 2, 3)).containsAllIn(asList(1, 2));
 
     expectFailureWhenTestingThat(asList(1, 2, 3)).containsAllIn(asList(1, 2, 4));
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <[1, 2, 3]> contains at least <[1, 2, 4]>. It is missing <[4]>");
+    assertFailureKeys("missing (1)", "---", "expected to contain at least", "but was");
+    assertFailureValue("missing (1)", "4");
+    assertFailureValue("expected to contain at least", "[1, 2, 4]");
+  }
+
+  @Test
+  public void iterableContainsAllInCanUseFactPerElement() {
+    expectFailureWhenTestingThat(asList("abc")).containsAllIn(asList("123\n456", "789"));
+    assertFailureKeys("missing (2)", "#1", "#2", "---", "expected to contain at least", "but was");
+    assertFailureValue("#1", "123\n456");
+    assertFailureValue("#2", "789");
   }
 
   @Test
@@ -485,9 +457,9 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
     assertThat(asList(1, 2, 3)).containsAllIn(new Integer[] {1, 2});
 
     expectFailureWhenTestingThat(asList(1, 2, 3)).containsAllIn(new Integer[] {1, 2, 4});
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <[1, 2, 3]> contains at least <[1, 2, 4]>. It is missing <[4]>");
+    assertFailureKeys("missing (1)", "---", "expected to contain at least", "but was");
+    assertFailureValue("missing (1)", "4");
+    assertFailureValue("expected to contain at least", "[1, 2, 4]");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/PrimitiveShortArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveShortArraySubjectTest.java
@@ -49,13 +49,13 @@ public class PrimitiveShortArraySubjectTest extends BaseSubjectTestCase {
   @Test
   public void asListWithoutCastingFails() {
     expectFailureWhenTestingThat(array(1, 1, 0)).asList().containsAllOf(1, 0);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "value of: array.asList()\nNot true that <[1, 1, 0]> "
-                + "contains at least <[1, 0]>. It is missing "
-                + "<[1, 0] (java.lang.Integer)>. However, it does contain "
-                + "<[1 [2 copies], 0] (java.lang.Short)>.");
+    assertFailureKeys(
+        "value of",
+        "missing (2)",
+        "though it did contain (3)",
+        "---",
+        "expected to contain at least",
+        "but was");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/SubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/SubjectTest.java
@@ -17,6 +17,7 @@ package com.google.common.truth;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.ExpectFailure.assertThat;
+import static com.google.common.truth.Fact.simpleFact;
 import static com.google.common.truth.TestPlatform.isGwt;
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.common.truth.Truth.assertThat;
@@ -61,6 +62,7 @@ public class SubjectTest extends BaseSubjectTestCase {
   @GwtIncompatible("NullPointerTester")
   public void nullPointerTester() {
     NullPointerTester npTester = new NullPointerTester();
+    npTester.setDefault(Fact.class, simpleFact("fact"));
 
     // TODO(kak): Automatically generate this list with reflection,
     // or maybe use AbstractPackageSanityTests?
@@ -92,6 +94,7 @@ public class SubjectTest extends BaseSubjectTestCase {
   @GwtIncompatible("NullPointerTester")
   public void allAssertThatOverloadsAcceptNull() throws Exception {
     NullPointerTester npTester = new NullPointerTester();
+    npTester.setDefault(Fact.class, simpleFact("fact"));
     for (Method method : Truth.class.getDeclaredMethods()) {
       if (Modifier.isPublic(method.getModifiers())
           && method.getName().equals("assertThat")

--- a/core/src/test/java/com/google/common/truth/TruthFailureSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/TruthFailureSubjectTest.java
@@ -17,7 +17,7 @@
 package com.google.common.truth;
 
 import static com.google.common.truth.Fact.fact;
-import static com.google.common.truth.Fact.factWithoutValue;
+import static com.google.common.truth.Fact.simpleFact;
 import static com.google.common.truth.TruthFailureSubject.HOW_TO_TEST_KEYS_WITHOUT_VALUES;
 import static com.google.common.truth.TruthFailureSubject.truthFailures;
 import static org.junit.Assert.fail;
@@ -39,7 +39,7 @@ public class TruthFailureSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void factKeysNoValue() {
-    assertThat(factWithoutValue("foo")).factKeys().containsExactly("foo");
+    assertThat(simpleFact("foo")).factKeys().containsExactly("foo");
   }
 
   @Test
@@ -84,7 +84,7 @@ public class TruthFailureSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void factValueFailNoValue() {
-    Object unused = expectFailureWhenTestingThat(factWithoutValue("foo")).factValue("foo");
+    Object unused = expectFailureWhenTestingThat(simpleFact("foo")).factValue("foo");
     assertFailureKeys(
         "expected to have a value",
         "for key",
@@ -141,7 +141,7 @@ public class TruthFailureSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void factValueIntFailNoValue() {
-    Object unused = expectFailureWhenTestingThat(factWithoutValue("foo")).factValue("foo", 0);
+    Object unused = expectFailureWhenTestingThat(simpleFact("foo")).factValue("foo", 0);
     assertFailureKeys(
         "expected to have a value",
         "for key",

--- a/core/src/test/java/com/google/common/truth/extension/EmployeeSubject.java
+++ b/core/src/test/java/com/google/common/truth/extension/EmployeeSubject.java
@@ -15,6 +15,7 @@
  */
 package com.google.common.truth.extension;
 
+import static com.google.common.truth.Fact.simpleFact;
 import static com.google.common.truth.Truth.assertAbout;
 
 import com.google.common.truth.FailureMetadata;
@@ -55,38 +56,30 @@ public final class EmployeeSubject extends Subject<EmployeeSubject, Employee> {
   // User-defined test assertion SPI below this point
 
   public void hasName(String name) {
-    if (!actual().name().equals(name)) {
-      fail("has name", name);
-    }
+    check("name()").that(actual().name()).isEqualTo(name);
   }
 
   public void hasUsername(String username) {
-    if (!actual().username().equals(username)) {
-      fail("has username", username);
-    }
+    check("username()").that(actual().username()).isEqualTo(username);
   }
 
   public void hasId(long id) {
-    if (actual().id() != id) {
-      fail("has id", id);
-    }
+    check("id()").that(actual().id()).isEqualTo(id);
   }
 
   public void hasLocation(Employee.Location location) {
-    if (actual().location() != location) {
-      fail("has location", location);
-    }
+    check("location()").that(actual().location()).isEqualTo(location);
   }
 
   public void isCeo() {
     if (!actual().isCeo()) {
-      fail("is CEO");
+      failWithActual(simpleFact("expected to be CEO"));
     }
   }
 
   public void isNotCeo() {
     if (actual().isCeo()) {
-      fail("is not CEO");
+      failWithActual(simpleFact("expected not to be CEO"));
     }
   }
 

--- a/core/src/test/java/com/google/common/truth/extension/EmployeeSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/extension/EmployeeSubjectTest.java
@@ -15,6 +15,7 @@
  */
 package com.google.common.truth.extension;
 
+import static com.google.common.truth.ExpectFailure.assertThat;
 import static com.google.common.truth.ExpectFailure.expectFailureAbout;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.extension.EmployeeSubject.assertThat;
@@ -49,9 +50,11 @@ public final class EmployeeSubjectTest {
   @Test
   public void username() {
     assertThat(KURT).hasUsername("kak");
-    // Here's an example of asserting on the failure message:
-    AssertionError failure = expectFailure(whenTesting -> whenTesting.that(KURT).hasName("sundar"));
-    assertThat(failure).hasMessageThat().contains("username");
+    // Here's an example of asserting on the failure message.
+    // Note that it uses the assertThat method from ExpectFailure.
+    AssertionError failure =
+        expectFailure(whenTesting -> whenTesting.that(KURT).hasUsername("sundar"));
+    assertThat(failure).factValue("value of").isEqualTo("employee.username()");
   }
 
   private static AssertionError expectFailure(

--- a/extensions/java8/src/main/java/com/google/common/truth/OptionalDoubleSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/OptionalDoubleSubject.java
@@ -16,7 +16,7 @@
 package com.google.common.truth;
 
 import static com.google.common.truth.Fact.fact;
-import static com.google.common.truth.Fact.factWithoutValue;
+import static com.google.common.truth.Fact.simpleFact;
 
 import java.util.OptionalDouble;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
@@ -38,19 +38,19 @@ public final class OptionalDoubleSubject extends Subject<OptionalDoubleSubject, 
   /** Fails if the {@link OptionalDouble} is empty or the subject is null. */
   public void isPresent() {
     if (actual() == null) {
-      fail(factWithoutValue("expected present optional"));
+      failWithActual(simpleFact("expected present optional"));
     } else if (!actual().isPresent()) {
-      failWithoutActual(factWithoutValue("expected to be present"));
+      failWithoutActual(simpleFact("expected to be present"));
     }
   }
 
   /** Fails if the {@link OptionalDouble} is present or the subject is null. */
   public void isEmpty() {
     if (actual() == null) {
-      fail(factWithoutValue("expected empty optional"));
+      failWithActual(simpleFact("expected empty optional"));
     } else if (actual().isPresent()) {
       failWithoutActual(
-          factWithoutValue("expected to be empty"),
+          simpleFact("expected to be empty"),
           fact("but was present with value", actual().getAsDouble()));
     }
   }
@@ -65,10 +65,9 @@ public final class OptionalDoubleSubject extends Subject<OptionalDoubleSubject, 
    */
   public void hasValue(double expected) {
     if (actual() == null) {
-      failWithFact("expected an optional with value", expected);
+      failWithActual("expected an optional with value", expected);
     } else if (!actual().isPresent()) {
-      failWithoutActual(
-          fact("expected to have value", expected), factWithoutValue("but was absent"));
+      failWithoutActual(fact("expected to have value", expected), simpleFact("but was absent"));
     } else {
       checkNoNeedToDisplayBothValues("getAsDouble()")
           .that(actual().getAsDouble())

--- a/extensions/java8/src/main/java/com/google/common/truth/OptionalIntSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/OptionalIntSubject.java
@@ -16,7 +16,7 @@
 package com.google.common.truth;
 
 import static com.google.common.truth.Fact.fact;
-import static com.google.common.truth.Fact.factWithoutValue;
+import static com.google.common.truth.Fact.simpleFact;
 
 import java.util.OptionalInt;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
@@ -37,19 +37,19 @@ public final class OptionalIntSubject extends Subject<OptionalIntSubject, Option
   /** Fails if the {@link OptionalInt} is empty or the subject is null. */
   public void isPresent() {
     if (actual() == null) {
-      fail(factWithoutValue("expected present optional"));
+      failWithActual(simpleFact("expected present optional"));
     } else if (!actual().isPresent()) {
-      failWithoutActual(factWithoutValue("expected to be present"));
+      failWithoutActual(simpleFact("expected to be present"));
     }
   }
 
   /** Fails if the {@link OptionalInt} is present or the subject is null. */
   public void isEmpty() {
     if (actual() == null) {
-      fail(factWithoutValue("expected empty optional"));
+      failWithActual(simpleFact("expected empty optional"));
     } else if (actual().isPresent()) {
       failWithoutActual(
-          factWithoutValue("expected to be empty"),
+          simpleFact("expected to be empty"),
           fact("but was present with value", actual().getAsInt()));
     }
   }
@@ -60,10 +60,9 @@ public final class OptionalIntSubject extends Subject<OptionalIntSubject, Option
    */
   public void hasValue(int expected) {
     if (actual() == null) {
-      failWithFact("expected an optional with value", expected);
+      failWithActual("expected an optional with value", expected);
     } else if (!actual().isPresent()) {
-      failWithoutActual(
-          fact("expected to have value", expected), factWithoutValue("but was absent"));
+      failWithoutActual(fact("expected to have value", expected), simpleFact("but was absent"));
     } else {
       checkNoNeedToDisplayBothValues("getAsInt()").that(actual().getAsInt()).isEqualTo(expected);
     }

--- a/extensions/java8/src/main/java/com/google/common/truth/OptionalLongSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/OptionalLongSubject.java
@@ -16,7 +16,7 @@
 package com.google.common.truth;
 
 import static com.google.common.truth.Fact.fact;
-import static com.google.common.truth.Fact.factWithoutValue;
+import static com.google.common.truth.Fact.simpleFact;
 
 import java.util.OptionalLong;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
@@ -37,19 +37,19 @@ public final class OptionalLongSubject extends Subject<OptionalLongSubject, Opti
   /** Fails if the {@link OptionalLong} is empty or the subject is null. */
   public void isPresent() {
     if (actual() == null) {
-      fail(factWithoutValue("expected present optional"));
+      failWithActual(simpleFact("expected present optional"));
     } else if (!actual().isPresent()) {
-      failWithoutActual(factWithoutValue("expected to be present"));
+      failWithoutActual(simpleFact("expected to be present"));
     }
   }
 
   /** Fails if the {@link OptionalLong} is present or the subject is null. */
   public void isEmpty() {
     if (actual() == null) {
-      fail(factWithoutValue("expected empty optional"));
+      failWithActual(simpleFact("expected empty optional"));
     } else if (actual().isPresent()) {
       failWithoutActual(
-          factWithoutValue("expected to be empty"),
+          simpleFact("expected to be empty"),
           fact("but was present with value", actual().getAsLong()));
     }
   }
@@ -60,10 +60,9 @@ public final class OptionalLongSubject extends Subject<OptionalLongSubject, Opti
    */
   public void hasValue(long expected) {
     if (actual() == null) {
-      failWithFact("expected an optional with value", expected);
+      failWithActual("expected an optional with value", expected);
     } else if (!actual().isPresent()) {
-      failWithoutActual(
-          fact("expected to have value", expected), factWithoutValue("but was absent"));
+      failWithoutActual(fact("expected to have value", expected), simpleFact("but was absent"));
     } else {
       checkNoNeedToDisplayBothValues("getAsLong()").that(actual().getAsLong()).isEqualTo(expected);
     }

--- a/extensions/java8/src/main/java/com/google/common/truth/OptionalSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/OptionalSubject.java
@@ -16,7 +16,7 @@
 package com.google.common.truth;
 
 import static com.google.common.truth.Fact.fact;
-import static com.google.common.truth.Fact.factWithoutValue;
+import static com.google.common.truth.Fact.simpleFact;
 
 import java.util.Optional;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
@@ -39,20 +39,19 @@ public final class OptionalSubject extends Subject<OptionalSubject, Optional<?>>
   /** Fails if the {@link Optional}{@code <T>} is empty or the subject is null. */
   public void isPresent() {
     if (actual() == null) {
-      fail(factWithoutValue("expected present optional"));
+      failWithActual(simpleFact("expected present optional"));
     } else if (!actual().isPresent()) {
-      failWithoutActual(factWithoutValue("expected to be present"));
+      failWithoutActual(simpleFact("expected to be present"));
     }
   }
 
   /** Fails if the {@link Optional}{@code <T>} is present or the subject is null. */
   public void isEmpty() {
     if (actual() == null) {
-      fail(factWithoutValue("expected empty optional"));
+      failWithActual(simpleFact("expected empty optional"));
     } else if (actual().isPresent()) {
       failWithoutActual(
-          factWithoutValue("expected to be empty"),
-          fact("but was present with value", actual().get()));
+          simpleFact("expected to be empty"), fact("but was present with value", actual().get()));
     }
   }
 
@@ -71,10 +70,9 @@ public final class OptionalSubject extends Subject<OptionalSubject, Optional<?>>
       throw new NullPointerException("Optional cannot have a null value.");
     }
     if (actual() == null) {
-      failWithFact("expected an optional with value", expected);
+      failWithActual("expected an optional with value", expected);
     } else if (!actual().isPresent()) {
-      failWithoutActual(
-          fact("expected to have value", expected), factWithoutValue("but was absent"));
+      failWithoutActual(fact("expected to have value", expected), simpleFact("but was absent"));
     } else {
       checkNoNeedToDisplayBothValues("get()").that(actual().get()).isEqualTo(expected);
     }

--- a/extensions/java8/src/test/java/com/google/common/truth/IntStreamSubjectTest.java
+++ b/extensions/java8/src/test/java/com/google/common/truth/IntStreamSubjectTest.java
@@ -134,14 +134,8 @@ public final class IntStreamSubjectTest {
 
   @Test
   public void testContainsAnyOf_fails() throws Exception {
-    try {
-      assertThat(IntStream.of(42)).containsAnyOf(43, 44);
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Not true that <[42]> contains any of <[43, 44]>");
-    }
+    AssertionError unused =
+        expectFailure(whenTesting -> whenTesting.that(IntStream.of(42)).containsAnyOf(43, 44));
   }
 
   @Test
@@ -151,14 +145,9 @@ public final class IntStreamSubjectTest {
 
   @Test
   public void testContainsAnyIn_fails() throws Exception {
-    try {
-      assertThat(IntStream.of(42)).containsAnyIn(asList(43, 44));
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Not true that <[42]> contains any of <[43, 44]>");
-    }
+    AssertionError unused =
+        expectFailure(
+            whenTesting -> whenTesting.that(IntStream.of(42)).containsAnyIn(asList(43, 44)));
   }
 
   @Test
@@ -202,15 +191,9 @@ public final class IntStreamSubjectTest {
 
   @Test
   public void testContainsAllOf_fails() throws Exception {
-    try {
-      assertThat(IntStream.of(42, 43)).containsAllOf(42, 43, 44);
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Not true that <[42, 43]> contains at least <[42, 43, 44]>. It is missing <[44]>");
-    }
+    AssertionError unused =
+        expectFailure(
+            whenTesting -> whenTesting.that(IntStream.of(42, 43)).containsAllOf(42, 43, 44));
   }
 
   @Test
@@ -240,16 +223,10 @@ public final class IntStreamSubjectTest {
 
   @Test
   public void testContainsAllIn_fails() throws Exception {
-    try {
-      assertThat(IntStream.of(42, 43)).containsAllIn(asList(42, 43, 44));
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Not true that <[42, 43]> contains at least <[42, 43, 44]>. "
-                  + "It is missing <[44]>");
-    }
+    AssertionError unused =
+        expectFailure(
+            whenTesting ->
+                whenTesting.that(IntStream.of(42, 43)).containsAllIn(asList(42, 43, 44)));
   }
 
   @Test

--- a/extensions/java8/src/test/java/com/google/common/truth/LongStreamSubjectTest.java
+++ b/extensions/java8/src/test/java/com/google/common/truth/LongStreamSubjectTest.java
@@ -135,14 +135,8 @@ public final class LongStreamSubjectTest {
 
   @Test
   public void testContainsAnyOf_fails() throws Exception {
-    try {
-      assertThat(LongStream.of(42)).containsAnyOf(43, 44);
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Not true that <[42]> contains any of <[43, 44]>");
-    }
+    AssertionError unused =
+        expectFailure(whenTesting -> whenTesting.that(LongStream.of(42)).containsAnyOf(43, 44));
   }
 
   @Test
@@ -152,14 +146,9 @@ public final class LongStreamSubjectTest {
 
   @Test
   public void testContainsAnyIn_fails() throws Exception {
-    try {
-      assertThat(LongStream.of(42)).containsAnyIn(asList(43, 44));
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Not true that <[42]> contains any of <[43, 44]>");
-    }
+    AssertionError unused =
+        expectFailure(
+            whenTesting -> whenTesting.that(LongStream.of(42)).containsAnyIn(asList(43, 44)));
   }
 
   @Test
@@ -203,15 +192,9 @@ public final class LongStreamSubjectTest {
 
   @Test
   public void testContainsAllOf_fails() throws Exception {
-    try {
-      assertThat(LongStream.of(42, 43)).containsAllOf(42, 43, 44);
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Not true that <[42, 43]> contains at least <[42, 43, 44]>. It is missing <[44]>");
-    }
+    AssertionError unused =
+        expectFailure(
+            whenTesting -> whenTesting.that(LongStream.of(42, 43)).containsAllOf(42, 43, 44));
   }
 
   @Test
@@ -241,31 +224,18 @@ public final class LongStreamSubjectTest {
 
   @Test
   public void testContainsAllIn_fails() throws Exception {
-    try {
-      assertThat(LongStream.of(42, 43)).containsAllIn(asList(42L, 43L, 44L));
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Not true that <[42, 43]> contains at least <[42, 43, 44]>. "
-                  + "It is missing <[44]>");
-    }
+    AssertionError unused =
+        expectFailure(
+            whenTesting ->
+                whenTesting.that(LongStream.of(42, 43)).containsAllIn(asList(42L, 43L, 44L)));
   }
 
   @Test
   public void testContainsAllIn_wrongType_fails() throws Exception {
-    try {
-      assertThat(LongStream.of(42, 43)).containsAllIn(asList(42, 43, 44));
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Not true that <[42, 43]> contains at least <[42, 43, 44]>. "
-                  + "It is missing <[42, 43, 44] (java.lang.Integer)>. "
-                  + "However, it does contain <[42, 43] (java.lang.Long)>.");
-    }
+    AssertionError unused =
+        expectFailure(
+            whenTesting ->
+                whenTesting.that(LongStream.of(42, 43)).containsAllIn(asList(42, 43, 44)));
   }
 
   @Test
@@ -290,17 +260,10 @@ public final class LongStreamSubjectTest {
 
   @Test
   public void testContainsAllIn_inOrder_wrongType_fails() throws Exception {
-    try {
-      assertThat(LongStream.of(42, 43)).containsAllIn(asList(43, 42)).inOrder();
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Not true that <[42, 43]> contains at least <[43, 42]>. "
-                  + "It is missing <[43, 42] (java.lang.Integer)>. "
-                  + "However, it does contain <[42, 43] (java.lang.Long)>.");
-    }
+    AssertionError unused =
+        expectFailure(
+            whenTesting ->
+                whenTesting.that(LongStream.of(42, 43)).containsAllIn(asList(43, 42)).inOrder());
   }
 
   @Test

--- a/extensions/java8/src/test/java/com/google/common/truth/StreamSubjectTest.java
+++ b/extensions/java8/src/test/java/com/google/common/truth/StreamSubjectTest.java
@@ -135,14 +135,9 @@ public final class StreamSubjectTest {
 
   @Test
   public void testContainsAnyOf_fails() throws Exception {
-    try {
-      assertThat(Stream.of("hello")).containsAnyOf("goodbye", "good");
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Not true that <[hello]> contains any of <[goodbye, good]>");
-    }
+    AssertionError unused =
+        expectFailure(
+            whenTesting -> whenTesting.that(Stream.of("hello")).containsAnyOf("goodbye", "good"));
   }
 
   @Test
@@ -152,14 +147,10 @@ public final class StreamSubjectTest {
 
   @Test
   public void testContainsAnyIn_fails() throws Exception {
-    try {
-      assertThat(Stream.of("hello")).containsAnyIn(asList("goodbye", "good"));
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Not true that <[hello]> contains any of <[goodbye, good]>");
-    }
+    AssertionError unused =
+        expectFailure(
+            whenTesting ->
+                whenTesting.that(Stream.of("hello")).containsAnyIn(asList("goodbye", "good")));
   }
 
   @Test
@@ -205,16 +196,12 @@ public final class StreamSubjectTest {
 
   @Test
   public void testContainsAllOf_fails() throws Exception {
-    try {
-      assertThat(Stream.of("hell", "hello")).containsAllOf("hell", "hello", "goodbye");
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Not true that <[hell, hello]> contains at least <[hell, hello, goodbye]>. "
-                  + "It is missing <[goodbye]>");
-    }
+    AssertionError unused =
+        expectFailure(
+            whenTesting ->
+                whenTesting
+                    .that(Stream.of("hell", "hello"))
+                    .containsAllOf("hell", "hello", "goodbye"));
   }
 
   @Test
@@ -244,16 +231,12 @@ public final class StreamSubjectTest {
 
   @Test
   public void testContainsAllIn_fails() throws Exception {
-    try {
-      assertThat(Stream.of("hell", "hello")).containsAllIn(asList("hell", "hello", "goodbye"));
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Not true that <[hell, hello]> contains at least <[hell, hello, goodbye]>. "
-                  + "It is missing <[goodbye]>");
-    }
+    AssertionError unused =
+        expectFailure(
+            whenTesting ->
+                whenTesting
+                    .that(Stream.of("hell", "hello"))
+                    .containsAllIn(asList("hell", "hello", "goodbye")));
   }
 
   @Test

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoTruth.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoTruth.java
@@ -123,4 +123,5 @@ public final class ProtoTruth {
   }
 
   private ProtoTruth() {}
+
 }

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/OverloadResolutionTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/OverloadResolutionTest.java
@@ -363,4 +363,35 @@ public class OverloadResolutionTest extends ProtoSubjectTestBase {
     assertThat(altActualObjects).doesNotContainEntry("a", message1);
     assertThat(altActualObjects).doesNotContainEntry("b", message2);
   }
+
+  @Test
+  public void testHackHackHackBug195497495() {
+    // Empty sub message.
+    TestMessage2 message = parse("o_int: 1 o_sub_test_message: { }");
+    TestMessage2 strippedMessage = ProtoTruth.removeEmptySubMessagesForBug79268889(message);
+    assertThat(strippedMessage.hasOSubTestMessage()).isFalse();
+    assertThat(strippedMessage.getOInt()).isEqualTo(1);
+
+    // Recurisvely empty sub message.
+    message = parse("o_int: 1 o_sub_test_message: { o_sub_sub_test_message: { } }");
+    strippedMessage = ProtoTruth.removeEmptySubMessagesForBug79268889(message);
+    assertThat(strippedMessage.hasOSubTestMessage()).isFalse();
+    assertThat(strippedMessage.getOInt()).isEqualTo(1);
+
+    // Recursively non-empty sub message.
+    message = parse("o_int: 1 o_sub_test_message: { o_sub_sub_test_message: { o_int: 3 } }");
+    strippedMessage = ProtoTruth.removeEmptySubMessagesForBug79268889(message);
+    assertThat(strippedMessage).isEqualTo(message);
+
+    // Recursively empty repeated field.
+    message = parse("o_int: 1 r_sub_test_message: { } r_sub_test_message: { }");
+    strippedMessage = ProtoTruth.removeEmptySubMessagesForBug79268889(message);
+    assertThat(strippedMessage.getRSubTestMessageList()).isEmpty();
+    assertThat(strippedMessage.getOInt()).isEqualTo(1);
+
+    // Recursively non-empty repeated field.
+    message = parse("o_int: 1 r_sub_test_message: { } r_sub_test_message: { o_int: 5 }");
+    strippedMessage = ProtoTruth.removeEmptySubMessagesForBug79268889(message);
+    assertThat(strippedMessage).isEqualTo(message);
+  }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Migrate containsAnyIn() and containsAllIn() to the new message format.

I handled containsAnyIn() much like contains(), and I handled containsAllIn() much like containsExactly().

91dc44d7d4f4eb47d5a018ec573bfc446b7cdfe4

-------

<p> Document and expose the new failure API, including performing the renames decided upon in API Review.

RELNOTES=Introduced the new API for building failure messages in a "key: value" format. See `Subject.failWithActual` and `failWithoutActual`, which use the new `Fact` class.

9eeb0a59ec3b64d82ae8b1a7ef17fe4d787f0e6a

-------

<p> Add a temporary, Google-internal, hacky workaround for b/79268889.

da900364ff6624a53d12a86a3682b9e24107aae6