### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/Correspondence.java
+++ b/core/src/main/java/com/google/common/truth/Correspondence.java
@@ -20,11 +20,11 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.truth.DoubleSubject.checkTolerance;
 import static com.google.common.truth.Fact.fact;
 import static com.google.common.truth.Fact.simpleFact;
+import static com.google.common.truth.Facts.facts;
 import static com.google.common.truth.Platform.getStackTraceAsString;
 import static java.util.Arrays.asList;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.List;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
@@ -230,9 +230,9 @@ public abstract class Correspondence<A, E> {
      * discovered by assuming a false return and continuing (see the javadoc for {@link
      * Correspondence#compare}). C.f. {@link #describeAsAdditionalInfo}.
      */
-    ImmutableList<Fact> describeAsMainCause() {
+    Facts describeAsMainCause() {
       checkState(!empty);
-      return ImmutableList.of(
+      return facts(
           simpleFact("one or more exceptions were thrown while " + context), firstExceptionFact());
     }
 
@@ -244,13 +244,13 @@ public abstract class Correspondence<A, E> {
      * Correspondence#compare}), or when exceptions were thrown by other methods while generating
      * the failure message. C.f. {@link #describeAsMainCause}.
      */
-    ImmutableList<Fact> describeAsAdditionalInfo() {
+    Facts describeAsAdditionalInfo() {
       if (!empty) {
-        return ImmutableList.of(
+        return facts(
             simpleFact("additionally, one or more exceptions were thrown while " + context),
             firstExceptionFact());
       } else {
-        return ImmutableList.of();
+        return facts();
       }
     }
 

--- a/core/src/main/java/com/google/common/truth/Facts.java
+++ b/core/src/main/java/com/google/common/truth/Facts.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.common.truth;
+
+import static java.util.Arrays.asList;
+
+import com.google.common.collect.Iterables;
+
+/**
+ * Helper class that wraps a collection of {@link Fact} instances to make them easier to build.
+ *
+ * @author Pete Gillin
+ */
+final class Facts {
+
+  private final Iterable<Fact> facts;
+
+  /** Returns an instance wrapping the given facts. */
+  static Facts facts(Fact... facts) {
+    return new Facts(asList(facts));
+  }
+
+  private Facts(Iterable<Fact> facts) {
+    this.facts = facts;
+  }
+
+  /** Returns the facts wrapped by this instance. */
+  Iterable<Fact> asIterable() {
+    return facts;
+  }
+
+  /**
+   * Returns an instance concatenating the facts wrapped by the current instance followed by the
+   * given facts.
+   */
+  Facts and(Facts moreFacts) {
+    return new Facts(Iterables.concat(facts, moreFacts.asIterable()));
+  }
+
+  /**
+   * Returns an instance concatenating the facts wrapped by the current instance followed by the
+   * given facts.
+   */
+  Facts and(Fact... moreFacts) {
+    return new Facts(Iterables.concat(facts, asList(moreFacts)));
+  }
+}

--- a/core/src/main/java/com/google/common/truth/IterableSubject.java
+++ b/core/src/main/java/com/google/common/truth/IterableSubject.java
@@ -1081,7 +1081,7 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       // Find a many:many mapping between the indexes of the elements which correspond, and check
       // it for completeness.
       // Exceptions from Correspondence.compare are stored and treated as if false was returned.
-      Correspondence.ExceptionStore compareExceptions = new Correspondence.ExceptionStore();
+      Correspondence.ExceptionStore compareExceptions = Correspondence.ExceptionStore.forCompare();
       ImmutableSetMultimap<Integer, Integer> candidateMapping =
           findCandidateMapping(actualList, expectedList, compareExceptions);
       if (failIfCandidateMappingHasMissingOrExtra(
@@ -1102,13 +1102,14 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       // unexpected null) but we are contractually obliged to throw here if the assertions passed.
       if (!compareExceptions.isEmpty()) {
         subject.failWithActual(
-            simpleFact("one or more exceptions were thrown while comparing elements"),
-            compareExceptions.describe(),
-            simpleFact(
-                "comparing contents by testing that each element "
-                    + correspondence
-                    + " an expected value"),
-            fact("expected", expected));
+            concat(
+                compareExceptions.describeAsMainCause(),
+                asList(
+                    simpleFact(
+                        "comparing contents by testing that each element "
+                            + correspondence
+                            + " an expected value"),
+                    fact("expected", expected))));
         return ALREADY_FAILED;
       }
       // The 1:1 mapping is complete, so the test succeeds (but we know from above that the mapping
@@ -1153,7 +1154,7 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
      */
     private boolean correspondInOrderExactly(
         Iterator<? extends A> actual, Iterator<? extends E> expected) {
-      Correspondence.ExceptionStore exceptions = new Correspondence.ExceptionStore();
+      Correspondence.ExceptionStore exceptions = Correspondence.ExceptionStore.forCompare();
       while (actual.hasNext() && expected.hasNext()) {
         A actualElement = actual.next();
         E expectedElement = expected.next();
@@ -1205,24 +1206,18 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       List<? extends A> extra = findNotIndexed(actual, mapping.keySet());
       List<? extends E> missing = findNotIndexed(expected, mapping.inverse().keySet());
       if (!missing.isEmpty() || !extra.isEmpty()) {
-        Fact fact =
-            simpleFact(
-                lenientFormat(
-                    "Not true that %s contains exactly one element that %s each element of <%s>. "
-                        + "It %s",
-                    subject.actualAsString(),
-                    correspondence,
-                    expected,
-                    describeMissingOrExtra(missing, extra)));
-        if (compareExceptions.isEmpty()) {
-          subject.failWithoutActual(fact);
-        } else {
-          subject.failWithoutActual(
-              fact,
-              simpleFact(
-                  "additionally, one or more exceptions were thrown while comparing elements"),
-              compareExceptions.describe());
-        }
+        subject.failWithoutActual(
+            concat(
+                asList(
+                    simpleFact(
+                        lenientFormat(
+                            "Not true that %s contains exactly one element that %s each element "
+                                + "of <%s>. It %s",
+                            subject.actualAsString(),
+                            correspondence,
+                            expected,
+                            describeMissingOrExtra(missing, extra)))),
+                compareExceptions.describeAsAdditionalInfo()));
         return true;
       }
       return false;
@@ -1374,28 +1369,23 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       List<? extends A> extra = findNotIndexed(actual, mapping.keySet());
       List<? extends E> missing = findNotIndexed(expected, mapping.values());
       if (!missing.isEmpty() || !extra.isEmpty()) {
-        Fact fact =
-            simpleFact(
-                lenientFormat(
-                    "Not true that %s contains exactly one element that %s each element of <%s>. "
-                        + "It contains at least one element that matches each expected element, "
-                        + "and every element it contains matches at least one expected element, "
-                        + "but there was no 1:1 mapping between all the actual and expected "
-                        + "elements. Using the most complete 1:1 mapping (or one such mapping, if "
-                        + "there is a tie), it %s",
-                    subject.actualAsString(),
-                    correspondence,
-                    expected,
-                    describeMissingOrExtra(missing, extra)));
-        if (compareExceptions.isEmpty()) {
-          subject.failWithoutActual(fact);
-        } else {
-          subject.failWithoutActual(
-              fact,
-              simpleFact(
-                  "additionally, one or more exceptions were thrown while comparing elements"),
-              compareExceptions.describe());
-        }
+        subject.failWithoutActual(
+            concat(
+                asList(
+                    simpleFact(
+                        lenientFormat(
+                            "Not true that %s contains exactly one element that %s each element "
+                                + "of <%s>. It contains at least one element that matches each "
+                                + "expected element, and every element it contains matches at "
+                                + "least one expected element, but there was no 1:1 mapping "
+                                + "between all the actual and expected elements. Using the most "
+                                + "complete 1:1 mapping (or one such mapping, if there is a tie), "
+                                + "it %s",
+                            subject.actualAsString(),
+                            correspondence,
+                            expected,
+                            describeMissingOrExtra(missing, extra)))),
+                compareExceptions.describeAsAdditionalInfo()));
         return true;
       }
       return false;
@@ -1438,7 +1428,7 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       // We know they don't correspond in order, so we're going to have to do an any-order test.
       // Find a many:many mapping between the indexes of the elements which correspond, and check
       // it for completeness.
-      Correspondence.ExceptionStore compareExceptions = new Correspondence.ExceptionStore();
+      Correspondence.ExceptionStore compareExceptions = Correspondence.ExceptionStore.forCompare();
       ImmutableSetMultimap<Integer, Integer> candidateMapping =
           findCandidateMapping(actualList, expectedList, compareExceptions);
       if (failIfCandidateMappingHasMissing(
@@ -1459,13 +1449,14 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       // passed.
       if (!compareExceptions.isEmpty()) {
         subject.failWithActual(
-            simpleFact("one or more exceptions were thrown while comparing elements"),
-            compareExceptions.describe(),
-            simpleFact(
-                "comparing contents by testing that each element "
-                    + correspondence
-                    + " an expected value"),
-            fact("expected", expected));
+            concat(
+                compareExceptions.describeAsMainCause(),
+                asList(
+                    simpleFact(
+                        "comparing contents by testing that each element "
+                            + correspondence
+                            + " an expected value"),
+                    fact("expected", expected))));
         return ALREADY_FAILED;
       }
       // The 1:1 mapping maps all the expected elements, so the test succeeds (but we know from
@@ -1511,7 +1502,7 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       // couldn't be achieved by pairing it with the first. (For the any-order test, we may want to
       // pair an expected element with a later actual element so that we can pair the earlier actual
       // element with a later expected element, but that doesn't apply here.)
-      Correspondence.ExceptionStore exceptions = new Correspondence.ExceptionStore();
+      Correspondence.ExceptionStore exceptions = Correspondence.ExceptionStore.forCompare();
       while (expected.hasNext()) {
         E expectedElement = expected.next();
         // Return false if we couldn't find the expected exception, or if the correspondence threw
@@ -1553,24 +1544,18 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       List<? extends E> missing = findNotIndexed(expected, mapping.inverse().keySet());
       if (!missing.isEmpty()) {
         List<? extends A> extra = findNotIndexed(actual, mapping.keySet());
-        Fact fact =
-            simpleFact(
-                lenientFormat(
-                    "Not true that %s contains at least one element that %s each element of <%s>. "
-                        + "It %s",
-                    subject.actualAsString(),
-                    correspondence,
-                    expected,
-                    describeMissing(missing, extra)));
-        if (compareExceptions.isEmpty()) {
-          subject.failWithoutActual(fact);
-        } else {
-          subject.failWithoutActual(
-              fact,
-              simpleFact(
-                  "additionally, one or more exceptions were thrown while comparing elements"),
-              compareExceptions.describe());
-        }
+        subject.failWithoutActual(
+            concat(
+                asList(
+                    simpleFact(
+                        lenientFormat(
+                            "Not true that %s contains at least one element that %s each element "
+                                + "of <%s>. It %s",
+                            subject.actualAsString(),
+                            correspondence,
+                            expected,
+                            describeMissing(missing, extra)))),
+                compareExceptions.describeAsAdditionalInfo()));
         return true;
       }
       return false;
@@ -1640,27 +1625,22 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       List<? extends E> missing = findNotIndexed(expected, mapping.values());
       if (!missing.isEmpty()) {
         List<? extends A> extra = findNotIndexed(actual, mapping.keySet());
-        Fact fact =
-            simpleFact(
-                lenientFormat(
-                    "Not true that %s contains at least one element that %s each element of <%s>. "
-                        + "It contains at least one element that matches each expected element, "
-                        + "but there was no 1:1 mapping between all the expected elements and any "
-                        + "subset of the actual elements. Using the most complete 1:1 mapping (or "
-                        + "one such mapping, if there is a tie), it %s",
-                    subject.actualAsString(),
-                    correspondence,
-                    expected,
-                    describeMissing(missing, extra)));
-        if (compareExceptions.isEmpty()) {
-          subject.failWithoutActual(fact);
-        } else {
-          subject.failWithoutActual(
-              fact,
-              simpleFact(
-                  "additionally, one or more exceptions were thrown while comparing elements"),
-              compareExceptions.describe());
-        }
+        subject.failWithoutActual(
+            concat(
+                asList(
+                    simpleFact(
+                        lenientFormat(
+                            "Not true that %s contains at least one element that %s each element "
+                                + "of <%s>. It contains at least one element that matches each "
+                                + "expected element, but there was no 1:1 mapping between all the "
+                                + "expected elements and any subset of the actual elements. Using "
+                                + "the most complete 1:1 mapping (or one such mapping, if there is"
+                                + " a tie), it %s",
+                            subject.actualAsString(),
+                            correspondence,
+                            expected,
+                            describeMissing(missing, extra)))),
+                compareExceptions.describeAsAdditionalInfo()));
         return true;
       }
       return false;
@@ -1731,7 +1711,8 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
               simpleFact(
                   lenientFormat(
                       "Not true that %s %s <%s>. (N.B. A key function which does not uniquely key "
-                          + "the expected elements was provided and has consequently been ignored.)",
+                          + "the expected elements was provided and has consequently been "
+                          + "ignored.)",
                       subject.actualAsString(), failVerb, expected)));
         }
       } else {

--- a/core/src/main/java/com/google/common/truth/IterableSubject.java
+++ b/core/src/main/java/com/google/common/truth/IterableSubject.java
@@ -23,6 +23,7 @@ import static com.google.common.collect.Iterables.size;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.truth.Fact.fact;
 import static com.google.common.truth.Fact.simpleFact;
+import static com.google.common.truth.Facts.facts;
 import static com.google.common.truth.IterableSubject.ElementFactGrouping.ALL_IN_ONE_FACT;
 import static com.google.common.truth.IterableSubject.ElementFactGrouping.FACT_PER_ELEMENT;
 import static com.google.common.truth.SubjectUtils.accumulate;
@@ -1102,14 +1103,14 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       // unexpected null) but we are contractually obliged to throw here if the assertions passed.
       if (!compareExceptions.isEmpty()) {
         subject.failWithActual(
-            concat(
-                compareExceptions.describeAsMainCause(),
-                asList(
+            compareExceptions
+                .describeAsMainCause()
+                .and(
                     simpleFact(
                         "comparing contents by testing that each element "
                             + correspondence
                             + " an expected value"),
-                    fact("expected", expected))));
+                    fact("expected", expected)));
         return ALREADY_FAILED;
       }
       // The 1:1 mapping is complete, so the test succeeds (but we know from above that the mapping
@@ -1207,8 +1208,7 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       List<? extends E> missing = findNotIndexed(expected, mapping.inverse().keySet());
       if (!missing.isEmpty() || !extra.isEmpty()) {
         subject.failWithoutActual(
-            concat(
-                asList(
+            facts(
                     simpleFact(
                         lenientFormat(
                             "Not true that %s contains exactly one element that %s each element "
@@ -1216,8 +1216,8 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
                             subject.actualAsString(),
                             correspondence,
                             expected,
-                            describeMissingOrExtra(missing, extra)))),
-                compareExceptions.describeAsAdditionalInfo()));
+                            describeMissingOrExtra(missing, extra))))
+                .and(compareExceptions.describeAsAdditionalInfo()));
         return true;
       }
       return false;
@@ -1370,8 +1370,7 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       List<? extends E> missing = findNotIndexed(expected, mapping.values());
       if (!missing.isEmpty() || !extra.isEmpty()) {
         subject.failWithoutActual(
-            concat(
-                asList(
+            facts(
                     simpleFact(
                         lenientFormat(
                             "Not true that %s contains exactly one element that %s each element "
@@ -1384,8 +1383,8 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
                             subject.actualAsString(),
                             correspondence,
                             expected,
-                            describeMissingOrExtra(missing, extra)))),
-                compareExceptions.describeAsAdditionalInfo()));
+                            describeMissingOrExtra(missing, extra))))
+                .and(compareExceptions.describeAsAdditionalInfo()));
         return true;
       }
       return false;
@@ -1449,14 +1448,14 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       // passed.
       if (!compareExceptions.isEmpty()) {
         subject.failWithActual(
-            concat(
-                compareExceptions.describeAsMainCause(),
-                asList(
+            compareExceptions
+                .describeAsMainCause()
+                .and(
                     simpleFact(
                         "comparing contents by testing that each element "
                             + correspondence
                             + " an expected value"),
-                    fact("expected", expected))));
+                    fact("expected", expected)));
         return ALREADY_FAILED;
       }
       // The 1:1 mapping maps all the expected elements, so the test succeeds (but we know from
@@ -1545,8 +1544,7 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       if (!missing.isEmpty()) {
         List<? extends A> extra = findNotIndexed(actual, mapping.keySet());
         subject.failWithoutActual(
-            concat(
-                asList(
+            facts(
                     simpleFact(
                         lenientFormat(
                             "Not true that %s contains at least one element that %s each element "
@@ -1554,8 +1552,8 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
                             subject.actualAsString(),
                             correspondence,
                             expected,
-                            describeMissing(missing, extra)))),
-                compareExceptions.describeAsAdditionalInfo()));
+                            describeMissing(missing, extra))))
+                .and(compareExceptions.describeAsAdditionalInfo()));
         return true;
       }
       return false;
@@ -1626,8 +1624,7 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       if (!missing.isEmpty()) {
         List<? extends A> extra = findNotIndexed(actual, mapping.keySet());
         subject.failWithoutActual(
-            concat(
-                asList(
+            facts(
                     simpleFact(
                         lenientFormat(
                             "Not true that %s contains at least one element that %s each element "
@@ -1639,8 +1636,8 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
                             subject.actualAsString(),
                             correspondence,
                             expected,
-                            describeMissing(missing, extra)))),
-                compareExceptions.describeAsAdditionalInfo()));
+                            describeMissing(missing, extra))))
+                .and(compareExceptions.describeAsAdditionalInfo()));
         return true;
       }
       return false;

--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -799,6 +799,10 @@ public class Subject<S extends Subject<S, T>, T> {
     doFail(append(ImmutableList.copyOf(facts), butWas()));
   }
 
+  final void failWithActual(Facts facts) {
+    failWithActual(facts.asIterable());
+  }
+
   /**
    * Reports a failure constructing a message from a simple verb.
    *
@@ -982,6 +986,10 @@ public class Subject<S extends Subject<S, T>, T> {
   // TODO(cpovirk): Consider making this protected if there's a need for it.
   final void failWithoutActual(Iterable<Fact> facts) {
     doFail(ImmutableList.copyOf(facts));
+  }
+
+  final void failWithoutActual(Facts facts) {
+    failWithoutActual(facts.asIterable());
   }
 
   /**

--- a/core/src/test/java/com/google/common/truth/BaseSubjectTestCase.java
+++ b/core/src/test/java/com/google/common/truth/BaseSubjectTestCase.java
@@ -31,7 +31,7 @@ abstract class BaseSubjectTestCase extends PlatformBaseSubjectTestCase {
     assertThatFailure().factValue(key, index).isEqualTo(value);
   }
 
-  private TruthFailureSubject assertThatFailure() {
+  final TruthFailureSubject assertThatFailure() {
     return assertThat(expectFailure.getFailure());
   }
 }

--- a/core/src/test/java/com/google/common/truth/ChainingTest.java
+++ b/core/src/test/java/com/google/common/truth/ChainingTest.java
@@ -287,8 +287,4 @@ public final class ChainingTest extends BaseSubjectTestCase {
     assertThatFailure().hasMessageThat().isEqualTo(message);
     assertThatFailure().hasCauseThat().isEqualTo(throwable);
   }
-
-  private ThrowableSubject assertThatFailure() {
-    return assertThat(expectFailure.getFailure());
-  }
 }

--- a/core/src/test/java/com/google/common/truth/MultimapSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/MultimapSubjectTest.java
@@ -994,17 +994,24 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void comparingValuesUsing_containsExactlyEntriesIn_wrongTypeInActual() {
     ImmutableListMultimap<String, Object> actual =
-        ImmutableListMultimap.of("abc", "+123", "def", "+64", "def", "0x40", "def", new Object());
+        ImmutableListMultimap.<String, Object>of(
+            "abc", "+123", "def", "+64", "def", "0x40", "def", 999);
     ImmutableListMultimap<String, Integer> expected =
         ImmutableListMultimap.of("def", 64, "def", 123, "def", 64, "abc", 123);
-    try {
-      assertThat(actual)
-          .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
-          .containsExactlyEntriesIn(expected);
-      fail("Should have thrown.");
-    } catch (ClassCastException e) {
-      // expected
-    }
+    expectFailureWhenTestingThat(actual)
+        .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
+        .containsExactlyEntriesIn(expected);
+    assertFailureKeys(
+        "Not true that <{abc=[+123], def=[+64, 0x40, 999]}> contains exactly one element that "
+            + "has a key that is equal to and a value that parses to the key and value of each "
+            + "element of <[def=64, def=123, def=64, abc=123]>. It is missing an element that has "
+            + "a key that is equal to and a value that parses to the key and value of <def=123> "
+            + "and has unexpected elements <[def=999]>",
+        "additionally, one or more exceptions were thrown while comparing elements",
+        "first exception");
+    assertThatFailure()
+        .factValue("first exception")
+        .startsWith("compare([def=999, def=64]) threw java.lang.ClassCastException");
   }
 
   @Test
@@ -1162,15 +1169,22 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void comparingValuesUsing_containsExactly_wrongTypeInActual() {
     ImmutableListMultimap<String, Object> actual =
-        ImmutableListMultimap.of("abc", "+123", "def", "+64", "def", "0x40", "def", new Object());
-    try {
-      assertThat(actual)
-          .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
-          .containsExactly("def", 64, "def", 123, "def", 64, "abc", 123);
-      fail("Should have thrown.");
-    } catch (ClassCastException e) {
-      // expected
-    }
+        ImmutableListMultimap.<String, Object>of(
+            "abc", "+123", "def", "+64", "def", "0x40", "def", 999);
+    expectFailureWhenTestingThat(actual)
+        .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
+        .containsExactly("def", 64, "def", 123, "def", 64, "abc", 123);
+    assertFailureKeys(
+        "Not true that <{abc=[+123], def=[+64, 0x40, 999]}> contains exactly one element that "
+            + "has a key that is equal to and a value that parses to the key and value of each "
+            + "element of <[def=64, def=123, def=64, abc=123]>. It is missing an element that has "
+            + "a key that is equal to and a value that parses to the key and value of <def=123> "
+            + "and has unexpected elements <[def=999]>",
+        "additionally, one or more exceptions were thrown while comparing elements",
+        "first exception");
+    assertThatFailure()
+        .factValue("first exception")
+        .startsWith("compare([def=999, def=64]) threw java.lang.ClassCastException");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/TestCorrespondences.java
+++ b/core/src/test/java/com/google/common/truth/TestCorrespondences.java
@@ -84,6 +84,47 @@ final class TestCorrespondences {
       };
 
   /**
+   * A correspondence between strings which tests for case-insensitive equality. Supports null
+   * expected elements, but throws {@link NullPointerException} on null actual elements.
+   */
+  static final Correspondence<String, String> CASE_INSENSITIVE_EQUALITY =
+      new Correspondence<String, String>() {
+
+        @Override
+        public boolean compare(String actual, String expected) {
+          return actual.equalsIgnoreCase(expected);
+        }
+
+        @Override
+        public String toString() {
+          return "equals (ignoring case)";
+        }
+      };
+
+  /**
+   * A correspondence between strings which tests for case-insensitive equality, with a broken
+   * attempt at null-safety. The {@link #compare} implementation returns true for (null, null) and
+   * false for (non-null, null), but throws {@link NullPointerException} for (null, non-null).
+   */
+  static final Correspondence<String, String> CASE_INSENSITIVE_EQUALITY_HALF_NULL_SAFE =
+      new Correspondence<String, String>() {
+
+        @Override
+        public boolean compare(String actual, String expected) {
+          if (actual == null && expected == null) {
+            return true;
+          }
+          // Oops! We don't handle the case where actual == null but expected != null.
+          return actual.equalsIgnoreCase(expected);
+        }
+
+        @Override
+        public String toString() {
+          return "equals (ignoring case)";
+        }
+      };
+
+  /**
    * An example value object. It has an optional {@code id} field and a required {@code score}
    * field, both positive integers.
    */


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Start work on handling exceptions thrown by Correspondence.compare.

This CL:
 - Documents the agreed policy in the javadoc for Correspondence.compare.
 - Adds a package-private helper mechanism to make the policy easier to implement.
 - Implements the policy for IterableSubject's containsExactly, containsExactlyElementsIn, containsAllOf, and containsAllIn.

Implementing the policy for the other assertions is TBD. (We can get away with defining the policy but not fully implementing it since the other assertions will continue to throw any exceptions they encounter, which meets the "must fail" requirement. They're just missing the nicer behaviour which is only a convention, not a rule.)

436fb70c8c8dc7372daae94ab8e5bd8e9945a3c3

-------

<p> Refactor Correspondence.ExceptionStore for the convenience of its callers.

Previously, the assertions calling the describe() method were duplicating some common patterns and strings. This refactoring replaces describe() with two new methods that implement some of the common patterns. (The problem of duplication was only going to get worse as we implemented the same patterns in the other assertions.)

9c5c1544b9e9110085db48fb5b7f3b1253af20da

-------

<p> Introduce a helper class that makes it easier to construct lists of Facts.

2baf08afbb0e71c1d49fb1e68f57a9118067b1fe