### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/StringSubject.java
+++ b/core/src/main/java/com/google/common/truth/StringSubject.java
@@ -17,6 +17,7 @@ package com.google.common.truth;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.truth.Fact.fact;
 import static com.google.common.truth.Fact.simpleFact;
 
 import com.google.common.annotations.GwtIncompatible;
@@ -170,6 +171,52 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
   public void doesNotContainMatch(String regex) {
     if (Platform.containsMatch(actual(), regex)) {
       failWithActual("expected not to contain a match for", regex);
+    }
+  }
+
+  /**
+   * Returns a {@link StringSubject}-like instance that will ignore the case of the characters.
+   *
+   * <p>Character equality ignoring case is defined as follows: Characters are equal according to
+   * the {@code ==} operator before or after calling {@code
+   * Character.toLowerCase(Character.toUpperCase(character))} on each character. Note that this is
+   * independent of any locale.
+   */
+  public CaseInsensitiveStringComparison ignoringCase() {
+    return new CaseInsensitiveStringComparison();
+  }
+
+  /** Case insensitive propositions for string subjects. */
+  public final class CaseInsensitiveStringComparison {
+    private CaseInsensitiveStringComparison() {}
+
+    /**
+     * Fails if the subject is not equal to the given sequence (while ignoring case). For the
+     * purposes of this comparison, two strings are equal if any of the following is true:
+     *
+     * <ul>
+     *   <li>they are equal according to {@link String#equalsIgnoreCase}
+     *   <li>they are both null
+     * </ul>
+     *
+     * <p>Example: "abc" is equal to "ABC", but not to "abcd".
+     */
+    public void isEqualTo(CharSequence expected) {
+      if (actual() == null) {
+        if (expected != null) {
+          failWithoutActual(
+              fact("expected a string that is equal to", expected),
+              butWas(),
+              simpleFact("(case is ignored)"));
+        }
+      } else {
+        if (expected == null) {
+          failWithoutActual(
+              fact("expected", "null (null reference)"), butWas(), simpleFact("(case is ignored)"));
+        } else if (!actual().equalsIgnoreCase(expected.toString())) {
+          failWithoutActual(fact("expected", expected), butWas(), simpleFact("(case is ignored)"));
+        }
+      }
     }
   }
 }

--- a/core/src/main/java/com/google/common/truth/StringSubject.java
+++ b/core/src/main/java/com/google/common/truth/StringSubject.java
@@ -218,5 +218,41 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
         }
       }
     }
+
+    /** Fails if the string does not contain the given sequence (while ignoring case). */
+    public void contains(CharSequence expectedSequence) {
+      checkNotNull(expectedSequence);
+      String expected = expectedSequence.toString();
+      if (actual() == null) {
+        failWithoutActual(
+            fact("expected a string that contains", expected),
+            butWas(),
+            simpleFact("(case is ignored)"));
+      } else if (!containsIgnoreCase(expected)) {
+        failWithoutActual(
+            fact("expected to contain", expected), butWas(), simpleFact("(case is ignored)"));
+      }
+    }
+
+    private boolean containsIgnoreCase(String string) {
+      if (string.isEmpty()) {
+        // TODO(b/79459427): Fix for J2CL discrepancy when string is empty
+        return true;
+      }
+      String subject = actual();
+      for (int subjectOffset = 0;
+          subjectOffset <= subject.length() - string.length();
+          subjectOffset++) {
+        if (subject.regionMatches(
+            /* ignoreCase = */ true,
+            /* toffset = */ subjectOffset,
+            /* other = */ string,
+            /* ooffset = */ 0,
+            /* len = */ string.length())) {
+          return true;
+        }
+      }
+      return false;
+    }
   }
 }

--- a/core/src/main/java/com/google/common/truth/StringSubject.java
+++ b/core/src/main/java/com/google/common/truth/StringSubject.java
@@ -177,10 +177,9 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
   /**
    * Returns a {@link StringSubject}-like instance that will ignore the case of the characters.
    *
-   * <p>Character equality ignoring case is defined as follows: Characters are equal according to
-   * the {@code ==} operator before or after calling {@code
-   * Character.toLowerCase(Character.toUpperCase(character))} on each character. Note that this is
-   * independent of any locale.
+   * <p>Character equality ignoring case is defined as follows: Characters must be equal either
+   * after calling {@link Character#toLowerCase} or after calling {@link Character#toUpperCase}.
+   * Note that this is independent of any locale.
    */
   public CaseInsensitiveStringComparison ignoringCase() {
     return new CaseInsensitiveStringComparison();

--- a/core/src/test/java/com/google/common/truth/StringSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/StringSubjectTest.java
@@ -286,6 +286,56 @@ public class StringSubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure()).factKeys().contains("(case is ignored)");
   }
 
+  @Test
+  public void stringContainsIgnoringCase() {
+    assertThat("äbc").ignoringCase().contains("Ä");
+  }
+
+  @Test
+  public void stringContainsIgnoringCaseEmptyString() {
+    assertThat("abc").ignoringCase().contains("");
+  }
+
+  @Test
+  public void stringContainsIgnoringCaseWithWord() {
+    assertThat("abcdé").ignoringCase().contains("CdÉ");
+  }
+
+  @Test
+  public void stringContainsIgnoringCaseWholeWord() {
+    assertThat("abcde").ignoringCase().contains("ABCde");
+  }
+
+  @Test
+  public void stringContainsIgnoringCaseCharSeq() {
+    CharSequence charSeq = new StringBuilder("C");
+    assertThat("abc").ignoringCase().contains(charSeq);
+  }
+
+  @Test
+  public void stringContainsIgnoringCaseFail() {
+    expectFailureWhenTestingThat("abc").ignoringCase().contains("d");
+
+    assertFailureValue("expected to contain", "d");
+    assertThat(expectFailure.getFailure()).factKeys().contains("(case is ignored)");
+  }
+
+  @Test
+  public void stringContainsIgnoringCaseFailBecauseTooLarge() {
+    expectFailureWhenTestingThat("abc").ignoringCase().contains("abcc");
+
+    assertFailureValue("expected to contain", "abcc");
+    assertThat(expectFailure.getFailure()).factKeys().contains("(case is ignored)");
+  }
+
+  @Test
+  public void stringContainsIgnoringCaseFailBecauseNullSubject() {
+    expectFailureWhenTestingThat((String) null).ignoringCase().contains("d");
+
+    assertFailureValue("expected a string that contains", "d");
+    assertThat(expectFailure.getFailure()).factKeys().contains("(case is ignored)");
+  }
+
   private StringSubject expectFailureWhenTestingThat(String actual) {
     return expectFailure.whenTesting().that(actual);
   }

--- a/core/src/test/java/com/google/common/truth/StringSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/StringSubjectTest.java
@@ -15,6 +15,7 @@
  */
 package com.google.common.truth;
 
+import static com.google.common.truth.ExpectFailure.assertThat;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
@@ -139,7 +140,7 @@ public class StringSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void stringEqualityFail() {
-    expectFailureWhenTestingThat("abc").isEqualTo("abd");
+    expectFailureWhenTestingThat("abc").isEqualTo("ABC");
     assertThat(expectFailure.getFailure()).isInstanceOf(ComparisonFailureWithFacts.class);
   }
 
@@ -249,6 +250,40 @@ public class StringSubjectTest extends BaseSubjectTestCase {
 
     expectFailureWhenTestingThat("aba").doesNotContainMatch(Pattern.compile(".*b.*"));
     assertFailureValue("expected not to contain a match for", ".*b.*");
+  }
+
+  @Test
+  public void stringEqualityIgnoringCase() {
+    assertThat("café").ignoringCase().isEqualTo("CAFÉ");
+  }
+
+  @Test
+  public void stringEqualityIgnoringCaseWithNullSubject() {
+    assertThat((String) null).ignoringCase().isEqualTo(null);
+  }
+
+  @Test
+  public void stringEqualityIgnoringCaseFail() {
+    expectFailureWhenTestingThat("abc").ignoringCase().isEqualTo("abd");
+
+    assertFailureValue("expected", "abd");
+    assertThat(expectFailure.getFailure()).factKeys().contains("(case is ignored)");
+  }
+
+  @Test
+  public void stringEqualityIgnoringCaseFailWithNullSubject() {
+    expectFailureWhenTestingThat((String) null).ignoringCase().isEqualTo("abc");
+
+    assertFailureValue("expected a string that is equal to", "abc");
+    assertThat(expectFailure.getFailure()).factKeys().contains("(case is ignored)");
+  }
+
+  @Test
+  public void stringEqualityIgnoringCaseFailWithNullString() {
+    expectFailureWhenTestingThat("abc").ignoringCase().isEqualTo(null);
+
+    assertFailureValue("expected", "null (null reference)");
+    assertThat(expectFailure.getFailure()).factKeys().contains("(case is ignored)");
   }
 
   private StringSubject expectFailureWhenTestingThat(String actual) {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add StringSubject.ignoringCase().isEqualTo().

Note: The other methods on CaseInsensitiveStringComparison will follow later changes.

RELNOTES=Added `StringSubject.ignoringCase()`

59979ce122ed7649f5497dda82389c615c359506

-------

<p> Add StringSubject.ignoringCase().contains().

RELNOTES=Added `StringSubject.ignoringCase().contains()`

b1426eccebb4768775c1cb5b42875bb02c41e4f2

-------

<p> Simplify ignoringCase() javadoc about how character equality is defined.

Changes:
- Remove '== equality' as it is implied by lowerCase(upperCase()) equality
- Replace '== equality' by 'are equal' as there is no confusion for character primitives
- Explain behavior as equality after *either* lowerCase() or upperCase()

f0d381b62e432c32bf85dd7978f1c46f93274da1