### PR TITLE
Moe Sync

### DIFF
--- a/core/src/test/java/com/google/common/truth/TestCorrespondences.java
+++ b/core/src/test/java/com/google/common/truth/TestCorrespondences.java
@@ -288,9 +288,23 @@ final class TestCorrespondences {
 
   /**
    * A key function for {@link Record} instances that keys records by their {@code id} values. The
-   * key is null if the record has no {@code id}. Treats null records as if they have an ID of 0.
+   * key is null if the record has no {@code id}. Does not support null records.
    */
   static final Function<Record, Integer> RECORD_ID =
+      new Function<Record, Integer>() {
+
+        @Override
+        @NullableDecl
+        public Integer apply(Record record) {
+          return record.hasId() ? record.getId() : null;
+        }
+      };
+
+  /**
+   * A key function for {@link Record} instances that keys records by their {@code id} values. The
+   * key is null if the record has no {@code id}. Does not support null records.
+   */
+  static final Function<Record, Integer> NULL_SAFE_RECORD_ID =
       new Function<Record, Integer>() {
 
         @Override


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Catch exceptions thrown by the functions used to pair elements for diffing.

RELNOTES=All Fuzzy Truth assertions now handle exceptions thrown by the functions used to pair elements for diffing (see the javadoc of IterablSubject.UsingCorrespondence.displayingDiffsPairedBy for details).

1ed3a4d8e739cd023d6539445518b464c79078b2