### PR TITLE
Moe Sync

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,10 +18,16 @@
       <groupId>org.checkerframework</groupId>
       <artifactId>checker-compat-qual</artifactId>
     </dependency>
-    <!-- Manually add a dependency that guava-gwt needs but doesn't declare as of May 2018. -->
+    <!--
+      Manually add a dependency that guava-gwt needs but doesn't declare as of May 2018.
+      But only in the test scope, since that's the only place that _we_ need it.
+      _Downstream users_ might need to add it manually, as we've done here, but only until we fix guava-gwt and update Truth to use the new version.
+      And anyway, the current setup is causing users problems, since checker-qual is built for Java 8: https://github.com/google/truth/issues/479
+      -->
     <dependency>
       <groupId>org.checkerframework</groupId>
       <artifactId>checker-qual</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/core/src/main/java/com/google/common/truth/StackTraceCleaner.java
+++ b/core/src/main/java/com/google/common/truth/StackTraceCleaner.java
@@ -88,6 +88,14 @@ final class StackTraceCleaner {
         endIndex++) {
       // Find last frame of setup frames, and remove from there down.
     }
+    /*
+     * If the stack trace would be empty, the error was probably thrown from "JUnit infrastructure"
+     * frames. Keep those frames around (though much of JUnit itself and related startup frames will
+     * still be removed by the remainder of this method) so that the user sees a useful stack.
+     */
+    if (!(stackIndex < endIndex)) {
+      endIndex = stackFrames.length;
+    }
 
     for (; stackIndex < endIndex; stackIndex++) {
       StackTraceElementWrapper stackTraceElementWrapper =
@@ -174,30 +182,75 @@ final class StackTraceCleaner {
     currentStreakLength = 0;
   }
 
-  private static final ImmutableSet<Class<?>> TRUTH_ENTRANCE_CLASSES =
-      ImmutableSet.<Class<?>>of(Subject.class, StandardSubjectBuilder.class);
+  private static final ImmutableSet<Class<?>> SUBJECT_CLASS =
+      ImmutableSet.<Class<?>>of(Subject.class);
+
+  private static final ImmutableSet<Class<?>> STANDARD_SUBJECT_BUILDER_CLASS =
+      ImmutableSet.<Class<?>>of(StandardSubjectBuilder.class);
 
   private static boolean isTruthEntrance(StackTraceElement stackTraceElement) {
-    return isFromClass(stackTraceElement, TRUTH_ENTRANCE_CLASSES);
+    return isFromClassOrClassNestedInside(stackTraceElement, SUBJECT_CLASS)
+        /*
+         * Don't match classes _nested inside_ StandardSubjectBuilder because that would match
+         * Expect's Statement implementation. While we want to strip everything from there _down_, we
+         * don't want to strip everything from there _up_ (which would strip the test class itself!).
+         *
+         * (StandardSubjectBuilder is listed here only for its fail() methods, anyway, so we don't
+         * have to worry about nested classes like we do with Subject.)
+         */
+        || isFromClassDirectly(stackTraceElement, STANDARD_SUBJECT_BUILDER_CLASS);
   }
 
   private static final ImmutableSet<Class<?>> JUNIT_INFRASTRUCTURE_CLASSES =
       ImmutableSet.<Class<?>>of(Runner.class, Statement.class);
 
   private static boolean isJUnitIntrastructure(StackTraceElement stackTraceElement) {
-    return isFromClass(stackTraceElement, JUNIT_INFRASTRUCTURE_CLASSES);
+    // It's not clear whether looking at nested classes here is useful, harmful, or neutral.
+    return isFromClassOrClassNestedInside(stackTraceElement, JUNIT_INFRASTRUCTURE_CLASSES);
   }
 
-  private static boolean isFromClass(
-      StackTraceElement stackTraceElement, ImmutableSet<Class<?>> classes) {
+  private static boolean isFromClassOrClassNestedInside(
+      StackTraceElement stackTraceElement, ImmutableSet<Class<?>> recognizedClasses) {
     Class<?> stackClass;
     try {
       stackClass = Class.forName(stackTraceElement.getClassName());
     } catch (ClassNotFoundException e) {
       return false;
     }
-    for (Class<?> knownEntranceClass : classes) {
-      if (knownEntranceClass.isAssignableFrom(stackClass)) {
+    try {
+      for (; stackClass != null; stackClass = stackClass.getEnclosingClass()) {
+        for (Class<?> recognizedClass : recognizedClasses) {
+          if (recognizedClass.isAssignableFrom(stackClass)) {
+            return true;
+          }
+        }
+      }
+    } catch (Error e) {
+      if (e.getClass().getName().equals("com.google.j2objc.ReflectionStrippedError")) {
+        /*
+         * We're running under j2objc without reflection. Skip testing the enclosing classes. At
+         * least we tested the class itself against all the recognized classes.
+         *
+         * TODO(cpovirk): The smarter thing might be to guess the name of the enclosing classes by
+         * removing "$Foo" from the end of the name. But this should be good enough for now.
+         */
+        return false;
+      }
+      throw e;
+    }
+    return false;
+  }
+
+  private static boolean isFromClassDirectly(
+      StackTraceElement stackTraceElement, ImmutableSet<Class<?>> recognizedClasses) {
+    Class<?> stackClass;
+    try {
+      stackClass = Class.forName(stackTraceElement.getClassName());
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+    for (Class<?> recognizedClass : recognizedClasses) {
+      if (recognizedClass.isAssignableFrom(stackClass)) {
         return true;
       }
     }
@@ -276,6 +329,9 @@ final class StackTraceCleaner {
     private static StackFrameType forClassName(String fullyQualifiedClassName) {
       // Never remove the frames from a test class. These will probably be the frame of a failing
       // assertion.
+      // TODO(cpovirk): This is really only for tests in Truth itself, so this doesn't matter yet,
+      // but.... If the Truth tests someday start calling into nested classes, we may want to add:
+      // || fullyQualifiedClassName.contains("Test$")
       if (fullyQualifiedClassName.endsWith("Test")) {
         return StackFrameType.NEVER_REMOVE;
       }

--- a/core/src/main/java/com/google/common/truth/StackTraceCleaner.java
+++ b/core/src/main/java/com/google/common/truth/StackTraceCleaner.java
@@ -88,6 +88,14 @@ final class StackTraceCleaner {
         endIndex++) {
       // Find last frame of setup frames, and remove from there down.
     }
+    /*
+     * If the stack trace would be empty, the error was probably thrown from "JUnit infrastructure"
+     * frames. Keep those frames around (though much of JUnit itself and related startup frames will
+     * still be removed by the remainder of this method) so that the user sees a useful stack.
+     */
+    if (!(stackIndex < endIndex)) {
+      endIndex = stackFrames.length;
+    }
 
     for (; stackIndex < endIndex; stackIndex++) {
       StackTraceElementWrapper stackTraceElementWrapper =
@@ -174,21 +182,52 @@ final class StackTraceCleaner {
     currentStreakLength = 0;
   }
 
-  private static final ImmutableSet<Class<?>> TRUTH_ENTRANCE_CLASSES =
-      ImmutableSet.<Class<?>>of(Subject.class, StandardSubjectBuilder.class);
+  private static final ImmutableSet<Class<?>> SUBJECT_CLASS =
+      ImmutableSet.<Class<?>>of(Subject.class);
+
+  private static final ImmutableSet<Class<?>> STANDARD_SUBJECT_BUILDER_CLASS =
+      ImmutableSet.<Class<?>>of(StandardSubjectBuilder.class);
 
   private static boolean isTruthEntrance(StackTraceElement stackTraceElement) {
-    return isFromClass(stackTraceElement, TRUTH_ENTRANCE_CLASSES);
+    return isFromClassOrClassNestedInside(stackTraceElement, SUBJECT_CLASS)
+        /*
+         * Don't match classes _nested inside_ StandardSubjectBuilder because that would match
+         * Expect's Statement implementation. While we want to strip everything from there _down_, we
+         * don't want to strip everything from there _up_ (which would strip the test class itself!).
+         *
+         * (StandardSubjectBuilder is listed here only for its fail() methods, anyway, so we don't
+         * have to worry about nested classes like we do with Subject.)
+         */
+        || isFromClassDirectly(stackTraceElement, STANDARD_SUBJECT_BUILDER_CLASS);
   }
 
   private static final ImmutableSet<Class<?>> JUNIT_INFRASTRUCTURE_CLASSES =
       ImmutableSet.<Class<?>>of(Runner.class, Statement.class);
 
   private static boolean isJUnitIntrastructure(StackTraceElement stackTraceElement) {
-    return isFromClass(stackTraceElement, JUNIT_INFRASTRUCTURE_CLASSES);
+    // It's not clear whether looking at nested classes here is useful, harmful, or neutral.
+    return isFromClassOrClassNestedInside(stackTraceElement, JUNIT_INFRASTRUCTURE_CLASSES);
   }
 
-  private static boolean isFromClass(
+  private static boolean isFromClassOrClassNestedInside(
+      StackTraceElement stackTraceElement, ImmutableSet<Class<?>> classes) {
+    Class<?> stackClass;
+    try {
+      stackClass = Class.forName(stackTraceElement.getClassName());
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+    for (; stackClass != null; stackClass = stackClass.getEnclosingClass()) {
+      for (Class<?> knownEntranceClass : classes) {
+        if (knownEntranceClass.isAssignableFrom(stackClass)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private static boolean isFromClassDirectly(
       StackTraceElement stackTraceElement, ImmutableSet<Class<?>> classes) {
     Class<?> stackClass;
     try {
@@ -276,6 +315,9 @@ final class StackTraceCleaner {
     private static StackFrameType forClassName(String fullyQualifiedClassName) {
       // Never remove the frames from a test class. These will probably be the frame of a failing
       // assertion.
+      // TODO(cpovirk): This is really only for tests in Truth itself, so this doesn't matter yet,
+      // but.... If the Truth tests someday start calling into nested classes, we may want to add:
+      // || fullyQualifiedClassName.contains("Test$")
       if (fullyQualifiedClassName.endsWith("Test")) {
         return StackFrameType.NEVER_REMOVE;
       }

--- a/core/src/test/java/com/google/common/truth/StackTraceCleanerTest.java
+++ b/core/src/test/java/com/google/common/truth/StackTraceCleanerTest.java
@@ -145,6 +145,21 @@ public class StackTraceCleanerTest extends BaseSubjectTestCase {
   }
 
   @Test
+  public void classNestedInSubject() {
+    Throwable throwable =
+        createThrowableWithStackTrace(
+            "com.google.common.truth.IterableSubject$UsingCorrespondence", "com.example.MyTest");
+
+    StackTraceCleaner.cleanStackTrace(throwable);
+
+    assertThat(throwable.getStackTrace())
+        .isEqualTo(
+            new StackTraceElement[] {
+              createStackTraceElement("com.example.MyTest"),
+            });
+  }
+
+  @Test
   public void removesTestingAndReflectiveFramesOnBottom() {
     Throwable throwable =
         createThrowableWithStackTrace(
@@ -238,6 +253,24 @@ public class StackTraceCleanerTest extends BaseSubjectTestCase {
         .isEqualTo(
             new StackTraceElement[] {
               createStackTraceElement("com.google.example.SomeTest"),
+            });
+  }
+
+  @Test
+  public void failureFromJUnitInfrastructureIncludesItInStack() {
+    Throwable throwable =
+        createThrowableWithStackTrace(
+            "com.google.common.truth.StringSubject",
+            SomeStatement.class.getName(),
+            "com.google.example.SomeClass");
+
+    StackTraceCleaner.cleanStackTrace(throwable);
+
+    assertThat(throwable.getStackTrace())
+        .isEqualTo(
+            new StackTraceElement[] {
+              createStackTraceElement(SomeStatement.class.getName()),
+              createStackTraceElement("com.google.example.SomeClass"),
             });
   }
 

--- a/core/src/test/java/com/google/common/truth/StackTraceCleanerTest.java
+++ b/core/src/test/java/com/google/common/truth/StackTraceCleanerTest.java
@@ -145,21 +145,6 @@ public class StackTraceCleanerTest extends BaseSubjectTestCase {
   }
 
   @Test
-  public void classNestedInSubject() {
-    Throwable throwable =
-        createThrowableWithStackTrace(
-            "com.google.common.truth.IterableSubject$UsingCorrespondence", "com.example.MyTest");
-
-    StackTraceCleaner.cleanStackTrace(throwable);
-
-    assertThat(throwable.getStackTrace())
-        .isEqualTo(
-            new StackTraceElement[] {
-              createStackTraceElement("com.example.MyTest"),
-            });
-  }
-
-  @Test
   public void removesTestingAndReflectiveFramesOnBottom() {
     Throwable throwable =
         createThrowableWithStackTrace(
@@ -253,24 +238,6 @@ public class StackTraceCleanerTest extends BaseSubjectTestCase {
         .isEqualTo(
             new StackTraceElement[] {
               createStackTraceElement("com.google.example.SomeTest"),
-            });
-  }
-
-  @Test
-  public void failureFromJUnitInfrastructureIncludesItInStack() {
-    Throwable throwable =
-        createThrowableWithStackTrace(
-            "com.google.common.truth.StringSubject",
-            SomeStatement.class.getName(),
-            "com.google.example.SomeClass");
-
-    StackTraceCleaner.cleanStackTrace(throwable);
-
-    assertThat(throwable.getStackTrace())
-        .isEqualTo(
-            new StackTraceElement[] {
-              createStackTraceElement(SomeStatement.class.getName()),
-              createStackTraceElement("com.google.example.SomeClass"),
             });
   }
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Depend on checker-qual from our tests only.

Fixes https://github.com/google/truth/issues/479

RELNOTES: Moved `checker-qual` dependency to the test scope. It is included only to work around [a `guava-gwt` problem](https://github.com/google/truth/commit/85eafa37a986ca53822c30438b622d41b4ca1922#diff-357e4854869b2e21c38b1b437f11095aR34), which [will be fixed](https://github.com/google/guava/commit/dd71527fc004c5dc5451a7256097d46ba0abb4f5#diff-ab96976c645d76e2c46f2d965bb99969) in Guava 25.2. Fixes https://github.com/google/truth/issues/479

9338bb82fc86458f8bb3814349f3438b895ec0b0

-------

<p> Two minor improvements to stack-trace cleaning:

1. Remove frames for classes nested inside Subject (and also Runner and Statement because "why not?" but not StandardSubjectBuilder for reasons I discovered and documented after some tests failed when I tried).

Before:
required elements were all found, but order was wrong
expected order for required elements: [3, 5, 2]
but was                             : [3, 2, 5]
	at com.google.common.truth.IterableSubject$1.inOrder(IterableSubject.java:290)
	at com.google.common.truth.IterableSubjectTest.iterableContainsAllOfInOrder(IterableSubjectTest.java:358)

After:
required elements were all found, but order was wrong
expected order for required elements: [3, 5, 2]
but was                             : [3, 2, 5]
	at com.google.common.truth.IterableSubjectTest.iterableContainsAllOfInOrder(IterableSubjectTest.java:358)

2. Prevent us from making the stack completely empty. (It's probably still *possible* to make the stack completely empty, but this change prevents the practical way I realized it could actually happen.)

Before:
1) testExpectTrace_loop(com.google.common.truth.ExpectWithStackTest)
expected to be false

After:
1) testExpectTrace_loop(com.google.common.truth.ExpectWithStackTest)
expected to be false
	at com.google.common.truth.ExpectWithStackTest$TestRuleVerifier$1.evaluate(ExpectWithStackTest.java:146)

Finally, this seemed like as good a time as any to make ExpectWithStackTest stop using a Predicate when we wanted something more like a Consumer.

28936be1ebb3062de8115553ef9d1c30bf0de7a9

-------

<p> Automated rollback of 250a582d68ecc497b2d142a488daee90c23714f6

*** Original change description ***

Two minor improvements to stack-trace cleaning:

1. Remove frames for classes nested inside Subject (and also Runner and Statement because "why not?" but not StandardSubjectBuilder for reasons I discovered and documented after some tests failed when I tried).

Before:
required elements were all found, but order was wrong
expected order for required elements: [3, 5, 2]
but was                             : [3, 2, 5]
	at com.google.common.truth.IterableSubject$1.inOrder(IterableSubject.java:290)...

***

b3a21bbb445a2eb13b3097e2915219f4a09da004

-------

<p> Redo "Two minor improvements to stack-trace cleaning" (250a582d68ecc497b2d142a488daee90c23714f6, which was rolled back in b3a21bbb445a2eb13b3097e2915219f4a09da004).

But this time, avoid throwing an exception if running under j2objc with reflection off.

And while here, eliminate the variable name "knownEntranceClass," since these methods have been used for "exit" classes as well as "entrance" classes ever since we started looking for isJUnitIntrastructure() frames.

a6a01f5eeb5ac17c695a695e7e00cb51509acf2f