### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/StringSubject.java
+++ b/core/src/main/java/com/google/common/truth/StringSubject.java
@@ -200,7 +200,7 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
      *
      * <p>Example: "abc" is equal to "ABC", but not to "abcd".
      */
-    public void isEqualTo(CharSequence expected) {
+    public void isEqualTo(String expected) {
       if (actual() == null) {
         if (expected != null) {
           failWithoutActual(
@@ -212,7 +212,7 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
         if (expected == null) {
           failWithoutActual(
               fact("expected", "null (null reference)"), butWas(), simpleFact("(case is ignored)"));
-        } else if (!actual().equalsIgnoreCase(expected.toString())) {
+        } else if (!actual().equalsIgnoreCase(expected)) {
           failWithoutActual(fact("expected", expected), butWas(), simpleFact("(case is ignored)"));
         }
       }
@@ -222,7 +222,7 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
      * Fails if the subject is equal to the given string (while ignoring case). The meaning of
      * equality is the same as for the {@link #isEqualTo} method.
      */
-    public void isNotEqualTo(CharSequence unexpected) {
+    public void isNotEqualTo(String unexpected) {
       if (actual() == null) {
         if (unexpected == null) {
           failWithoutActual(
@@ -230,7 +230,7 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
               simpleFact("(case is ignored)"));
         }
       } else {
-        if (unexpected != null && actual().equalsIgnoreCase(unexpected.toString())) {
+        if (unexpected != null && actual().equalsIgnoreCase(unexpected)) {
           failWithoutActual(
               fact("expected not to be", unexpected), butWas(), simpleFact("(case is ignored)"));
         }

--- a/core/src/main/java/com/google/common/truth/StringSubject.java
+++ b/core/src/main/java/com/google/common/truth/StringSubject.java
@@ -252,6 +252,21 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
       }
     }
 
+    /** Fails if the string contains the given sequence (while ignoring case). */
+    public void doesNotContain(CharSequence expectedSequence) {
+      checkNotNull(expectedSequence);
+      String expected = expectedSequence.toString();
+      if (actual() == null) {
+        failWithoutActual(
+            fact("expected a string that does not contain", expected),
+            butWas(),
+            simpleFact("(case is ignored)"));
+      } else if (containsIgnoreCase(expected)) {
+        failWithoutActual(
+            fact("expected not to contain", expected), butWas(), simpleFact("(case is ignored)"));
+      }
+    }
+
     private boolean containsIgnoreCase(String string) {
       if (string.isEmpty()) {
         // TODO(b/79459427): Fix for J2CL discrepancy when string is empty

--- a/core/src/main/java/com/google/common/truth/StringSubject.java
+++ b/core/src/main/java/com/google/common/truth/StringSubject.java
@@ -218,6 +218,25 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
       }
     }
 
+    /**
+     * Fails if the subject is equal to the given string (while ignoring case). The meaning of
+     * equality is the same as for the {@link #isEqualTo} method.
+     */
+    public void isNotEqualTo(CharSequence unexpected) {
+      if (actual() == null) {
+        if (unexpected == null) {
+          failWithoutActual(
+              fact("expected a string that is not equal to", "null (null reference)"),
+              simpleFact("(case is ignored)"));
+        }
+      } else {
+        if (unexpected != null && actual().equalsIgnoreCase(unexpected.toString())) {
+          failWithoutActual(
+              fact("expected not to be", unexpected), butWas(), simpleFact("(case is ignored)"));
+        }
+      }
+    }
+
     /** Fails if the string does not contain the given sequence (while ignoring case). */
     public void contains(CharSequence expectedSequence) {
       checkNotNull(expectedSequence);

--- a/core/src/test/java/com/google/common/truth/StringSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/StringSubjectTest.java
@@ -367,6 +367,41 @@ public class StringSubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure()).factKeys().contains("(case is ignored)");
   }
 
+  @Test
+  public void stringDoesNotContainIgnoringCase() {
+    assertThat("äbc").ignoringCase().doesNotContain("Äc");
+  }
+
+  @Test
+  public void stringDoesNotContainIgnoringCaseCharSeq() {
+    CharSequence charSeq = new StringBuilder("cb");
+    assertThat("abc").ignoringCase().doesNotContain(charSeq);
+  }
+
+  @Test
+  public void stringDoesNotContainIgnoringCaseFail() {
+    expectFailureWhenTestingThat("äbc").ignoringCase().doesNotContain("Äb");
+
+    assertFailureValue("expected not to contain", "Äb");
+    assertThat(expectFailure.getFailure()).factKeys().contains("(case is ignored)");
+  }
+
+  @Test
+  public void stringDoesNotContainIgnoringCaseFailWithEmptyString() {
+    expectFailureWhenTestingThat("abc").ignoringCase().doesNotContain("");
+
+    assertFailureValue("expected not to contain", "");
+    assertThat(expectFailure.getFailure()).factKeys().contains("(case is ignored)");
+  }
+
+  @Test
+  public void stringDoesNotContainIgnoringCaseFailBecauseNullSubject() {
+    expectFailureWhenTestingThat((String) null).ignoringCase().doesNotContain("d");
+
+    assertFailureValue("expected a string that does not contain", "d");
+    assertThat(expectFailure.getFailure()).factKeys().contains("(case is ignored)");
+  }
+
   private StringSubject expectFailureWhenTestingThat(String actual) {
     return expectFailure.whenTesting().that(actual);
   }

--- a/core/src/test/java/com/google/common/truth/StringSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/StringSubjectTest.java
@@ -279,10 +279,41 @@ public class StringSubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
-  public void stringEqualityIgnoringCaseFailWithNullString() {
+  public void stringEqualityIgnoringCaseFailWithNullExpectedString() {
     expectFailureWhenTestingThat("abc").ignoringCase().isEqualTo(null);
 
     assertFailureValue("expected", "null (null reference)");
+    assertThat(expectFailure.getFailure()).factKeys().contains("(case is ignored)");
+  }
+
+  @Test
+  public void stringInequalityIgnoringCase() {
+    assertThat("café").ignoringCase().isNotEqualTo("AFÉ");
+  }
+
+  @Test
+  public void stringInequalityIgnoringCaseWithNullSubject() {
+    assertThat((String) null).ignoringCase().isNotEqualTo("abc");
+  }
+
+  @Test
+  public void stringInequalityIgnoringCaseWithNullExpectedString() {
+    assertThat("abc").ignoringCase().isNotEqualTo(null);
+  }
+
+  @Test
+  public void stringInequalityIgnoringCaseFail() {
+    expectFailureWhenTestingThat("café").ignoringCase().isNotEqualTo("CAFÉ");
+
+    assertFailureValue("expected not to be", "CAFÉ");
+    assertThat(expectFailure.getFailure()).factKeys().contains("(case is ignored)");
+  }
+
+  @Test
+  public void stringInequalityIgnoringCaseFailWithNullSubject() {
+    expectFailureWhenTestingThat((String) null).ignoringCase().isNotEqualTo(null);
+
+    assertFailureValue("expected a string that is not equal to", "null (null reference)");
     assertThat(expectFailure.getFailure()).factKeys().contains("(case is ignored)");
   }
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add StringSubject.ignoringCase().isNotEqualTo().

8736890371e187f19314f7b5f2855f1f22a48a5a

-------

<p> Add StringSubject.ignoringCase().doesNotContain().

1a49a78928cf49ee1a945603385fecb96a1cfd6d

-------

<p> Only accept String in StringSubject.ignoringCase().is[Not]EqualTo().

All other inputs would fail the regular Subject.isEqualTo() so supporting e.g. StringBuffers here would only confuse users.

ef37113e95e060240da58777768f20a58ceb53ce