### PR TITLE
Moe Sync

### DIFF
--- a/extensions/java8/pom.xml
+++ b/extensions/java8/pom.xml
@@ -18,7 +18,6 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.checkerframework</groupId>

--- a/extensions/liteproto/pom.xml
+++ b/extensions/liteproto/pom.xml
@@ -19,7 +19,6 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/extensions/proto/pom.xml
+++ b/extensions/proto/pom.xml
@@ -19,12 +19,10 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.truth.extensions</groupId>
       <artifactId>truth-liteproto-extension</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/extensions/re2j/pom.xml
+++ b/extensions/re2j/pom.xml
@@ -18,7 +18,6 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.re2j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -298,12 +298,8 @@
                     satisfy requireUpperBoundDeps, which apparently still sees
                     the original request for the newer version.
                     requireUpperBoundDeps's behavior is probably a good thing.
-                    But: Given the problem I describe in the next paragraph, I
-                    suspect that requireUpperBoundDeps doesn't have well defined
-                    behavior under dependencyManagement, so it might not be as
-                    good as I'd hoped.
 
-                    And in what seems like a bug, dependencyConvergence catches
+                    But, in what seems like a bug, dependencyConvergence catches
                     certain upper-bound problems that requireUpperBoundDeps does
                     not. To be clear, it's usually *not* a bug for
                     dependencyConvergence to give an error when
@@ -320,6 +316,9 @@
                     to depend on guava-26.0, which depends on
                     checker-compat-qual 2.5.3, then requireUpperBoundDeps
                     detected the problem.
+
+                    I filed a bug against Maven:
+                    https://issues.apache.org/jira/browse/MENFORCER-316
                     -->
                   <requireUpperBoundDeps>
                     <excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,20 @@
   </properties>
   <dependencyManagement>
     <dependencies>
-      <!-- I tried also including Truth's own submodules here, with version set to ${project.version} (as we have it in the individual POMs), but Maven doesn't like that, at least when run under TAP (which probably means "with an empty local repository" and/or "with no access to remote repositories"). So we have to specify project.version wherever we use submodules. At least we'll never need to update it :) -->
+      <dependency>
+        <groupId>com.google.truth</groupId>
+        <artifactId>truth</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.truth.extensions</groupId>
+        <artifactId>truth-liteproto-extension</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <!--
+        We could add the other modules of Truth, but there's no need because no
+        modules depend on them yet.
+        -->
       <dependency>
         <!--
           In addition to setting the version of Guava that's used when Truth


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Link to the bug I filed against the Maven Enforcer Plugin.

Tweak comment to reflect that I think the Enforcer is *supposed* to do what I want (based on https://issues.apache.org/jira/browse/MENFORCER-146). That is, it seems like missing the problem I describe is a bug. (I'd begun to wonder if the real bug was that it caught that kind of problem at all.)

f97297e2b444c77dc860d1f0bbe2fcdabfdc7eec

-------

<p> Get dependencyManagement working for Truth's own modules.

The problem before was the "circular" Truth[tests] -> Compile-Testing -> Truth dependency chain. Because we started using dependencyManagement, Maven wanted Compile-Testing to depend on the specific version of Truth that we specified there. That meant that Truth 1.0-SNAPSHOT needed to be available before we could build Truth 1.0-SNAPSHOT. (Again, not really, because Compile-Testing needs only Truth itself, and Truth doesn't need Compile-Testing until its _tests_, but that's circular to Maven. We had similar problems with guava and guava-testlib, IIRC, and that's why we have a separate guava-tests artifact.)

Anyway, now that we exclude Compile-Testing's dependency on Truth, Maven doesn't go looking for a version of Truth that we haven't built yet.

cc9c7ea4c0f52f7ea534d2b731e7eb04871b96aa