### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/Correspondence.java
+++ b/core/src/main/java/com/google/common/truth/Correspondence.java
@@ -196,6 +196,10 @@ public abstract class Correspondence<A, E> {
       return new ExceptionStore("comparing elements");
     }
 
+    static ExceptionStore forMapValuesCompare() {
+      return new ExceptionStore("comparing values");
+    }
+
     private ExceptionStore(String context) {
       this.context = context;
     }

--- a/core/src/main/java/com/google/common/truth/Correspondence.java
+++ b/core/src/main/java/com/google/common/truth/Correspondence.java
@@ -175,7 +175,6 @@ public abstract class Correspondence<A, E> {
    * returned false. (Note that, in the latter case at least, it is likely that the test author's
    * intention was <i>not</i> for the test to pass with these values.)
    */
-  // TODO(b/119038411): Ensure that all callers in Truth handle exceptions sensibly
   // TODO(b/119038894): Simplify the 'for example' by using a factory method when it's ready
   public abstract boolean compare(@NullableDecl A actual, @NullableDecl E expected);
 

--- a/core/src/main/java/com/google/common/truth/IterableSubject.java
+++ b/core/src/main/java/com/google/common/truth/IterableSubject.java
@@ -993,8 +993,8 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
       Correspondence.ExceptionStore compareExceptions = Correspondence.ExceptionStore.forCompare();
       for (A actual : getCastActual()) {
         if (correspondence.safeCompare(actual, expected, compareExceptions)) {
+          // Found a match, but we still need to fail if we hit an exception along the way.
           if (!compareExceptions.isEmpty()) {
-            // Found a match, but we still need to fail if we hit an exception along the way.
             subject.failWithActual(
                 compareExceptions
                     .describeAsMainCause()

--- a/core/src/main/java/com/google/common/truth/MultimapSubject.java
+++ b/core/src/main/java/com/google/common/truth/MultimapSubject.java
@@ -165,7 +165,9 @@ public class MultimapSubject extends Subject<MultimapSubject, Multimap<?, ?>> {
 
   @Override
   public void isEqualTo(@NullableDecl Object other) {
-    if (Objects.equal(actual(), other)) {
+    @SuppressWarnings("UndefinedEquals") // the contract of this method is to follow Multimap.equals
+    boolean isEqual = Objects.equal(actual(), other);
+    if (isEqual) {
       return;
     }
 

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoTruth.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoTruth.java
@@ -123,5 +123,4 @@ public final class ProtoTruth {
   }
 
   private ProtoTruth() {}
-
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove the sub-message hack method, now unused.

912b7ae63d8186d9348f5e4703fa4dfad98588f7

-------

<p> Handle exceptions from Correspondence.compare in the Fuzzy Truth assertions in MapSubject.

This follows the pattern established in IterableSubject.

(It also moves one comment in IterableSubject, which I think is slightly clearer outside its condition.)

ba8f4e089a781d150c239b9776564009730249b7

-------

<p> Suppress an ErrorProne warning in Truth.

The UndefinedEquals warning[*] triggers for MultimapSubject.ieEqualTo, because it calls Objects.equal on the multimaps. Whatever the issues with the contract of Multimap.equals, MultimapSubject.isEqualTo is required to follow that contract, so suppressing the warning seems like the right thing to do.

[*] https://github.com/google/error-prone/blob/master/docs/bugpattern/UndefinedEquals.md

e612be881b7e29aa9877fd6c0fbf186624244532

-------

<p> Handle exceptions from Correspondence.compare in the Fuzzy Truth assertions implemented directly in MultimapSubject.

They were already handled in containsExactly(EntriesIn) because those methods delegate to IterableSubject which handled them. However, this CL does add some tests for those (because at some point we plan to implement them directly in MultimapSubject to improve the failure messages, and it would be good to have the test cases in place before we do that).

This completes the work for Correspondence.compare. There's still work to do for exceptions from Correspondence.formatDiff, and from the function used to pair elements for diffing.

RELNOTES=All Fuzzy Truth assertions now handle exceptions thrown by Correspondence.compare (see the javadoc of that method for details).

81b8b77cbc74b062ed545a7994137ceb27c33c02