### PR TITLE
Moe Sync

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ url: "https://google.github.io"
 baseurl: '/truth'
 markdown: kramdown
 repository: google/truth
-version: "0.41"
+version: "0.42"
 
 title: Truth
 tagline: Fluent assertions for Java
@@ -26,7 +26,7 @@ nav:
       url: /comparison
   - item:
       name: Javadoc
-      url: /api/0.41/
+      url: /api/0.42/
   - item:
       name: FAQ
       url: /faq

--- a/release.md
+++ b/release.md
@@ -70,66 +70,6 @@ currently at the tip of the branch is sound.
 
 ### Update versions
 
-#### Increment SNAPSHOT dependency versions
-
-Do a quick check of the dependency versions to ensure that the truth artifact
-is not relying on -SNAPSHOT dependencies. Since truth manages versions in maven
-properties, the following is a useful tool:
-
-```shell
-mvn -N versions:display-property-updates
-```
-
-Version properties will be generated and should look something like this:
-
-```
-...
-[INFO] ------------------------------------------------------------------------
-[INFO] Building truth 1.0-SNAPSHOT
-[INFO] ------------------------------------------------------------------------
-[INFO]
-[INFO] --- versions-maven-plugin:2.3:display-property-updates (default-cli) @ truth ---
-[INFO]
-[INFO] The following version properties are referencing the newest available version:
-[INFO]   ${auto-value.version} ......................................... 1.5-SNAPSHOT
-[INFO]   ${jsr305.version} ............................................. 3.0.2
-[INFO]   ${compile-testing.version} ..................................... 0.11
-[INFO]   ${junit.version} ............................................... 4.12
-[INFO]   ${error-prone.annotations.version} ........................... 2.0.19
-[INFO] The following version property updates are available:
-[INFO]   ${gwt.version} ....................................... 2.8.0 -> 2.8.1
-[INFO]   ${guava.version} ....................................... 21.0 -> 22.0
-[INFO]
-...
-[INFO] ------------------------------------------------------------------------
-[INFO] Building Truth Extension for Lite Protocol Buffers 1.0-SNAPSHOT
-[INFO] ------------------------------------------------------------------------
-[INFO]
-[INFO] --- versions-maven-plugin:2.3:display-property-updates (default-cli) @ truth-liteproto-extension ---
-[INFO]
-[INFO] The following version properties are referencing the newest available version:
-[INFO]   ${auto-value.version} ......................................... 1.4.1
-[INFO] The following version property updates are available:
-[INFO]   ${findbugs.version} .................................. 3.0.1 -> 3.0.2
-[INFO]   ${protobuf.version} .................................. 3.1.0 -> 3.3.1
-[INFO]   ${guava.version} ............................... 21.0 -> 22.0-android
-[INFO]   ${error_prone_annotations.version} .................. 2.0.8 -> 2.0.19
-...
-```
-
-For release avoid updating older verisions at the last minute, as this requires
-more testing and investigation than one typically does at release.  But
-**releases are gated on any -SNAPSHOT dependencies**, so these should be
-incremented.
-
-> ***Note:*** *If any dependencies are altered, file a bug to update the
-> dependencies in the project's master branch.*
-
-
-> ***Note:*** *If there is enough dependency lag, the release should be abandoned
-> and dependencies should be incremented as a normal part of development, and
-> a release re-rolled after these have been merged into the master branch.*
-
 #### Update the project's version.
 
 Update the versions of the project and commit the changes, like so:


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Distinguish between subjects provided outside core Truth and "custom" (i.e. third-party / end-user) subjects.

941a63d0078b6c82c3ceefed96bbe5583be553a5

-------

<p> Remove section about versions:display-property-updates.

We haven't been in the habit of using SNAPSHOT dependencies, and anyway, this section would need a rewrite to switch to display-dependency-updates.

6b9e61c5094cb362955c720b68fc3689157a4dec

-------

<p> Update docs for Truth 0.42.

0c778594266bf4c729837944599a82b8ea4c004a