### PR TITLE
Moe Sync

### DIFF
--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosFluentAssertion.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosFluentAssertion.java
@@ -37,14 +37,13 @@ public interface IterableOfProtosFluentAssertion<M extends Message>
    * equality.
    *
    * <p>For version 2 Protocol Buffers, this setting determines whether two protos with the same
-   * value for a primitive field compare equal if one explicitly sets the value, and the other
-   * merely implicitly uses the schema-defined default. This setting also determines whether unknown
-   * fields should be considered in the comparison. By {@code ignoringFieldAbsence()}, unknown
-   * fields are ignored, and value-equal fields as specified above are considered equal.
+   * value for a field compare equal if one explicitly sets the value, and the other merely
+   * implicitly uses the schema-defined default. This setting also determines whether unknown fields
+   * should be considered in the comparison. By {@code ignoringFieldAbsence()}, unknown fields are
+   * ignored, and value-equal fields as specified above are considered equal.
    *
-   * <p>For version 3 Protocol Buffers, this setting has no effect. Primitive fields set to their
-   * default value are indistinguishable from unset fields in proto 3. Proto 3 also eliminates
-   * unknown fields, so this setting has no effect there either.
+   * <p>For version 3 Protocol Buffers, this setting does not affect primitive fields, because their
+   * default value is indistinguishable from unset.
    */
   IterableOfProtosFluentAssertion<M> ignoringFieldAbsence();
 

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosSubject.java
@@ -413,14 +413,13 @@ public class IterableOfProtosSubject<
    * equality.
    *
    * <p>For version 2 Protocol Buffers, this setting determines whether two protos with the same
-   * value for a primitive field compare equal if one explicitly sets the value, and the other
-   * merely implicitly uses the schema-defined default. This setting also determines whether unknown
-   * fields should be considered in the comparison. By {@code ignoringFieldAbsence()}, unknown
-   * fields are ignored, and value-equal fields as specified above are considered equal.
+   * value for a field compare equal if one explicitly sets the value, and the other merely
+   * implicitly uses the schema-defined default. This setting also determines whether unknown fields
+   * should be considered in the comparison. By {@code ignoringFieldAbsence()}, unknown fields are
+   * ignored, and value-equal fields as specified above are considered equal.
    *
-   * <p>For version 3 Protocol Buffers, this setting has no effect. Primitive fields set to their
-   * default value are indistinguishable from unset fields in proto 3. Proto 3 also eliminates
-   * unknown fields, so this setting has no effect there either.
+   * <p>For version 3 Protocol Buffers, this setting does not affect primitive fields, because their
+   * default value is indistinguishable from unset.
    */
   public IterableOfProtosFluentAssertion<M> ignoringFieldAbsence() {
     return usingConfig(config.ignoringFieldAbsence());

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesFluentAssertion.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesFluentAssertion.java
@@ -46,14 +46,13 @@ public interface MapWithProtoValuesFluentAssertion<M extends Message> {
    * equality.
    *
    * <p>For version 2 Protocol Buffers, this setting determines whether two protos with the same
-   * value for a primitive field compare equal if one explicitly sets the value, and the other
-   * merely implicitly uses the schema-defined default. This setting also determines whether unknown
-   * fields should be considered in the comparison. By {@code ignoringFieldAbsence()}, unknown
-   * fields are ignored, and value-equal fields as specified above are considered equal.
+   * value for a field compare equal if one explicitly sets the value, and the other merely
+   * implicitly uses the schema-defined default. This setting also determines whether unknown fields
+   * should be considered in the comparison. By {@code ignoringFieldAbsence()}, unknown fields are
+   * ignored, and value-equal fields as specified above are considered equal.
    *
-   * <p>For version 3 Protocol Buffers, this setting has no effect. Primitive fields set to their
-   * default value are indistinguishable from unset fields in proto 3. Proto 3 also eliminates
-   * unknown fields, so this setting has no effect there either.
+   * <p>For version 3 Protocol Buffers, this setting does not affect primitive fields, because their
+   * default value is indistinguishable from unset.
    */
   MapWithProtoValuesFluentAssertion<M> ignoringFieldAbsenceForValues();
 

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubject.java
@@ -222,14 +222,13 @@ public class MapWithProtoValuesSubject<
    * equality.
    *
    * <p>For version 2 Protocol Buffers, this setting determines whether two protos with the same
-   * value for a primitive field compare equal if one explicitly sets the value, and the other
-   * merely implicitly uses the schema-defined default. This setting also determines whether unknown
-   * fields should be considered in the comparison. By {@code ignoringFieldAbsence()}, unknown
-   * fields are ignored, and value-equal fields as specified above are considered equal.
+   * value for a field compare equal if one explicitly sets the value, and the other merely
+   * implicitly uses the schema-defined default. This setting also determines whether unknown fields
+   * should be considered in the comparison. By {@code ignoringFieldAbsence()}, unknown fields are
+   * ignored, and value-equal fields as specified above are considered equal.
    *
-   * <p>For version 3 Protocol Buffers, this setting has no effect. Primitive fields set to their
-   * default value are indistinguishable from unset fields in proto 3. Proto 3 also eliminates
-   * unknown fields, so this setting has no effect there either.
+   * <p>For version 3 Protocol Buffers, this setting does not affect primitive fields, because their
+   * default value is indistinguishable from unset.
    */
   public MapWithProtoValuesFluentAssertion<M> ignoringFieldAbsenceForValues() {
     return usingConfig(config.ignoringFieldAbsence());

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesFluentAssertion.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesFluentAssertion.java
@@ -46,14 +46,13 @@ public interface MultimapWithProtoValuesFluentAssertion<M extends Message> {
    * equality.
    *
    * <p>For version 2 Protocol Buffers, this setting determines whether two protos with the same
-   * value for a primitive field compare equal if one explicitly sets the value, and the other
-   * merely implicitly uses the schema-defined default. This setting also determines whether unknown
-   * fields should be considered in the comparison. By {@code ignoringFieldAbsence()}, unknown
-   * fields are ignored, and value-equal fields as specified above are considered equal.
+   * value for a field compare equal if one explicitly sets the value, and the other merely
+   * implicitly uses the schema-defined default. This setting also determines whether unknown fields
+   * should be considered in the comparison. By {@code ignoringFieldAbsence()}, unknown fields are
+   * ignored, and value-equal fields as specified above are considered equal.
    *
-   * <p>For version 3 Protocol Buffers, this setting has no effect. Primitive fields set to their
-   * default value are indistinguishable from unset fields in proto 3. Proto 3 also eliminates
-   * unknown fields, so this setting has no effect there either.
+   * <p>For version 3 Protocol Buffers, this setting does not affect primitive fields, because their
+   * default value is indistinguishable from unset.
    */
   MultimapWithProtoValuesFluentAssertion<M> ignoringFieldAbsenceForValues();
 

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubject.java
@@ -267,14 +267,13 @@ public class MultimapWithProtoValuesSubject<
    * equality.
    *
    * <p>For version 2 Protocol Buffers, this setting determines whether two protos with the same
-   * value for a primitive field compare equal if one explicitly sets the value, and the other
-   * merely implicitly uses the schema-defined default. This setting also determines whether unknown
-   * fields should be considered in the comparison. By {@code ignoringFieldAbsence()}, unknown
-   * fields are ignored, and value-equal fields as specified above are considered equal.
+   * value for a field compare equal if one explicitly sets the value, and the other merely
+   * implicitly uses the schema-defined default. This setting also determines whether unknown fields
+   * should be considered in the comparison. By {@code ignoringFieldAbsence()}, unknown fields are
+   * ignored, and value-equal fields as specified above are considered equal.
    *
-   * <p>For version 3 Protocol Buffers, this setting has no effect. Primitive fields set to their
-   * default value are indistinguishable from unset fields in proto 3. Proto 3 also eliminates
-   * unknown fields, so this setting has no effect there either.
+   * <p>For version 3 Protocol Buffers, this setting does not affect primitive fields, because their
+   * default value is indistinguishable from unset.
    */
   public MultimapWithProtoValuesFluentAssertion<M> ignoringFieldAbsenceForValues() {
     return usingConfig(config.ignoringFieldAbsence());

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoFluentAssertion.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoFluentAssertion.java
@@ -35,14 +35,13 @@ public interface ProtoFluentAssertion {
    * equality.
    *
    * <p>For version 2 Protocol Buffers, this setting determines whether two protos with the same
-   * value for a primitive field compare equal if one explicitly sets the value, and the other
-   * merely implicitly uses the schema-defined default. This setting also determines whether unknown
-   * fields should be considered in the comparison. By {@code ignoringFieldAbsence()}, unknown
-   * fields are ignored, and value-equal fields as specified above are considered equal.
+   * value for a field compare equal if one explicitly sets the value, and the other merely
+   * implicitly uses the schema-defined default. This setting also determines whether unknown fields
+   * should be considered in the comparison. By {@code ignoringFieldAbsence()}, unknown fields are
+   * ignored, and value-equal fields as specified above are considered equal.
    *
-   * <p>For version 3 Protocol Buffers, this setting has no effect. Primitive fields set to their
-   * default value are indistinguishable from unset fields in proto 3. Proto 3 also eliminates
-   * unknown fields, so this setting has no effect there either.
+   * <p>For version 3 Protocol Buffers, this setting does not affect primitive fields, because their
+   * default value is indistinguishable from unset.
    */
   ProtoFluentAssertion ignoringFieldAbsence();
 

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTest.java
@@ -179,11 +179,6 @@ public class ProtoSubjectTest extends ProtoSubjectTestBase {
   @SuppressWarnings("unchecked")
   @Test
   public void testUnknownFields() throws InvalidProtocolBufferException {
-    if (isProto3()) {
-      // Proto 3 doesn't support unknown fields.
-      return;
-    }
-
     Message message =
         fromUnknownFields(
             UnknownFieldSet.newBuilder()


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update ignoringFieldAbsence() javadoc and tests to match actual behavior

(1) or proto2 and proto3, message fields (not just primitives) are affected, as shown by existing tests extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTest.java

(2) for proto3, unknown fields are back so tests are updated to include proto3 coverage

fc367c95f0bf1ed686d641e371a9737981d553d2