### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/MapSubject.java
+++ b/core/src/main/java/com/google/common/truth/MapSubject.java
@@ -116,21 +116,27 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
       List<Object> keyList = Lists.newArrayList(key);
       List<Object> valueList = Lists.newArrayList(value);
       if (hasMatchingToStringPair(actual().keySet(), keyList)) {
-        failWithRawMessage(
-            "Not true that %s contains entry <%s (%s)>. However, it does contain keys <%s>.",
-            actualAsString(),
-            entry,
-            objectToTypeName(entry),
-            countDuplicatesAndAddTypeInfo(
-                retainMatchingToString(actual().keySet(), keyList /* itemsToCheck */)));
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s contains entry <%s (%s)>. However, it does contain keys "
+                        + "<%s>.",
+                    actualAsString(),
+                    entry,
+                    objectToTypeName(entry),
+                    countDuplicatesAndAddTypeInfo(
+                        retainMatchingToString(actual().keySet(), keyList /* itemsToCheck */)))));
       } else if (hasMatchingToStringPair(actual().values(), valueList)) {
-        failWithRawMessage(
-            "Not true that %s contains entry <%s (%s)>. However, it does contain values <%s>.",
-            actualAsString(),
-            entry,
-            objectToTypeName(entry),
-            countDuplicatesAndAddTypeInfo(
-                retainMatchingToString(actual().values(), valueList /* itemsToCheck */)));
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s contains entry <%s (%s)>. However, it does contain values "
+                        + "<%s>.",
+                    actualAsString(),
+                    entry,
+                    objectToTypeName(entry),
+                    countDuplicatesAndAddTypeInfo(
+                        retainMatchingToString(actual().values(), valueList /* itemsToCheck */)))));
       } else if (actual().containsKey(key)) {
         Object actualValue = actual().get(key);
         /*

--- a/core/src/main/java/com/google/common/truth/MultimapSubject.java
+++ b/core/src/main/java/com/google/common/truth/MultimapSubject.java
@@ -107,13 +107,17 @@ public class MultimapSubject extends Subject<MultimapSubject, Multimap<?, ?>> {
       Entry<Object, Object> entry = Maps.immutableEntry(key, value);
       List<Entry<Object, Object>> entryList = ImmutableList.of(entry);
       if (hasMatchingToStringPair(actual().entries(), entryList)) {
-        failWithRawMessage(
-            "Not true that %s contains entry <%s (%s)>. However, it does contain entries <%s>",
-            actualAsString(),
-            entry,
-            objectToTypeName(entry),
-            countDuplicatesAndAddTypeInfo(
-                retainMatchingToString(actual().entries(), entryList /* itemsToCheck */)));
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s contains entry <%s (%s)>. However, it does contain entries "
+                        + "<%s>",
+                    actualAsString(),
+                    entry,
+                    objectToTypeName(entry),
+                    countDuplicatesAndAddTypeInfo(
+                        retainMatchingToString(
+                            actual().entries(), entryList /* itemsToCheck */)))));
       } else if (actual().containsKey(key)) {
         failWithoutActual(
             simpleFact(
@@ -204,20 +208,25 @@ public class MultimapSubject extends Subject<MultimapSubject, Multimap<?, ?>> {
     if (!missing.isEmpty()) {
       if (!extra.isEmpty()) {
         boolean addTypeInfo = hasMatchingToStringPair(missing.entries(), extra.entries());
-        failWithRawMessage(
-            "Not true that %s contains exactly <%s>. "
-                + "It is missing <%s> and has unexpected items <%s>",
-            actualAsString(),
-            annotateEmptyStringsMultimap(expectedMultimap),
-            // Note: The usage of countDuplicatesAndAddTypeInfo() below causes entries no longer to
-            // be grouped by key in the 'missing' and 'unexpected items' parts of the message (we
-            // still show the actual and expected multimaps in the standard format).
-            addTypeInfo
-                ? countDuplicatesAndAddTypeInfo(annotateEmptyStringsMultimap(missing).entries())
-                : countDuplicatesMultimap(annotateEmptyStringsMultimap(missing)),
-            addTypeInfo
-                ? countDuplicatesAndAddTypeInfo(annotateEmptyStringsMultimap(extra).entries())
-                : countDuplicatesMultimap(annotateEmptyStringsMultimap(extra)));
+        failWithoutActual(
+            simpleFact(
+                lenientFormat(
+                    "Not true that %s contains exactly <%s>. "
+                        + "It is missing <%s> and has unexpected items <%s>",
+                    actualAsString(),
+                    annotateEmptyStringsMultimap(expectedMultimap),
+                    // Note: The usage of countDuplicatesAndAddTypeInfo() below causes entries no
+                    // longer to be grouped by key in the 'missing' and 'unexpected items' parts of
+                    // the message (we still show the actual and expected multimaps in the standard
+                    // format).
+                    addTypeInfo
+                        ? countDuplicatesAndAddTypeInfo(
+                            annotateEmptyStringsMultimap(missing).entries())
+                        : countDuplicatesMultimap(annotateEmptyStringsMultimap(missing)),
+                    addTypeInfo
+                        ? countDuplicatesAndAddTypeInfo(
+                            annotateEmptyStringsMultimap(extra).entries())
+                        : countDuplicatesMultimap(annotateEmptyStringsMultimap(extra)))));
         return ALREADY_FAILED;
       } else {
         failWithBadResults(

--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -994,18 +994,6 @@ public class Subject<S extends Subject<S, T>, T> {
   }
 
   /**
-   * Passes through a failure message verbatim. Used for {@link Subject} subclasses which need to
-   * provide alternate language for more fit-to-purpose error messages.
-   *
-   * @param message a template with {@code %s} placeholders
-   * @param parameters the object parameters which will be applied to the message template.
-   */
-  // TODO(cgruber) final
-  protected void failWithRawMessage(String message, Object... parameters) {
-    failWithoutActual(simpleFact(lenientFormat(message, parameters)));
-  }
-
-  /**
    * @throws UnsupportedOperationException always
    * @deprecated {@link Object#equals(Object)} is not supported on Truth subjects. If you meant to
    *     test object equality between an expected and the actual value, use {@link

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoSubject.java
@@ -286,10 +286,11 @@ public class ProtoSubject<S extends ProtoSubject<S, M>, M extends Message>
       DiffResult diffResult =
           makeDifferencer((Message) expected).diffMessages(actual(), (Message) expected);
       if (!diffResult.isMatched()) {
-        failWithRawMessage(
-            failureMessage(/* expectedEqual = */ true)
-                + "\n"
-                + diffResult.printToString(config.reportMismatchesOnly()));
+        failWithoutActual(
+            simpleFact(
+                failureMessage(/* expectedEqual = */ true)
+                    + "\n"
+                    + diffResult.printToString(config.reportMismatchesOnly())));
       }
     }
   }
@@ -316,10 +317,11 @@ public class ProtoSubject<S extends ProtoSubject<S, M>, M extends Message>
       DiffResult diffResult =
           makeDifferencer((Message) expected).diffMessages(actual(), (Message) expected);
       if (diffResult.isMatched()) {
-        failWithRawMessage(
-            failureMessage(/* expectedEqual= */ false)
-                + "\n"
-                + diffResult.printToString(config.reportMismatchesOnly()));
+        failWithoutActual(
+            simpleFact(
+                failureMessage(/* expectedEqual= */ false)
+                    + "\n"
+                    + diffResult.printToString(config.reportMismatchesOnly())));
       }
     }
   }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Migrate callers of Truth's Subject.failWithRawMessage to Subject.failWithoutActual

Requires the use of Guava 25.1 for Strings.lenientFormat and Truth 0.41 for Subject.failWithoutActual

592b8fbb9cfe14fbff81899567ed8f7dbf1b852d

-------

<p> Delete Subject.failWithRawMessage, it has been replaced with failWithoutActual

RELNOTES=Delete Subject.failWithRawMessage, it has been replaced with failWithoutActual

42f645f6a4a6aa5ee0a9595b2cd2bfe889c5e376