### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/IterableSubject.java
+++ b/core/src/main/java/com/google/common/truth/IterableSubject.java
@@ -1250,14 +1250,14 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       return Joiner.on(", ").join(messages);
     }
 
-    private List<String> formatExtras(E missing, List<? extends A> extras) {
-      List<String> extrasFormatted = new ArrayList<>();
+    private List<Object> formatExtras(E missing, List<? extends A> extras) {
+      List<Object> extrasFormatted = new ArrayList<>();
       for (A extra : extras) {
         @NullableDecl String diff = correspondence.formatDiff(extra, missing);
         if (diff != null) {
           extrasFormatted.add(lenientFormat("%s (diff: %s)", extra, diff));
         } else {
-          extrasFormatted.add(extra.toString());
+          extrasFormatted.add(extra);
         }
       }
       return extrasFormatted;

--- a/core/src/test/java/com/google/common/truth/IterableSubjectCorrespondenceTest.java
+++ b/core/src/test/java/com/google/common/truth/IterableSubjectCorrespondenceTest.java
@@ -323,6 +323,46 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
   }
 
   @Test
+  public void comparingElementsUsing_containsExactlyElementsIn_failsMissingAndExtraNull() {
+    ImmutableList<Integer> expected = ImmutableList.of(64, 128, 256, 128);
+    List<String> actual = asList("+64", "+128", "0x80", null);
+    // Actual list has candidate matches for 64, 128, and the other 128, but is missing 256 and has
+    // extra null. (N.B. This tests a previous regression from calling extra.toString().)
+    expectFailure
+        .whenTesting()
+        .that(actual)
+        .comparingElementsUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
+        .containsExactlyElementsIn(expected);
+    assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .isEqualTo(
+            "Not true that <[+64, +128, 0x80, null]> contains exactly one element that "
+                + "parses to each element of <[64, 128, 256, 128]>. "
+                + "It is missing an element that parses to <256> "
+                + "and has unexpected elements <[null]>");
+  }
+
+  @Test
+  public void comparingElementsUsing_containsExactlyElementsIn_failsNullMissingAndExtra() {
+    List<Integer> expected = asList(64, 128, null, 128);
+    ImmutableList<String> actual = ImmutableList.of("+64", "+128", "0x80", "cheese");
+    // Actual list has candidate matches for 64, 128, and the other 128, but is missing null and has
+    // extra cheese.
+    expectFailure
+        .whenTesting()
+        .that(actual)
+        .comparingElementsUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
+        .containsExactlyElementsIn(expected);
+    assertThat(expectFailure.getFailure())
+        .hasMessageThat()
+        .isEqualTo(
+            "Not true that <[+64, +128, 0x80, cheese]> contains exactly one element that "
+                + "parses to each element of <[64, 128, null, 128]>. "
+                + "It is missing an element that parses to <null> "
+                + "and has unexpected elements <[cheese]>");
+  }
+
+  @Test
   public void comparingElementsUsing_containsExactlyElementsIn_diffOneMissingSomeExtraCandidate() {
     ImmutableList<Integer> expected = ImmutableList.of(30, 60, 90);
     ImmutableList<Integer> actual = ImmutableList.of(101, 65, 35, 190);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix a NPE bug in Fuzzy Truth.

If the actual array contains extra elements, and Smart Diffing is active (either because it was explicitly invoked or because there is exactly one missing element), but the Correspondence.diffFormat method was returning null, we were calling extra.toString(), which is no good because extra could legitimately be null.

3d922b29a10dfcb2667a309d6a908312c86c79ff