### PR TITLE
Moe Sync

### DIFF
--- a/core/src/test/java/com/google/common/truth/CorrespondenceTest.java
+++ b/core/src/test/java/com/google/common/truth/CorrespondenceTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.fail;
 
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
-import java.util.ArrayList;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -196,17 +195,6 @@ public final class CorrespondenceTest extends BaseSubjectTestCase {
       fail("Expected NullPointerException to be thrown but wasn't");
     } catch (NullPointerException expected) {
     }
-  }
-
-  @Test
-  public void foo() {
-    ArrayList<String> list = new ArrayList<>();
-    assertThat(list).isEmpty();
-    list.add("element");
-    assertThat(list).containsExactly("element");
-    list.remove("element");
-    assertThat(list).isEmpty();
-    assertThat(list.size()).isEqualTo(0);
   }
 
   @Test


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove garbage in CorrespondenceTest

I must have been playing about with something and got confused about what client I was in. Note to self: be more careful about using D0 N0T SUBM1T...

c0a183561af8ed8af7f78b236e281780e421ed1e

-------

<p> Add formattingDiffUsing to Correspondence.

(There are a few bits of documentation cleanup left to do after this, which will happen in a follow-up CL.)

RELNOTES=You can now create a Correspondence instance that adds in diff-formatting behaviour to an existing Correspondence using Correspondence.formattingDiffsUsing.

8b52721dcc46ca9b20409674e6b6ed0d00abc832