### PR TITLE
Moe Sync

### DIFF
--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTest.java
@@ -324,6 +324,46 @@ public class ProtoSubjectTest extends ProtoSubjectTestBase {
   }
 
   @Test
+  public void testDoubleTolerance_defaultValue() {
+    Message message = parse("o_double: 0.0");
+    Message defaultInstance = parse("");
+    Message diffMessage = parse("o_double: 0.01");
+
+    expectThat(diffMessage).isNotEqualTo(message);
+
+    if (isProto3()) {
+      // The default value is ignored and treated as unset.
+      // We treat is as equivalent to being set to 0.0 because there is no distinction in Proto 3.
+      expectThat(message).isEqualTo(defaultInstance);
+      expectThat(diffMessage).usingDoubleTolerance(0.1).isEqualTo(message);
+      expectThat(diffMessage).usingDoubleTolerance(0.1).ignoringFieldAbsence().isEqualTo(message);
+    } else {
+      // The default value can be set or unset, so we respect it.
+      expectThat(message).isNotEqualTo(defaultInstance);
+
+      expectThat(diffMessage).usingDoubleTolerance(0.1).isEqualTo(message);
+      expectThat(diffMessage).usingDoubleTolerance(0.1).isNotEqualTo(defaultInstance);
+      expectThat(diffMessage).usingDoubleTolerance(0.1).ignoringFieldAbsence().isEqualTo(message);
+      expectThat(diffMessage)
+          .usingDoubleTolerance(0.1)
+          .ignoringFieldAbsence()
+          .isEqualTo(defaultInstance);
+
+      // The same logic applies for a specified default; not available in Proto 3.
+      Message message2 = parse("o_double_defaults_to_42: 42.0");
+      Message diffMessage2 = parse("o_double_defaults_to_42: 42.01");
+
+      expectThat(diffMessage2).usingDoubleTolerance(0.1).isEqualTo(message2);
+      expectThat(diffMessage2).usingDoubleTolerance(0.1).isNotEqualTo(defaultInstance);
+      expectThat(diffMessage2).usingDoubleTolerance(0.1).ignoringFieldAbsence().isEqualTo(message2);
+      expectThat(diffMessage2)
+          .usingDoubleTolerance(0.1)
+          .ignoringFieldAbsence()
+          .isEqualTo(defaultInstance);
+    }
+  }
+
+  @Test
   public void testDoubleTolerance_scoped() {
     Message message = parse("o_double: 1.0 o_double2: 1.0");
     Message diffMessage = parse("o_double: 1.1 o_double2: 1.5");
@@ -378,6 +418,46 @@ public class ProtoSubjectTest extends ProtoSubjectTestBase {
     expectThat(diffMessage).usingFloatTolerance(0.05f).isNotEqualTo(message);
     expectThat(diffMessage).usingDoubleTolerance(0.2).isNotEqualTo(message);
 
+  }
+
+  @Test
+  public void testFloatTolerance_defaultValue() {
+    Message message = parse("o_float: 0.0");
+    Message defaultInstance = parse("");
+    Message diffMessage = parse("o_float: 0.01");
+
+    expectThat(diffMessage).isNotEqualTo(message);
+
+    if (isProto3()) {
+      // The default value is ignored and treated as unset.
+      // We treat is as equivalent to being set to 0.0f because there is no distinction in Proto 3.
+      expectThat(message).isEqualTo(defaultInstance);
+      expectThat(diffMessage).usingFloatTolerance(0.1f).isEqualTo(message);
+      expectThat(diffMessage).usingFloatTolerance(0.1f).ignoringFieldAbsence().isEqualTo(message);
+    } else {
+      // The default value can be set or unset, so we respect it.
+      expectThat(message).isNotEqualTo(defaultInstance);
+
+      expectThat(diffMessage).usingFloatTolerance(0.1f).isEqualTo(message);
+      expectThat(diffMessage).usingFloatTolerance(0.1f).isNotEqualTo(defaultInstance);
+      expectThat(diffMessage).usingFloatTolerance(0.1f).ignoringFieldAbsence().isEqualTo(message);
+      expectThat(diffMessage)
+          .usingFloatTolerance(0.1f)
+          .ignoringFieldAbsence()
+          .isEqualTo(defaultInstance);
+
+      // The same logic applies for a specified default; not available in Proto 3.
+      Message message2 = parse("o_float_defaults_to_42: 42.0");
+      Message diffMessage2 = parse("o_float_defaults_to_42: 42.01");
+
+      expectThat(diffMessage2).usingFloatTolerance(0.1f).isEqualTo(message2);
+      expectThat(diffMessage2).usingFloatTolerance(0.1f).isNotEqualTo(defaultInstance);
+      expectThat(diffMessage2).usingFloatTolerance(0.1f).ignoringFieldAbsence().isEqualTo(message2);
+      expectThat(diffMessage2)
+          .usingFloatTolerance(0.1f)
+          .ignoringFieldAbsence()
+          .isEqualTo(defaultInstance);
+    }
   }
 
   @Test

--- a/extensions/proto/src/test/proto/test_message2.proto
+++ b/extensions/proto/src/test/proto/test_message2.proto
@@ -26,14 +26,16 @@ message TestMessage2 {
   optional float o_float2 = 6;
   optional double o_double = 7;
   optional double o_double2 = 8;
+  optional float o_float_defaults_to_42 = 9 [default = 42.0];
+  optional double o_double_defaults_to_42 = 10 [default = 42.0];
 
-  optional RequiredStringMessage2 o_required_string_message = 9;
-  repeated RequiredStringMessage2 r_required_string_message = 10;
-  optional TestMessage2 o_test_message = 11;
-  repeated TestMessage2 r_test_message = 12;
-  optional SubTestMessage2 o_sub_test_message = 13;
-  repeated SubTestMessage2 r_sub_test_message = 14;
-  map<string, TestMessage2> test_message_map = 15;
+  optional RequiredStringMessage2 o_required_string_message = 11;
+  repeated RequiredStringMessage2 r_required_string_message = 12;
+  optional TestMessage2 o_test_message = 13;
+  repeated TestMessage2 r_test_message = 14;
+  optional SubTestMessage2 o_sub_test_message = 15;
+  repeated SubTestMessage2 r_sub_test_message = 16;
+  map<string, TestMessage2> test_message_map = 17;
 }
 
 message RequiredStringMessage2 {

--- a/extensions/proto/src/test/proto/test_message3.proto
+++ b/extensions/proto/src/test/proto/test_message3.proto
@@ -26,14 +26,16 @@ message TestMessage3 {
   float o_float2 = 6;
   double o_double = 7;
   double o_double2 = 8;
+  // optional float o_float_defaults_to_42 = 9 [default = 42.0];
+  // optional double o_double_defaults_to_42 = 10 [default = 42.0];
 
-  // optional RequiredStringMessage3 o_required_string_message = 9;
-  // repeated RequiredStringMessage3 r_required_string_message = 10;
-  TestMessage3 o_test_message = 11;
-  repeated TestMessage3 r_test_message = 12;
-  SubTestMessage3 o_sub_test_message = 13;
-  repeated SubTestMessage3 r_sub_test_message = 14;
-  map<string, TestMessage3> test_message_map = 15;
+  // optional RequiredStringMessage3 o_required_string_message = 11;
+  // repeated RequiredStringMessage3 r_required_string_message = 12;
+  TestMessage3 o_test_message = 13;
+  repeated TestMessage3 r_test_message = 14;
+  SubTestMessage3 o_sub_test_message = 15;
+  repeated SubTestMessage3 r_sub_test_message = 16;
+  map<string, TestMessage3> test_message_map = 17;
 }
 
 // message RequiredStringMessage3 {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Treat Proto3 primitives as with field absence ignored by default, for saner behavior of approximate float/double comparisons.

3ce14b6977a2a3930ddadcf235f0e0f141f8cd82

-------

<p> Add the basic factory method for Correspondence, that takes a BinaryPredicate.

RELNOTES=You can now create a Correspondence instance using a lambda or method reference, with the Correspondence.from factory method.

dec21783bb14a843be4d009928f8b902930a6c3c