### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/IterableSubject.java
+++ b/core/src/main/java/com/google/common/truth/IterableSubject.java
@@ -834,12 +834,15 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       }
     }
     if (!nonIterables.isEmpty()) {
-      failWithRawMessage(
-          "The actual value is an Iterable, and you've written a test that compares it to some "
-              + "objects that are not Iterables. Did you instead mean to check whether its "
-              + "*contents* match any of the *contents* of the given values? If so, call "
-              + "containsNoneOf(...)/containsNoneIn(...) instead. Non-iterables: %s",
-          nonIterables);
+      failWithoutActual(
+          simpleFact(
+              lenientFormat(
+                  "The actual value is an Iterable, and you've written a test that compares it to "
+                      + "some objects that are not Iterables. Did you instead mean to check "
+                      + "whether its *contents* match any of the *contents* of the given values? "
+                      + "If so, call containsNoneOf(...)/containsNoneIn(...) instead. "
+                      + "Non-iterables: %s",
+                  nonIterables)));
     }
   }
 
@@ -994,13 +997,15 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       if (pairer.isPresent()) {
         List<A> keyMatches = pairer.get().pairOne(expected, getCastActual());
         if (!keyMatches.isEmpty()) {
-          subject.failWithRawMessage(
-              "Not true that %s contains exactly one element that %s <%s>. It did contain the "
-                  + "following elements with the correct key: <%s>",
-              subject.actualAsString(),
-              correspondence,
-              expected,
-              formatExtras(expected, keyMatches));
+          subject.failWithoutActual(
+              simpleFact(
+                  lenientFormat(
+                      "Not true that %s contains exactly one element that %s <%s>. It did contain "
+                          + "the following elements with the correct key: <%s>",
+                      subject.actualAsString(),
+                      correspondence,
+                      expected,
+                      formatExtras(expected, keyMatches))));
           return;
         }
       }
@@ -1016,10 +1021,12 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
         }
       }
       if (!matchingElements.isEmpty()) {
-        subject.failWithRawMessage(
-            "%s should not have contained an element that %s <%s>. "
-                + "It contained the following such elements: <%s>",
-            subject.actualAsString(), correspondence, excluded, matchingElements);
+        subject.failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "%s should not have contained an element that %s <%s>. "
+                        + "It contained the following such elements: <%s>",
+                    subject.actualAsString(), correspondence, excluded, matchingElements)));
       }
     }
 
@@ -1169,12 +1176,15 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       List<? extends A> extra = findNotIndexed(actual, mapping.keySet());
       List<? extends E> missing = findNotIndexed(expected, mapping.inverse().keySet());
       if (!missing.isEmpty() || !extra.isEmpty()) {
-        subject.failWithRawMessage(
-            "Not true that %s contains exactly one element that %s each element of <%s>. It %s",
-            subject.actualAsString(),
-            correspondence,
-            expected,
-            describeMissingOrExtra(missing, extra));
+        subject.failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s contains exactly one element that %s each element of <%s>. "
+                        + "It %s",
+                    subject.actualAsString(),
+                    correspondence,
+                    expected,
+                    describeMissingOrExtra(missing, extra))));
         return true;
       }
       return false;
@@ -1323,17 +1333,19 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       List<? extends A> extra = findNotIndexed(actual, mapping.keySet());
       List<? extends E> missing = findNotIndexed(expected, mapping.values());
       if (!missing.isEmpty() || !extra.isEmpty()) {
-        subject.failWithRawMessage(
-            "Not true that %s contains exactly one element that %s each element of <%s>. "
-                + "It contains at least one element that matches each expected element, "
-                + "and every element it contains matches at least one expected element, "
-                + "but there was no 1:1 mapping between all the actual and expected elements. "
-                + "Using the most complete 1:1 mapping (or one such mapping, if there is a tie), "
-                + "it %s",
-            subject.actualAsString(),
-            correspondence,
-            expected,
-            describeMissingOrExtra(missing, extra));
+        subject.failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s contains exactly one element that %s each element of <%s>. "
+                        + "It contains at least one element that matches each expected element, "
+                        + "and every element it contains matches at least one expected element, "
+                        + "but there was no 1:1 mapping between all the actual and expected "
+                        + "elements. Using the most complete 1:1 mapping (or one such mapping, if "
+                        + "there is a tie), it %s",
+                    subject.actualAsString(),
+                    correspondence,
+                    expected,
+                    describeMissingOrExtra(missing, extra))));
         return true;
       }
       return false;
@@ -1468,9 +1480,15 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       List<? extends E> missing = findNotIndexed(expected, mapping.inverse().keySet());
       if (!missing.isEmpty()) {
         List<? extends A> extra = findNotIndexed(actual, mapping.keySet());
-        subject.failWithRawMessage(
-            "Not true that %s contains at least one element that %s each element of <%s>. It %s",
-            subject.actualAsString(), correspondence, expected, describeMissing(missing, extra));
+        subject.failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s contains at least one element that %s each element of <%s>. "
+                        + "It %s",
+                    subject.actualAsString(),
+                    correspondence,
+                    expected,
+                    describeMissing(missing, extra))));
         return true;
       }
       return false;
@@ -1537,13 +1555,18 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       List<? extends E> missing = findNotIndexed(expected, mapping.values());
       if (!missing.isEmpty()) {
         List<? extends A> extra = findNotIndexed(actual, mapping.keySet());
-        subject.failWithRawMessage(
-            "Not true that %s contains at least one element that %s each element of <%s>. "
-                + "It contains at least one element that matches each expected element, "
-                + "but there was no 1:1 mapping between all the expected elements and any subset "
-                + "of the actual elements. Using the most complete 1:1 mapping (or one such "
-                + "mapping, if there is a tie), it %s",
-            subject.actualAsString(), correspondence, expected, describeMissing(missing, extra));
+        subject.failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s contains at least one element that %s each element of <%s>. "
+                        + "It contains at least one element that matches each expected element, "
+                        + "but there was no 1:1 mapping between all the expected elements and any "
+                        + "subset of the actual elements. Using the most complete 1:1 mapping (or "
+                        + "one such mapping, if there is a tie), it %s",
+                    subject.actualAsString(),
+                    correspondence,
+                    expected,
+                    describeMissing(missing, extra))));
         return true;
       }
       return false;
@@ -1593,19 +1616,29 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
         Pairing pairing = pairer.get().pair(iterableToList(expected), iterableToList(actual));
         if (pairing != null) {
           if (!pairing.pairedKeysToExpectedValues.isEmpty()) {
-            subject.failWithRawMessage(
-                "Not true that %s %s <%s>. It contains the following values that match by key: %s",
-                subject.actualAsString(), failVerb, expected, describeAnyMatchesByKey(pairing));
+            subject.failWithoutActual(
+                simpleFact(
+                    lenientFormat(
+                        "Not true that %s %s <%s>. It contains the following values that match by "
+                            + "key: %s",
+                        subject.actualAsString(),
+                        failVerb,
+                        expected,
+                        describeAnyMatchesByKey(pairing))));
           } else {
-            subject.failWithRawMessage(
-                "Not true that %s %s <%s>. It does not contain any matches by key, either",
-                subject.actualAsString(), failVerb, expected);
+            subject.failWithoutActual(
+                simpleFact(
+                    lenientFormat(
+                        "Not true that %s %s <%s>. It does not contain any matches by key, either",
+                        subject.actualAsString(), failVerb, expected)));
           }
         } else {
-          subject.failWithRawMessage(
-              "Not true that %s %s <%s>. (N.B. A key function which does not uniquely key the "
-                  + "expected elements was provided and has consequently been ignored.)",
-              subject.actualAsString(), failVerb, expected);
+          subject.failWithoutActual(
+              simpleFact(
+                  lenientFormat(
+                      "Not true that %s %s <%s>. (N.B. A key function which does not uniquely key "
+                          + "the expected elements was provided and has consequently been ignored.)",
+                      subject.actualAsString(), failVerb, expected)));
         }
       } else {
         subject.fail(failVerb, expected);
@@ -1685,9 +1718,15 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
                 .append(excludedItem);
           }
         }
-        subject.failWithRawMessage(
-            "Not true that %s contains no element that %s %s <%s>. It contains <[%s]>",
-            subject.actualAsString(), correspondence, excludedPrefix, excluded, presentDescription);
+        subject.failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s contains no element that %s %s <%s>. It contains <[%s]>",
+                    subject.actualAsString(),
+                    correspondence,
+                    excludedPrefix,
+                    excluded,
+                    presentDescription)));
       }
     }
 

--- a/core/src/main/java/com/google/common/truth/MapSubject.java
+++ b/core/src/main/java/com/google/common/truth/MapSubject.java
@@ -70,10 +70,12 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
 
     boolean mapEquals = containsExactlyEntriesInAnyOrder((Map<?, ?>) other, "is equal to");
     if (mapEquals) {
-      failWithRawMessage(
-          "Not true that %s is equal to <%s>. It is equal according to the contract of "
-              + "Map.equals(Object), but this implementation returned false",
-          actualAsString(), other);
+      failWithoutActual(
+          simpleFact(
+              lenientFormat(
+                  "Not true that %s is equal to <%s>. It is equal according to the contract of "
+                      + "Map.equals(Object), but this implementation returned false",
+                  actualAsString(), other)));
     }
   }
 
@@ -149,10 +151,12 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
             keys.add(actualEntry.getKey());
           }
         }
-        failWithRawMessage(
-            "Not true that %s contains entry <%s>. "
-                + "However, the following keys are mapped to <%s>: %s",
-            actualAsString(), entry, value, keys);
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s contains entry <%s>. "
+                        + "However, the following keys are mapped to <%s>: %s",
+                    actualAsString(), entry, value, keys)));
       } else {
         fail("contains entry", entry);
       }
@@ -235,9 +239,11 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
     if (diff.isEmpty()) {
       return true;
     }
-    failWithRawMessage(
-        "Not true that %s %s <%s>. It %s",
-        actualAsString(), failVerb, expectedMap, diff.describe(VALUE_DIFFERENCE_FORMAT));
+    failWithoutActual(
+        simpleFact(
+            lenientFormat(
+                "Not true that %s %s <%s>. It %s",
+                actualAsString(), failVerb, expectedMap, diff.describe(VALUE_DIFFERENCE_FORMAT))));
     return false;
   }
 
@@ -404,7 +410,10 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
       List<?> expectedKeyOrder = Lists.newArrayList(expectedMap.keySet());
       List<?> actualKeyOrder = Lists.newArrayList(actual().keySet());
       if (!actualKeyOrder.equals(expectedKeyOrder)) {
-        failWithRawMessage("Not true that %s %s <%s>", actualAsString(), failVerb, expectedMap);
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s %s <%s>", actualAsString(), failVerb, expectedMap)));
       }
     }
   }
@@ -480,15 +489,24 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
         // Found matching key with non-matching value.
         @NullableDecl String diff = correspondence.formatDiff(actualValue, expectedValue);
         if (diff != null) {
-          failWithRawMessage(
-              "Not true that %s contains an entry with key <%s> and a value that %s <%s>. "
-                  + "However, it has a mapping from that key to <%s> (diff: %s)",
-              actualAsString(), expectedKey, correspondence, expectedValue, actualValue, diff);
+          failWithoutActual(
+              simpleFact(
+                  lenientFormat(
+                      "Not true that %s contains an entry with key <%s> and a value that %s <%s>. "
+                          + "However, it has a mapping from that key to <%s> (diff: %s)",
+                      actualAsString(),
+                      expectedKey,
+                      correspondence,
+                      expectedValue,
+                      actualValue,
+                      diff)));
         } else {
-          failWithRawMessage(
-              "Not true that %s contains an entry with key <%s> and a value that %s <%s>. "
-                  + "However, it has a mapping from that key to <%s>",
-              actualAsString(), expectedKey, correspondence, expectedValue, actualValue);
+          failWithoutActual(
+              simpleFact(
+                  lenientFormat(
+                      "Not true that %s contains an entry with key <%s> and a value that %s <%s>. "
+                          + "However, it has a mapping from that key to <%s>",
+                      actualAsString(), expectedKey, correspondence, expectedValue, actualValue)));
         }
       } else {
         // Did not find matching key.
@@ -500,15 +518,19 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
         }
         if (!keys.isEmpty()) {
           // Found matching values with non-matching keys.
-          failWithRawMessage(
-              "Not true that %s contains an entry with key <%s> and a value that %s <%s>. "
-                  + "However, the following keys are mapped to such values: <%s>",
-              actualAsString(), expectedKey, correspondence, expectedValue, keys);
+          failWithoutActual(
+              simpleFact(
+                  lenientFormat(
+                      "Not true that %s contains an entry with key <%s> and a value that %s <%s>. "
+                          + "However, the following keys are mapped to such values: <%s>",
+                      actualAsString(), expectedKey, correspondence, expectedValue, keys)));
         } else {
           // Did not find matching key or value.
-          failWithRawMessage(
-              "Not true that %s contains an entry with key <%s> and a value that %s <%s>",
-              actualAsString(), expectedKey, correspondence, expectedValue);
+          failWithoutActual(
+              simpleFact(
+                  lenientFormat(
+                      "Not true that %s contains an entry with key <%s> and a value that %s <%s>",
+                      actualAsString(), expectedKey, correspondence, expectedValue)));
         }
       }
     }
@@ -522,10 +544,12 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
       if (actual().containsKey(excludedKey)) {
         A actualValue = getCastSubject().get(excludedKey);
         if (correspondence.compare(actualValue, excludedValue)) {
-          failWithRawMessage(
-              "Not true that %s does not contain an entry with key <%s> and a value that %s <%s>. "
-                  + "It maps that key to <%s>",
-              actualAsString(), excludedKey, correspondence, excludedValue, actualValue);
+          failWithoutActual(
+              simpleFact(
+                  lenientFormat(
+                      "Not true that %s does not contain an entry with key <%s> and a value that "
+                          + "%s <%s>. It maps that key to <%s>",
+                      actualAsString(), excludedKey, correspondence, excludedValue, actualValue)));
         }
       }
     }
@@ -581,10 +605,15 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
                     + "that %s the key and value of each entry of",
                 correspondence));
       }
-      failWithRawMessage(
-          "Not true that %s contains exactly one entry that has a key that is equal to and a value "
-              + "that %s the key and value of each entry of <%s>. It %s",
-          actualAsString(), correspondence, expectedMap, diff.describe(this.<V>valueDiffFormat()));
+      failWithoutActual(
+          simpleFact(
+              lenientFormat(
+                  "Not true that %s contains exactly one entry that has a key that is equal to "
+                      + "and a value that %s the key and value of each entry of <%s>. It %s",
+                  actualAsString(),
+                  correspondence,
+                  expectedMap,
+                  diff.describe(this.<V>valueDiffFormat()))));
       return ALREADY_FAILED;
     }
 

--- a/core/src/main/java/com/google/common/truth/MultimapSubject.java
+++ b/core/src/main/java/com/google/common/truth/MultimapSubject.java
@@ -115,9 +115,12 @@ public class MultimapSubject extends Subject<MultimapSubject, Multimap<?, ?>> {
             countDuplicatesAndAddTypeInfo(
                 retainMatchingToString(actual().entries(), entryList /* itemsToCheck */)));
       } else if (actual().containsKey(key)) {
-        failWithRawMessage(
-            "Not true that %s contains entry <%s>. However, it has a mapping from <%s> to <%s>",
-            actualAsString(), entry, key, actual().asMap().get(key));
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s contains entry <%s>. However, it has a mapping from <%s> to "
+                        + "<%s>",
+                    actualAsString(), entry, key, actual().asMap().get(key))));
       } else if (actual().containsValue(value)) {
         Set<Object> keys = new LinkedHashSet<>();
         for (Entry<?, ?> actualEntry : actual().entries()) {
@@ -125,10 +128,12 @@ public class MultimapSubject extends Subject<MultimapSubject, Multimap<?, ?>> {
             keys.add(actualEntry.getKey());
           }
         }
-        failWithRawMessage(
-            "Not true that %s contains entry <%s>. "
-                + "However, the following keys are mapped to <%s>: %s",
-            actualAsString(), entry, value, keys);
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s contains entry <%s>. "
+                        + "However, the following keys are mapped to <%s>: %s",
+                    actualAsString(), entry, value, keys)));
       } else {
         fail("contains entry", Maps.immutableEntry(key, value));
       }
@@ -165,10 +170,12 @@ public class MultimapSubject extends Subject<MultimapSubject, Multimap<?, ?>> {
         || (actual() instanceof SetMultimap && other instanceof ListMultimap)) {
       String mapType1 = (actual() instanceof ListMultimap) ? "ListMultimap" : "SetMultimap";
       String mapType2 = (other instanceof ListMultimap) ? "ListMultimap" : "SetMultimap";
-      failWithRawMessage(
-          "Not true that %s %s is equal to %s <%s>. "
-              + "A %s cannot equal a %s if either is non-empty.",
-          mapType1, actualAsString(), mapType2, other, mapType1, mapType2);
+      failWithoutActual(
+          simpleFact(
+              lenientFormat(
+                  "Not true that %s %s is equal to %s <%s>. "
+                      + "A %s cannot equal a %s if either is non-empty.",
+                  mapType1, actualAsString(), mapType2, other, mapType1, mapType2)));
     } else if (actual() instanceof ListMultimap) {
       containsExactlyEntriesIn((Multimap<?, ?>) other).inOrder();
     } else if (actual() instanceof SetMultimap) {
@@ -320,20 +327,26 @@ public class MultimapSubject extends Subject<MultimapSubject, Multimap<?, ?>> {
 
       if (!keysInOrder) {
         if (!keysWithValuesOutOfOrder.isEmpty()) {
-          failWithRawMessage(
-              "Not true that %s contains exactly <%s> in order. The keys are not in order, "
-                  + "and the values for keys <%s> are not in order either",
-              actualAsString(), expectedMultimap, keysWithValuesOutOfOrder);
+          failWithoutActual(
+              simpleFact(
+                  lenientFormat(
+                      "Not true that %s contains exactly <%s> in order. The keys are not in order, "
+                          + "and the values for keys <%s> are not in order either",
+                      actualAsString(), expectedMultimap, keysWithValuesOutOfOrder)));
         } else {
-          failWithRawMessage(
-              "Not true that %s contains exactly <%s> in order. The keys are not in order",
-              actualAsString(), expectedMultimap);
+          failWithoutActual(
+              simpleFact(
+                  lenientFormat(
+                      "Not true that %s contains exactly <%s> in order. The keys are not in order",
+                      actualAsString(), expectedMultimap)));
         }
       } else if (!keysWithValuesOutOfOrder.isEmpty()) {
-        failWithRawMessage(
-            "Not true that %s contains exactly <%s> in order. "
-                + "The values for keys <%s> are not in order",
-            actualAsString(), expectedMultimap, keysWithValuesOutOfOrder);
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s contains exactly <%s> in order. "
+                        + "The values for keys <%s> are not in order",
+                    actualAsString(), expectedMultimap, keysWithValuesOutOfOrder)));
       }
     }
   }
@@ -458,10 +471,12 @@ public class MultimapSubject extends Subject<MultimapSubject, Multimap<?, ?>> {
           }
         }
         // Found matching key with non-matching values.
-        failWithRawMessage(
-            "Not true that %s contains at least one entry with key <%s> and a value that %s <%s>. "
-                + "However, it has a mapping from that key to <%s>",
-            actualAsString(), expectedKey, correspondence, expectedValue, actualValues);
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s contains at least one entry with key <%s> and a value that "
+                        + "%s <%s>. However, it has a mapping from that key to <%s>",
+                    actualAsString(), expectedKey, correspondence, expectedValue, actualValues)));
       } else {
         // Did not find matching key.
         Set<Object> keys = new LinkedHashSet<>();
@@ -472,15 +487,20 @@ public class MultimapSubject extends Subject<MultimapSubject, Multimap<?, ?>> {
         }
         if (!keys.isEmpty()) {
           // Found matching values with non-matching keys.
-          failWithRawMessage(
-              "Not true that %s contains at least one entry with key <%s> and a value that %s <%s>."
-                  + " However, the following keys are mapped to such values: <%s>",
-              actualAsString(), expectedKey, correspondence, expectedValue, keys);
+          failWithoutActual(
+              simpleFact(
+                  lenientFormat(
+                      "Not true that %s contains at least one entry with key <%s> and a value that "
+                          + "%s <%s>. However, the following keys are mapped to such values: <%s>",
+                      actualAsString(), expectedKey, correspondence, expectedValue, keys)));
         } else {
           // Did not find matching key or value.
-          failWithRawMessage(
-              "Not true that %s contains at least one entry with key <%s> and a value that %s <%s>",
-              actualAsString(), expectedKey, correspondence, expectedValue);
+          failWithoutActual(
+              simpleFact(
+                  lenientFormat(
+                      "Not true that %s contains at least one entry with key <%s> and a value that "
+                          + "%s <%s>",
+                      actualAsString(), expectedKey, correspondence, expectedValue)));
         }
       }
     }
@@ -500,10 +520,16 @@ public class MultimapSubject extends Subject<MultimapSubject, Multimap<?, ?>> {
           }
         }
         if (!matchingValues.isEmpty()) {
-          failWithRawMessage(
-              "Not true that %s did not contain an entry with key <%s> and a value that %s <%s>. "
-                  + "It maps that key to the following such values: <%s>",
-              actualAsString(), excludedKey, correspondence, excludedValue, matchingValues);
+          failWithoutActual(
+              simpleFact(
+                  lenientFormat(
+                      "Not true that %s did not contain an entry with key <%s> and a value that %s <%s>. "
+                          + "It maps that key to the following such values: <%s>",
+                      actualAsString(),
+                      excludedKey,
+                      correspondence,
+                      excludedValue,
+                      matchingValues)));
         }
       }
     }

--- a/core/src/main/java/com/google/common/truth/PrimitiveDoubleArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveDoubleArraySubject.java
@@ -18,8 +18,10 @@ package com.google.common.truth;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.lenientFormat;
 import static com.google.common.truth.Correspondence.tolerance;
 import static com.google.common.truth.DoubleSubject.checkTolerance;
+import static com.google.common.truth.Fact.simpleFact;
 import static com.google.common.truth.MathUtil.equalWithinTolerance;
 import static com.google.common.truth.MathUtil.notEqualWithinTolerance;
 
@@ -181,13 +183,16 @@ public final class PrimitiveDoubleArraySubject
           expectedCount++;
         }
         if (actual.length != expectedCount) {
-          failWithRawMessage(
-              "Not true that %s has values within %s of <%s>. Expected length <%s> but got <%s>",
-              actualAsString(),
-              tolerance,
-              Iterables.toString(expected),
-              expectedCount,
-              actual.length);
+          failWithoutActual(
+              simpleFact(
+                  lenientFormat(
+                      "Not true that %s has values within %s of <%s>. Expected length <%s> but "
+                          + "got <%s>",
+                      actualAsString(),
+                      tolerance,
+                      Iterables.toString(expected),
+                      expectedCount,
+                      actual.length)));
           return;
         }
         if (!mismatches.isEmpty()) {

--- a/core/src/main/java/com/google/common/truth/PrimitiveFloatArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveFloatArraySubject.java
@@ -18,7 +18,9 @@ package com.google.common.truth;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.lenientFormat;
 import static com.google.common.truth.Correspondence.tolerance;
+import static com.google.common.truth.Fact.simpleFact;
 import static com.google.common.truth.FloatSubject.checkTolerance;
 import static com.google.common.truth.MathUtil.equalWithinTolerance;
 import static com.google.common.truth.MathUtil.notEqualWithinTolerance;
@@ -180,13 +182,16 @@ public final class PrimitiveFloatArraySubject
           expectedCount++;
         }
         if (actual.length != expectedCount) {
-          failWithRawMessage(
-              "Not true that %s has values within %s of <%s>. Expected length <%s> but got <%s>",
-              actualAsString(),
-              tolerance,
-              Iterables.toString(expected),
-              expectedCount,
-              actual.length);
+          failWithoutActual(
+              simpleFact(
+                  lenientFormat(
+                      "Not true that %s has values within %s of <%s>. Expected length <%s> but "
+                          + "got <%s>",
+                      actualAsString(),
+                      tolerance,
+                      Iterables.toString(expected),
+                      expectedCount,
+                      actual.length)));
           return;
         }
         if (!mismatches.isEmpty()) {

--- a/core/src/main/java/com/google/common/truth/SortedMapSubject.java
+++ b/core/src/main/java/com/google/common/truth/SortedMapSubject.java
@@ -16,6 +16,8 @@
 package com.google.common.truth;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.lenientFormat;
+import static com.google.common.truth.Fact.simpleFact;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ForwardingSortedMap;
@@ -60,16 +62,20 @@ public final class SortedMapSubject extends MapSubject {
 
     if (!Objects.equal(actualAsNavigableMap().firstKey(), key)) {
       if (actualAsNavigableMap().containsKey(key)) {
-        failWithRawMessage(
-            "Not true that %s has first key <%s>. "
-                + "It does contain this key, but the first key is <%s>",
-            actualAsString(), key, actualAsNavigableMap().firstKey());
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s has first key <%s>. "
+                        + "It does contain this key, but the first key is <%s>",
+                    actualAsString(), key, actualAsNavigableMap().firstKey())));
         return;
       }
-      failWithRawMessage(
-          "Not true that %s has first key <%s>. "
-              + "It does not contain this key, and the first key is <%s>",
-          actualAsString(), key, actualAsNavigableMap().firstKey());
+      failWithoutActual(
+          simpleFact(
+              lenientFormat(
+                  "Not true that %s has first key <%s>. "
+                      + "It does not contain this key, and the first key is <%s>",
+                  actualAsString(), key, actualAsNavigableMap().firstKey())));
     }
   }
 
@@ -85,23 +91,34 @@ public final class SortedMapSubject extends MapSubject {
     if (!Objects.equal(actualFirstEntry, expectedEntry)) {
       Object actualFirstKey = actualFirstEntry.getKey();
       if (actualAsNavigableMap().entrySet().contains(expectedEntry)) {
-        failWithRawMessage(
-            "Not true that %s has first entry <%s>. "
-                + "It does contain this entry, but the first entry is <%s>",
-            actualAsString(), expectedEntry, actualFirstEntry);
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s has first entry <%s>. "
+                        + "It does contain this entry, but the first entry is <%s>",
+                    actualAsString(), expectedEntry, actualFirstEntry)));
       } else if (Objects.equal(actualFirstKey, key)) {
-        failWithRawMessage(
-            "Not true that %s has first entry <%s>, the first value is <%s>",
-            actualAsString(), expectedEntry, actualFirstEntry.getValue());
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s has first entry <%s>, the first value is <%s>",
+                    actualAsString(), expectedEntry, actualFirstEntry.getValue())));
       } else if (Objects.equal(actualFirstEntry.getValue(), value)) {
-        failWithRawMessage(
-            "Not true that %s has first entry <%s>, the first key is <%s>",
-            actualAsString(), expectedEntry, actualFirstKey);
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s has first entry <%s>, the first key is <%s>",
+                    actualAsString(), expectedEntry, actualFirstKey)));
       } else if (actualAsNavigableMap().containsKey(key)) {
-        failWithRawMessage(
-            "Not true that %s has first entry <%s>. It does contain this key, "
-                + "but the key is mapped to <%s>, and the first entry is <%s>",
-            actualAsString(), expectedEntry, actualAsNavigableMap().get(key), actualFirstEntry);
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s has first entry <%s>. It does contain this key, "
+                        + "but the key is mapped to <%s>, and the first entry is <%s>",
+                    actualAsString(),
+                    expectedEntry,
+                    actualAsNavigableMap().get(key),
+                    actualFirstEntry)));
       } else if (actualAsNavigableMap().containsValue(value)) {
         Set<Object> keys = new LinkedHashSet<>();
         for (Entry<?, ?> actualEntry : actualAsNavigableMap().entrySet()) {
@@ -109,15 +126,19 @@ public final class SortedMapSubject extends MapSubject {
             keys.add(actualEntry.getKey());
           }
         }
-        failWithRawMessage(
-            "Not true that %s has first entry <%s>. It does contain this value, but the value is "
-                + "mapped from the keys <%s>, and the first entry is <%s>",
-            actualAsString(), expectedEntry, keys, actualFirstEntry);
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s has first entry <%s>. It does contain this value, but the "
+                        + "value is mapped from the keys <%s>, and the first entry is <%s>",
+                    actualAsString(), expectedEntry, keys, actualFirstEntry)));
       } else {
-        failWithRawMessage(
-            "Not true that %s has first entry <%s>. "
-                + "It does not contain this entry, and the first entry is <%s>",
-            actualAsString(), expectedEntry, actualFirstEntry);
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s has first entry <%s>. "
+                        + "It does not contain this entry, and the first entry is <%s>",
+                    actualAsString(), expectedEntry, actualFirstEntry)));
       }
     }
   }
@@ -131,16 +152,20 @@ public final class SortedMapSubject extends MapSubject {
 
     if (!Objects.equal(actualAsNavigableMap().lastKey(), key)) {
       if (actualAsNavigableMap().containsKey(key)) {
-        failWithRawMessage(
-            "Not true that %s has last key <%s>. "
-                + "It does contain this key, but the last key is <%s>",
-            actualAsString(), key, actualAsNavigableMap().lastKey());
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s has last key <%s>. "
+                        + "It does contain this key, but the last key is <%s>",
+                    actualAsString(), key, actualAsNavigableMap().lastKey())));
         return;
       }
-      failWithRawMessage(
-          "Not true that %s has last key <%s>. "
-              + "It does not contain this key, and the last key is <%s>",
-          actualAsString(), key, actualAsNavigableMap().lastKey());
+      failWithoutActual(
+          simpleFact(
+              lenientFormat(
+                  "Not true that %s has last key <%s>. "
+                      + "It does not contain this key, and the last key is <%s>",
+                  actualAsString(), key, actualAsNavigableMap().lastKey())));
     }
   }
 
@@ -156,23 +181,34 @@ public final class SortedMapSubject extends MapSubject {
     if (!Objects.equal(actualLastEntry, expectedEntry)) {
       Object actualLastKey = actualLastEntry.getKey();
       if (actualAsNavigableMap().entrySet().contains(expectedEntry)) {
-        failWithRawMessage(
-            "Not true that %s has last entry <%s>. "
-                + "It does contain this entry, but the last entry is <%s>",
-            actualAsString(), expectedEntry, actualLastEntry);
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s has last entry <%s>. "
+                        + "It does contain this entry, but the last entry is <%s>",
+                    actualAsString(), expectedEntry, actualLastEntry)));
       } else if (Objects.equal(actualLastKey, key)) {
-        failWithRawMessage(
-            "Not true that %s has last entry <%s>, the last value is <%s>",
-            actualAsString(), expectedEntry, actualLastEntry.getValue());
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s has last entry <%s>, the last value is <%s>",
+                    actualAsString(), expectedEntry, actualLastEntry.getValue())));
       } else if (Objects.equal(actualLastEntry.getValue(), value)) {
-        failWithRawMessage(
-            "Not true that %s has last entry <%s>, the last key is <%s>",
-            actualAsString(), expectedEntry, actualLastKey);
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s has last entry <%s>, the last key is <%s>",
+                    actualAsString(), expectedEntry, actualLastKey)));
       } else if (actualAsNavigableMap().containsKey(key)) {
-        failWithRawMessage(
-            "Not true that %s has last entry <%s>. It does contain this key, "
-                + "but the key is mapped to <%s>, and the last entry is <%s>",
-            actualAsString(), expectedEntry, actualAsNavigableMap().get(key), actualLastEntry);
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s has last entry <%s>. It does contain this key, "
+                        + "but the key is mapped to <%s>, and the last entry is <%s>",
+                    actualAsString(),
+                    expectedEntry,
+                    actualAsNavigableMap().get(key),
+                    actualLastEntry)));
       } else if (actualAsNavigableMap().containsValue(value)) {
         Set<Object> keys = new LinkedHashSet<>();
         for (Entry<?, ?> actualEntry : actualAsNavigableMap().entrySet()) {
@@ -180,15 +216,19 @@ public final class SortedMapSubject extends MapSubject {
             keys.add(actualEntry.getKey());
           }
         }
-        failWithRawMessage(
-            "Not true that %s has last entry <%s>. It does contain this value, but the value is "
-                + "mapped from the keys <%s>, and the last entry is <%s>",
-            actualAsString(), expectedEntry, keys, actualLastEntry);
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s has last entry <%s>. It does contain this value, but the "
+                        + "value is mapped from the keys <%s>, and the last entry is <%s>",
+                    actualAsString(), expectedEntry, keys, actualLastEntry)));
       } else {
-        failWithRawMessage(
-            "Not true that %s has last entry <%s>. "
-                + "It does not contain this entry, and the last entry is <%s>",
-            actualAsString(), expectedEntry, actualLastEntry);
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s has last entry <%s>. "
+                        + "It does not contain this entry, and the last entry is <%s>",
+                    actualAsString(), expectedEntry, actualLastEntry)));
       }
     }
   }

--- a/core/src/main/java/com/google/common/truth/SortedSetSubject.java
+++ b/core/src/main/java/com/google/common/truth/SortedSetSubject.java
@@ -16,6 +16,8 @@
 package com.google.common.truth;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.lenientFormat;
+import static com.google.common.truth.Fact.simpleFact;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ForwardingSortedSet;
@@ -53,16 +55,20 @@ public final class SortedSetSubject extends IterableSubject {
 
     if (!Objects.equal(actualAsNavigableSet().first(), element)) {
       if (actualAsNavigableSet().contains(element)) {
-        failWithRawMessage(
-            "Not true that %s has first element <%s>. "
-                + "It does contain this element, but the first element is <%s>",
-            actualAsString(), element, actualAsNavigableSet().first());
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s has first element <%s>. "
+                        + "It does contain this element, but the first element is <%s>",
+                    actualAsString(), element, actualAsNavigableSet().first())));
         return;
       }
-      failWithRawMessage(
-          "Not true that %s has first element <%s>. "
-              + "It does not contain this element, and the first element is <%s>",
-          actualAsString(), element, actualAsNavigableSet().first());
+      failWithoutActual(
+          simpleFact(
+              lenientFormat(
+                  "Not true that %s has first element <%s>. "
+                      + "It does not contain this element, and the first element is <%s>",
+                  actualAsString(), element, actualAsNavigableSet().first())));
     }
   }
 
@@ -75,16 +81,20 @@ public final class SortedSetSubject extends IterableSubject {
 
     if (!Objects.equal(actualAsNavigableSet().last(), element)) {
       if (actualAsNavigableSet().contains(element)) {
-        failWithRawMessage(
-            "Not true that %s has last element <%s>. "
-                + "It does contain this element, but the last element is <%s>",
-            actualAsString(), element, actualAsNavigableSet().last());
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s has last element <%s>. "
+                        + "It does contain this element, but the last element is <%s>",
+                    actualAsString(), element, actualAsNavigableSet().last())));
         return;
       }
-      failWithRawMessage(
-          "Not true that %s has last element <%s>. "
-              + "It does not contain this element, and the last element is <%s>",
-          actualAsString(), element, actualAsNavigableSet().last());
+      failWithoutActual(
+          simpleFact(
+              lenientFormat(
+                  "Not true that %s has last element <%s>. "
+                      + "It does not contain this element, and the last element is <%s>",
+                  actualAsString(), element, actualAsNavigableSet().last())));
     }
   }
 

--- a/core/src/test/java/com/google/common/truth/ChainingTest.java
+++ b/core/src/test/java/com/google/common/truth/ChainingTest.java
@@ -16,6 +16,7 @@
 
 package com.google.common.truth;
 
+import static com.google.common.truth.Fact.simpleFact;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assert_;
 
@@ -237,7 +238,7 @@ public final class ChainingTest extends BaseSubjectTestCase {
 
     /** Runs a check that always fails with the generic message "message." */
     void isThePresentKingOfFrance() {
-      failWithRawMessage("message");
+      failWithoutActual(simpleFact("message"));
     }
 
     void doCheckFail() {

--- a/core/src/test/java/com/google/common/truth/ExpectFailureTest.java
+++ b/core/src/test/java/com/google/common/truth/ExpectFailureTest.java
@@ -15,6 +15,8 @@
  */
 package com.google.common.truth;
 
+import static com.google.common.base.Strings.lenientFormat;
+import static com.google.common.truth.Fact.simpleFact;
 import static com.google.common.truth.Truth.assertThat;
 
 import org.junit.Before;
@@ -146,8 +148,10 @@ public class ExpectFailureTest {
     @Override
     public void isEqualTo(Object expected) {
       if (!actual().equals(expected)) {
-        failWithRawMessage("expected <%s> is equal to <%s>", actual(), expected);
-        failWithRawMessage("expected <%s> is equal to <%s>", expected, actual());
+        failWithoutActual(
+            simpleFact(lenientFormat("expected <%s> is equal to <%s>", actual(), expected)));
+        failWithoutActual(
+            simpleFact(lenientFormat("expected <%s> is equal to <%s>", expected, actual())));
       }
     }
 

--- a/extensions/liteproto/pom.xml
+++ b/extensions/liteproto/pom.xml
@@ -15,12 +15,6 @@
     An extension for the Truth test assertion framework supporting the Lite
     version of Protocol Buffers.
   </description>
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <protobuf.lite.version>3.0.1</protobuf.lite.version>
-    <protobuf.lite.protoc.version>3.1.0</protobuf.lite.protoc.version>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>com.google.truth</groupId>
@@ -51,7 +45,6 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-lite</artifactId>
-      <version>${protobuf.lite.version}</version>
       <!-- protobuf-lite is not compatible with protobuf-java, so we mark it optional. -->
       <optional>true</optional>
     </dependency>
@@ -61,7 +54,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.5.0.Final</version>
+        <version>${os-maven-plugin.version}</version>
       </extension>
     </extensions>
 
@@ -72,9 +65,8 @@
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
-        <version>0.5.1</version>
         <configuration>
-          <protocArtifact>com.google.protobuf:protoc:${protobuf.lite.protoc.version}:exe:${os.detected.classifier}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:${protobuf-lite.protoc.version}:exe:${os.detected.classifier}</protocArtifact>
           <includes>
             <param>test_message_lite2.proto</param>
             <param>test_message_lite3.proto</param>

--- a/extensions/liteproto/pom.xml
+++ b/extensions/liteproto/pom.xml
@@ -48,7 +48,7 @@
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
     </dependency>
-    <!-- TODO(dploch): Depend on protobuf-lite when available. -->
+    <!-- TODO(user): Depend on protobuf-lite when available. -->
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>

--- a/extensions/liteproto/pom.xml
+++ b/extensions/liteproto/pom.xml
@@ -18,8 +18,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <!-- TODO(cgruber): Add protoc dependencies to support tests. -->
-    <maven.test.skip>true</maven.test.skip>
+    <protobuf.lite.version>3.0.1</protobuf.lite.version>
+    <protobuf.lite.protoc.version>3.1.0</protobuf.lite.protoc.version>
   </properties>
   <dependencies>
     <dependency>
@@ -48,23 +48,47 @@
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
     </dependency>
-    <!-- TODO(user): Depend on protobuf-lite when available. -->
     <dependency>
       <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
+      <artifactId>protobuf-lite</artifactId>
+      <version>${protobuf.lite.version}</version>
+      <!-- protobuf-lite is not compatible with protobuf-java, so we mark it optional. -->
+      <optional>true</optional>
     </dependency>
   </dependencies>
   <build>
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.5.0.Final</version>
+      </extension>
+    </extensions>
+
     <plugins>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
       </plugin>
-      <!-- TODO(cgruber): Add protoc dependencies to support tests. -->
       <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>0.5.1</version>
         <configuration>
-          <skip>true</skip>
+          <protocArtifact>com.google.protobuf:protoc:${protobuf.lite.protoc.version}:exe:${os.detected.classifier}</protocArtifact>
+          <includes>
+            <param>test_message_lite2.proto</param>
+            <param>test_message_lite3.proto</param>
+          </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>build-test-protos</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/extensions/liteproto/src/main/java/com/google/common/truth/extensions/proto/LiteProtoSubject.java
+++ b/extensions/liteproto/src/main/java/com/google/common/truth/extensions/proto/LiteProtoSubject.java
@@ -16,6 +16,9 @@
 
 package com.google.common.truth.extensions.proto;
 
+import static com.google.common.base.Strings.lenientFormat;
+import static com.google.common.truth.Fact.simpleFact;
+
 import com.google.common.base.Objects;
 import com.google.common.truth.FailureMetadata;
 import com.google.common.truth.IntegerSubject;
@@ -102,12 +105,14 @@ public class LiteProtoSubject<S extends LiteProtoSubject<S, M>, M extends Messag
     if (actual() == null || expected == null) {
       super.isEqualTo(expected);
     } else if (actual().getClass() != expected.getClass()) {
-      failWithRawMessage(
-          "Not true that (%s) %s is equal to the expected (%s) object. "
-              + "They are not of the same class.",
-          actual().getClass().getName(),
-          internalCustomName() != null ? internalCustomName() + " (proto)" : "proto",
-          expected.getClass().getName());
+      failWithoutActual(
+          simpleFact(
+              lenientFormat(
+                  "Not true that (%s) %s is equal to the expected (%s) object. "
+                      + "They are not of the same class.",
+                  actual().getClass().getName(),
+                  internalCustomName() != null ? internalCustomName() + " (proto)" : "proto",
+                  expected.getClass().getName())));
     } else {
       /*
        * TODO(cpovirk): If we someday let subjects override formatActualOrExpected(), change this
@@ -139,9 +144,11 @@ public class LiteProtoSubject<S extends LiteProtoSubject<S, M>, M extends Messag
       if (actual() == null) {
         super.isNotEqualTo(expected);
       } else {
-        failWithRawMessage(
-            "Not true that protos are different. Both are (%s) <%s>.",
-            actual().getClass().getName(), getTrimmedToString(actual()));
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that protos are different. Both are (%s) <%s>.",
+                    actual().getClass().getName(), getTrimmedToString(actual()))));
       }
     }
   }
@@ -158,20 +165,27 @@ public class LiteProtoSubject<S extends LiteProtoSubject<S, M>, M extends Messag
   /** Checks whether the subject is a {@link MessageLite} with no fields set. */
   public void isEqualToDefaultInstance() {
     if (actual() == null) {
-      failWithRawMessage(
-          "Not true that %s is a default proto instance. It is null.", actualAsString());
+      failWithoutActual(
+          simpleFact(
+              lenientFormat(
+                  "Not true that %s is a default proto instance. It is null.", actualAsString())));
     } else if (!actual().equals(actual().getDefaultInstanceForType())) {
-      failWithRawMessage(
-          "Not true that %s is a default proto instance. It has set values.", actualAsString());
+      failWithoutActual(
+          simpleFact(
+              lenientFormat(
+                  "Not true that %s is a default proto instance. It has set values.",
+                  actualAsString())));
     }
   }
 
   /** Checks whether the subject is not equivalent to a {@link MessageLite} with no fields set. */
   public void isNotEqualToDefaultInstance() {
     if (actual() != null && actual().equals(actual().getDefaultInstanceForType())) {
-      failWithRawMessage(
-          "Not true that (%s) %s is not a default proto instance. It has no set values.",
-          actual().getClass().getName(), actualAsString());
+      failWithoutActual(
+          simpleFact(
+              lenientFormat(
+                  "Not true that (%s) %s is not a default proto instance. It has no set values.",
+                  actual().getClass().getName(), actualAsString())));
     }
   }
 
@@ -182,10 +196,12 @@ public class LiteProtoSubject<S extends LiteProtoSubject<S, M>, M extends Messag
   public void hasAllRequiredFields() {
     if (!actual().isInitialized()) {
       // MessageLite doesn't support reflection so this is the best we can do.
-      failWithRawMessage(
-          "Not true that %s has all required fields set. "
-              + "(Lite runtime could not determine which fields were missing.)",
-          actualAsString());
+      failWithoutActual(
+          simpleFact(
+              lenientFormat(
+                  "Not true that %s has all required fields set. "
+                      + "(Lite runtime could not determine which fields were missing.)",
+                  actualAsString())));
     }
   }
 

--- a/extensions/liteproto/src/test/proto/test_message_lite2.proto
+++ b/extensions/liteproto/src/test/proto/test_message_lite2.proto
@@ -6,7 +6,6 @@ option optimize_for = LITE_RUNTIME;
 
 option java_package = "com.google.common.truth.extensions.proto";
 option java_multiple_files = true;
-option java_api_version = 2;
 
 message TestMessageLite2 {
   optional int32 optional_int = 1;

--- a/extensions/liteproto/src/test/proto/test_message_lite3.proto
+++ b/extensions/liteproto/src/test/proto/test_message_lite3.proto
@@ -6,7 +6,6 @@ option optimize_for = LITE_RUNTIME;
 
 option java_package = "com.google.common.truth.extensions.proto";
 option java_multiple_files = true;
-option java_api_version = 2;
 
 message TestMessageLite3 {
   int32 optional_int = 1;

--- a/extensions/proto/pom.xml
+++ b/extensions/proto/pom.xml
@@ -18,8 +18,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <!-- TODO(cgruber): Add protoc dependencies to support tests. -->
-    <maven.test.skip>true</maven.test.skip>
+    <protobuf.version>3.5.1</protobuf.version>
   </properties>
   <dependencies>
     <dependency>
@@ -56,19 +55,42 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
     </dependency>
   </dependencies>
   <build>
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.5.0.Final</version>
+      </extension>
+    </extensions>
+
     <plugins>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
       </plugin>
-      <!-- TODO(cgruber): Add protoc dependencies to support tests. -->
       <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>0.5.1</version>
         <configuration>
-          <skip>true</skip>
+          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+          <includes>
+            <param>test_message2.proto</param>
+            <param>test_message3.proto</param>
+          </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>build-test-protos</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/extensions/proto/pom.xml
+++ b/extensions/proto/pom.xml
@@ -15,11 +15,6 @@
     An extension for the Truth test assertion framework supporting
     Protocol Buffers.
   </description>
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <protobuf.version>3.5.1</protobuf.version>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>com.google.truth</groupId>
@@ -55,7 +50,6 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${protobuf.version}</version>
     </dependency>
   </dependencies>
   <build>
@@ -63,7 +57,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.5.0.Final</version>
+        <version>${os-maven-plugin.version}</version>
       </extension>
     </extensions>
 
@@ -74,9 +68,8 @@
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
-        <version>0.5.1</version>
         <configuration>
-          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:${protobuf.protoc.version}:exe:${os.detected.classifier}</protocArtifact>
           <includes>
             <param>test_message2.proto</param>
             <param>test_message3.proto</param>

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoSubject.java
@@ -17,7 +17,9 @@
 package com.google.common.truth.extensions.proto;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.lenientFormat;
 import static com.google.common.collect.Lists.asList;
+import static com.google.common.truth.Fact.simpleFact;
 import static com.google.common.truth.extensions.proto.FieldScopeUtil.asList;
 
 import com.google.common.base.Objects;
@@ -325,9 +327,11 @@ public class ProtoSubject<S extends ProtoSubject<S, M>, M extends Message>
   @Override
   public void hasAllRequiredFields() {
     if (!actual().isInitialized()) {
-      failWithRawMessage(
-          "Not true that %s has all required fields set. Missing: %s",
-          actualAsString(), actual().findInitializationErrors());
+      failWithoutActual(
+          simpleFact(
+              lenientFormat(
+                  "Not true that %s has all required fields set. Missing: %s",
+                  actualAsString(), actual().findInitializationErrors())));
     }
   }
 

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/FieldScopesTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/FieldScopesTest.java
@@ -30,6 +30,7 @@ import com.google.protobuf.UnknownFieldSet;
 import com.google.protobuf.UnknownFieldSet.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -780,7 +781,7 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
     messages.add(null);
 
     expectThat(listOf(message1, message2))
-        .withPartialScope(FieldScopes.fromSetFields(listOf()))
+        .withPartialScope(FieldScopes.fromSetFields(Collections.<Message>emptyList()))
         .containsExactly(eqIgnoredMessage1, eqIgnoredMessage2);
     expectThat(listOf(message1, message2))
         .withPartialScope(FieldScopes.fromSetFields(messages))
@@ -788,7 +789,7 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
 
     expectFailureWhenTesting()
         .that(listOf(message1, message2))
-        .withPartialScope(FieldScopes.fromSetFields(listOf()))
+        .withPartialScope(FieldScopes.fromSetFields(Collections.<Message>emptyList()))
         .containsNoneOf(eqIgnoredMessage1, eqIgnoredMessage2);
 
     expectFailureWhenTesting()

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/IterableOfProtosSubjectTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/IterableOfProtosSubjectTest.java
@@ -19,6 +19,7 @@ package com.google.common.truth.extensions.proto;
 import com.google.common.base.Function;
 import com.google.protobuf.Message;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -58,13 +59,13 @@ public class IterableOfProtosSubjectTest extends ProtoSubjectTestBase {
 
   @Test
   public void testPlain_isEmpty() {
-    expectThat(listOf()).isEmpty();
+    expectThat(Collections.<Message>emptyList()).isEmpty();
     expectThat(listOf(message1)).isNotEmpty();
 
     expectFailureWhenTesting().that(listOf(message1)).isEmpty();
     expectThatFailure().isNotNull();
 
-    expectFailureWhenTesting().that(listOf()).isNotEmpty();
+    expectFailureWhenTesting().that(Collections.<Message>emptyList()).isNotEmpty();
     expectThatFailure().isNotNull();
   }
 

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubjectTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubjectTest.java
@@ -71,13 +71,13 @@ public class MapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
 
   @Test
   public void testPlain_isEmpty() {
-    expectThat(ImmutableMap.of()).isEmpty();
+    expectThat(ImmutableMap.<Object, Message>of()).isEmpty();
     expectThat(mapOf(1, message1)).isNotEmpty();
 
     expectFailureWhenTesting().that(mapOf(1, message1)).isEmpty();
     expectThatFailure().isNotNull();
 
-    expectFailureWhenTesting().that(ImmutableMap.of()).isNotEmpty();
+    expectFailureWhenTesting().that(ImmutableMap.<Object, Message>of()).isNotEmpty();
     expectThatFailure().isNotNull();
   }
 

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubjectTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubjectTest.java
@@ -58,13 +58,13 @@ public class MultimapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
 
   @Test
   public void testPlain_isEmpty() {
-    expectThat(ImmutableMultimap.of()).isEmpty();
+    expectThat(ImmutableMultimap.<Object, Message>of()).isEmpty();
     expectThat(multimapOf(1, message1)).isNotEmpty();
 
     expectFailureWhenTesting().that(multimapOf(1, message1)).isEmpty();
     expectThatFailure().isNotNull();
 
-    expectFailureWhenTesting().that(ImmutableMap.of()).isNotEmpty();
+    expectFailureWhenTesting().that(ImmutableMap.<Object, Message>of()).isNotEmpty();
     expectThatFailure().isNotNull();
   }
 
@@ -131,8 +131,8 @@ public class MultimapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
 
   @Test
   public void testPlain_containsExactlyNoArgs() {
-    expectThat(ImmutableMultimap.of()).containsExactly();
-    expectThat(ImmutableMultimap.of()).containsExactly().inOrder();
+    expectThat(ImmutableMultimap.<Object, Message>of()).containsExactly();
+    expectThat(ImmutableMultimap.<Object, Message>of()).containsExactly().inOrder();
 
     expectFailureWhenTesting().that(multimapOf(1, message1)).containsExactly();
     expectThatFailure().isNotNull();
@@ -235,8 +235,10 @@ public class MultimapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
 
   @Test
   public void testFluent_containsExactly_noArgs() {
-    expectThat(ImmutableMultimap.of()).ignoringRepeatedFieldOrderForValues().containsExactly();
-    expectThat(ImmutableMultimap.of())
+    expectThat(ImmutableMultimap.<Object, Message>of())
+        .ignoringRepeatedFieldOrderForValues()
+        .containsExactly();
+    expectThat(ImmutableMultimap.<Object, Message>of())
         .ignoringRepeatedFieldOrderForValues()
         .containsExactly()
         .inOrder();

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTestBase.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTestBase.java
@@ -62,7 +62,6 @@ public class ProtoSubjectTestBase {
 
   private static final TextFormat.Parser PARSER =
       TextFormat.Parser.newBuilder()
-          .setAllowUnknownFields(false)
           .setSingularOverwritePolicy(
               TextFormat.Parser.SingularOverwritePolicy.FORBID_SINGULAR_OVERWRITES)
           .build();

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/proto_files/METADATA
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/proto_files/METADATA
@@ -1,5 +1,0 @@
-tricorder: {
-  # Test protos are never persisted, so it is fine to change them in
-  # breaking ways.
-  disable: ProtoBestPractices
-}

--- a/extensions/proto/src/test/proto/test_message2.proto
+++ b/extensions/proto/src/test/proto/test_message2.proto
@@ -4,7 +4,6 @@ package com.google.common.truth.extensions.proto;
 
 option java_package = "com.google.common.truth.extensions.proto";
 option java_multiple_files = true;
-option java_api_version = 2;
 
 // For brevity: o_ means 'optional', r_ means 'repeated'
 

--- a/extensions/proto/src/test/proto/test_message3.proto
+++ b/extensions/proto/src/test/proto/test_message3.proto
@@ -4,7 +4,6 @@ package com.google.common.truth.extensions.proto;
 
 option java_package = "com.google.common.truth.extensions.proto";
 option java_multiple_files = true;
-option java_api_version = 2;
 
 // For brevity: o_ means 'optional', r_ means 'repeated'
 

--- a/extensions/re2j/src/main/java/com/google/common/truth/extensions/re2j/Re2jSubjects.java
+++ b/extensions/re2j/src/main/java/com/google/common/truth/extensions/re2j/Re2jSubjects.java
@@ -15,6 +15,9 @@
  */
 package com.google.common.truth.extensions.re2j;
 
+import static com.google.common.base.Strings.lenientFormat;
+import static com.google.common.truth.Fact.simpleFact;
+
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.truth.FailureMetadata;
 import com.google.common.truth.Subject;
@@ -99,15 +102,20 @@ public final class Re2jSubjects {
     @GwtIncompatible("com.google.re2j.Pattern")
     public void containsMatch(Pattern pattern) {
       if (!pattern.matcher(actual()).find()) {
-        failWithRawMessage(
-            "%s should have contained a match for <%s>", actualAsString(), pattern);
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "%s should have contained a match for <%s>", actualAsString(), pattern)));
       }
     }
 
     /** Fails if the string does not contain a match on the given regex. */
     public void containsMatch(String regex) {
       if (!doContainsMatch(actual(), regex)) {
-        failWithRawMessage("%s should have contained a match for <%s>", actualAsString(), regex);
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "%s should have contained a match for <%s>", actualAsString(), regex)));
       }
     }
 
@@ -115,16 +123,20 @@ public final class Re2jSubjects {
     @GwtIncompatible("com.google.re2j.Pattern")
     public void doesNotContainMatch(Pattern pattern) {
       if (pattern.matcher(actual()).find()) {
-        failWithRawMessage(
-            "%s should not have contained a match for <%s>", actualAsString(), pattern);
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "%s should not have contained a match for <%s>", actualAsString(), pattern)));
       }
     }
 
     /** Fails if the string contains a match on the given regex. */
     public void doesNotContainMatch(String regex) {
       if (doContainsMatch(actual(), regex)) {
-        failWithRawMessage(
-            "%s should not have contained a match for <%s>", actualAsString(), regex);
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "%s should not have contained a match for <%s>", actualAsString(), regex)));
       }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,10 @@
   <packaging>pom</packaging>
   <name>Truth (Parent)</name>
   <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+    <!-- Property for a plugin for which pluginManagement hasn't been working for us. -->
     <maven-javadoc-plugin.version>3.0.0</maven-javadoc-plugin.version>
 
     <!-- Properties for multiple-artifact deps. -->
@@ -22,6 +26,14 @@
     <checker-framework.version>2.5.3</checker-framework.version>
     <guava.version>25.1</guava.version>
     <gwt.version>2.8.2</gwt.version>
+    <protobuf.version>3.6.0</protobuf.version>
+    <!-- Property for protobuf-lite protocArtifact, which isn't a "normal" Maven dep. -->
+    <protobuf-lite.protoc.version>3.1.0</protobuf-lite.protoc.version>
+    <!-- Property for protobuf-java protocArtifact, which ought to be the same as protobuf.version but can't be internally at the moment. -->
+    <protobuf.protoc.version>3.5.1</protobuf.protoc.version>
+
+    <!-- Property for an extension, since Maven doesn't have extensionManagement. -->
+    <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -89,7 +101,12 @@
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
-        <version>3.6.0</version>
+        <version>${protobuf.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-lite</artifactId>
+        <version>3.0.1</version>
       </dependency>
       <dependency>
         <groupId>com.google.re2j</groupId>
@@ -248,6 +265,11 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>gwt-maven-plugin</artifactId>
           <version>${gwt.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.xolstice.maven.plugins</groupId>
+          <artifactId>protobuf-maven-plugin</artifactId>
+          <version>0.5.1</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Make link point where it claims to.

340dbb4e7e49060271e645286c836256b2e659c1

-------

<p> Get tests working in open-source for proto-truth

RELNOTES=Tests for proto-truth enabled

aa808eae2b776f272269ec109082c64ef926a199

-------

<p> Pull versions from the protobuf extensions up into the parent POM.

The only change to the effective POM (aside from new properties and dependencyManagement) is to update protobuf-java from 3.5.1 to 3.6.0.

While we're at it, set UTF-8 everywhere, not just for the protobuf extensions.

08b37a43b63f4f472fb4188831ce5dd4d52e15c0

-------

<p> Migrate callers of Truth's Subject.failWithRawMessage to Subject.failWithoutActual

Requires the use of Guava 25.1 for Strings.lenientFormat and Truth 0.41 for Subject.failWithoutActual

RELNOTES: Migrated from Subject.failWithRawMessage to Subject.failWithoutActual

86334f1b35aeaa02d03e6ac3fc3cc559fdaa8a16