### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/Correspondence.java
+++ b/core/src/main/java/com/google/common/truth/Correspondence.java
@@ -24,6 +24,7 @@ import static com.google.common.truth.Facts.facts;
 import static com.google.common.truth.Platform.getStackTraceAsString;
 import static java.util.Arrays.asList;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import java.util.Arrays;
 import java.util.List;
@@ -82,12 +83,12 @@ public abstract class Correspondence<A, E> {
     private final double tolerance;
 
     private TolerantNumericEquality(double tolerance) {
+      checkTolerance(tolerance);
       this.tolerance = tolerance;
     }
 
     @Override
     public boolean compare(Number actual, Number expected) {
-      checkTolerance(tolerance);
       double actualDouble = checkNotNull(actual).doubleValue();
       double expectedDouble = checkNotNull(expected).doubleValue();
       return MathUtil.equalWithinTolerance(actualDouble, expectedDouble, tolerance);
@@ -183,6 +184,8 @@ public abstract class Correspondence<A, E> {
    */
   static final class ExceptionStore {
 
+    private static final Joiner ARGUMENT_JOINER = Joiner.on(", ").useForNull("null");
+
     private final String context;
     private boolean empty = true;
     private Exception firstException;
@@ -259,7 +262,10 @@ public abstract class Correspondence<A, E> {
           "first exception",
           Strings.lenientFormat(
               "%s(%s) threw %s at %s",
-              firstMethod, firstArguments, firstException, getStackTraceAsString(firstException)));
+              firstMethod,
+              ARGUMENT_JOINER.join(firstArguments),
+              firstException,
+              getStackTraceAsString(firstException)));
     }
 
     private static void truncateStackTrace(Exception exception, Class<?> callingClass) {

--- a/core/src/test/java/com/google/common/truth/MultimapSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/MultimapSubjectTest.java
@@ -1011,7 +1011,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
         "first exception");
     assertThatFailure()
         .factValue("first exception")
-        .startsWith("compare([def=999, def=64]) threw java.lang.ClassCastException");
+        .startsWith("compare(def=999, def=64) threw java.lang.ClassCastException");
   }
 
   @Test
@@ -1184,7 +1184,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
         "first exception");
     assertThatFailure()
         .factValue("first exception")
-        .startsWith("compare([def=999, def=64]) threw java.lang.ClassCastException");
+        .startsWith("compare(def=999, def=64) threw java.lang.ClassCastException");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/PrimitiveDoubleArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveDoubleArraySubjectTest.java
@@ -904,11 +904,20 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingTolerance_contains_nullExpected() {
-    try {
-      assertThat(array(1.1, 2.2, 3.3)).usingTolerance(DEFAULT_TOLERANCE).contains(null);
-      fail("Expected NullPointerException to be thrown but wasn't");
-    } catch (NullPointerException expected) {
-    }
+    expectFailureWhenTestingThat(array(1.1, 2.2, 3.3))
+        .usingTolerance(DEFAULT_TOLERANCE)
+        .contains(null);
+    assertFailureKeys(
+        "value of",
+        "Not true that <[1.1, 2.2, 3.3]> contains at least one element that is a finite number "
+            + "within "
+            + DEFAULT_TOLERANCE
+            + " of <null>",
+        "additionally, one or more exceptions were thrown while comparing elements",
+        "first exception");
+    assertThatFailure()
+        .factValue("first exception")
+        .startsWith("compare(1.1, null) threw java.lang.NullPointerException");
   }
 
   @Test
@@ -1093,41 +1102,73 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     // Expected value is Long - supported up to +/- 2^53
     assertThat(array(1.0, 2.0, 3.0)).usingExactEquality().contains(2L);
     assertThat(array(1.0, 1L << 53, 3.0)).usingExactEquality().contains(1L << 53);
-    try {
-      assertThat(array(1.0, 2.0, 3.0)).usingExactEquality().contains((1L << 53) + 1L);
-      fail("Expected IllegalArgumentException to be thrown");
-    } catch (IllegalArgumentException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Expected value 9007199254740993 in assertion using exact double equality was a long "
-                  + "with an absolute value greater than 2^52 which has no exact double "
-                  + "representation");
-    }
-    // Expected value is BigInteger - not supported
-    try {
-      assertThat(array(1.0, 2.0, 3.0)).usingExactEquality().contains(BigInteger.valueOf(2));
-      fail("Expected IllegalArgumentException to be thrown");
-    } catch (IllegalArgumentException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Expected value in assertion using exact double equality was of unsupported type "
-                  + BigInteger.class
-                  + " (it may not have an exact double representation)");
-    }
-    // Expected value is BigDecimal - not supported
-    try {
-      assertThat(array(1.0, 2.0, 3.0)).usingExactEquality().contains(BigDecimal.valueOf(2.0));
-      fail("Expected IllegalArgumentException to be thrown");
-    } catch (IllegalArgumentException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Expected value in assertion using exact double equality was of unsupported type "
-                  + BigDecimal.class
-                  + " (it may not have an exact double representation)");
-    }
+  }
+
+  @Test
+  public void usingExactEquality_contains_otherTypes_longOutOfRange() {
+    long expected = (1L << 53) + 1L;
+    expectFailureWhenTestingThat(array(1.1, 2.2, 3.3)).usingExactEquality().contains(expected);
+    assertFailureKeys(
+        "value of",
+        "Not true that <[1.1, 2.2, 3.3]> contains at least one element that is exactly equal to <"
+            + expected
+            + ">",
+        "additionally, one or more exceptions were thrown while comparing elements",
+        "first exception");
+    assertThatFailure()
+        .factValue("first exception")
+        .startsWith("compare(1.1, " + expected + ") threw java.lang.IllegalArgumentException");
+    assertThatFailure()
+        .factValue("first exception")
+        .contains(
+            "Expected value "
+                + expected
+                + " in assertion using exact double equality was a long with an absolute value "
+                + "greater than 2^52 which has no exact double representation");
+  }
+
+  @Test
+  public void usingExactEquality_contains_otherTypes_bigIntegerNotSupported() {
+    BigInteger expected = BigInteger.valueOf(2);
+    expectFailureWhenTestingThat(array(1.1, 2.2, 3.3)).usingExactEquality().contains(expected);
+    assertFailureKeys(
+        "value of",
+        "Not true that <[1.1, 2.2, 3.3]> contains at least one element that is exactly equal to <"
+            + expected
+            + ">",
+        "additionally, one or more exceptions were thrown while comparing elements",
+        "first exception");
+    assertThatFailure()
+        .factValue("first exception")
+        .startsWith("compare(1.1, " + expected + ") threw java.lang.IllegalArgumentException");
+    assertThatFailure()
+        .factValue("first exception")
+        .contains(
+            "Expected value in assertion using exact double equality was of unsupported type "
+                + BigInteger.class
+                + " (it may not have an exact double representation)");
+  }
+
+  @Test
+  public void usingExactEquality_contains_otherTypes_bigDecimalNotSupported() {
+    BigDecimal expected = BigDecimal.valueOf(2.0);
+    expectFailureWhenTestingThat(array(1.1, 2.2, 3.3)).usingExactEquality().contains(expected);
+    assertFailureKeys(
+        "value of",
+        "Not true that <[1.1, 2.2, 3.3]> contains at least one element that is exactly equal to <"
+            + expected
+            + ">",
+        "additionally, one or more exceptions were thrown while comparing elements",
+        "first exception");
+    assertThatFailure()
+        .factValue("first exception")
+        .startsWith("compare(1.1, " + expected + ") threw java.lang.IllegalArgumentException");
+    assertThatFailure()
+        .factValue("first exception")
+        .contains(
+            "Expected value in assertion using exact double equality was of unsupported type "
+                + BigDecimal.class
+                + " (it may not have an exact double representation)");
   }
 
   @Test
@@ -1161,11 +1202,16 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void usingExactEquality_contains_nullExpected() {
-    try {
-      assertThat(array(1.1, 2.2, 3.3)).usingExactEquality().contains(null);
-      fail("Expected NullPointerException to be thrown but wasn't");
-    } catch (NullPointerException expected) {
-    }
+    expectFailureWhenTestingThat(array(1.1, 2.2, 3.3)).usingExactEquality().contains(null);
+    assertFailureKeys(
+        "value of",
+        "Not true that <[1.1, 2.2, 3.3]> contains at least one element that is exactly equal to "
+            + "<null>",
+        "additionally, one or more exceptions were thrown while comparing elements",
+        "first exception");
+    assertThatFailure()
+        .factValue("first exception")
+        .startsWith("compare(1.1, null) threw java.lang.NullPointerException");
   }
 
   @Test


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Handle exceptions from Correspondence.compare in the remaining Fuzzy Truth assertions in IterableSubject.

This handles contains, doesNotContain, containsAnyOf/In, and containsNoneOf/In, following the established pattern.

It also includes two drive-by fixes for minor bugs in failure messages:
 - One of the containsAnyOf/In messages said "exactly one" instead of "at least one".
 - When Correspondence.ExceptionStore is describing the exception context, it had spurious square brackets around the parameter list (because it just called toString() on the list).

1cd18aad48de717a0858a3c2947612b9a57df294