### PR TITLE
Moe Sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ Read more at [the main website](https://google.github.io/truth).
 [travis-shield]: https://img.shields.io/travis/google/truth.png
 [travis-link]: https://travis-ci.org/google/truth
 [maven-shield]: https://img.shields.io/maven-central/v/com.google.truth/truth.png
-[maven-link]: https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.google.truth%22%20AND%20a%3A%22truth%22
+[maven-link]: https://search.maven.org/artifact/com.google.truth/truth
 [stackoverflow-shield]: https://img.shields.io/badge/stackoverflow-truth-5555ff.png?style=flat
 [stackoverflow-link]: https://stackoverflow.com/questions/tagged/google-truth


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix links broken by search.maven.org UI change.

Fixes https://github.com/google/truth/issues/488 and a similar issue for Dagger.

Dagger, like Truth, now links directly to search.maven.org rather than a redirector.

c80178b8b0d02390f874e5108527c5dd7c11ba61