### PR TITLE
Moe Sync

### DIFF
--- a/core/src/test/java/com/google/common/truth/SubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/SubjectTest.java
@@ -767,6 +767,8 @@ public class SubjectTest extends BaseSubjectTestCase {
   }
 
   private static final class ThrowsOnEqualsNull {
+
+    @SuppressWarnings("EqualsHashCode")
     @Override
     public boolean equals(Object obj) {
       checkNotNull(obj); // buggy implementation but one that we're working around, at least for now
@@ -775,6 +777,8 @@ public class SubjectTest extends BaseSubjectTestCase {
   }
 
   private static final class ThrowsOnEquals {
+
+    @SuppressWarnings("EqualsHashCode")
     @Override
     public boolean equals(Object obj) {
       throw new UnsupportedOperationException();


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Suppress warnings in classes that implement equals() without also implementing
hashCode().

The contract for Object.hashCode states that if two objects are equal, then
calling the hashCode() method on each of the two objects must produce the same
result. Implementing equals() but not hashCode() causes broken behaviour when
trying to store the object in a collection.

eb6688a1b18cdcc478b4209ebb150f361013ed62