### PR TITLE
Moe Sync

### DIFF
--- a/fuzzy.md
+++ b/fuzzy.md
@@ -8,57 +8,77 @@ title: Fuzzy Truth
 
 Fuzzy Truth extends Truth to allow you to make assertions about `Iterable`,
 `Map`, and `Multimap` subjects, where the values are compared using something
-other than object equality. The primary use cases are doubles and floats using
-[approximate equality](floating_point), as well as [protocol buffers], but the
-framework is quite general.
+other than object equality. This mechanism is integral to the APIs for comparing
+collections of doubles and floats using [approximate equality](floating_point)
+and of [protocol buffers], but the framework is quite general.
 
 ## Correspondence {#correspondence}
 
+The primary concept of Fuzzy Truth is a
+[`Correspondence`][correspondence-class]. A correspondence determines whether an
+instance of type `A` corresponds in some way to an instance of type `E`.
+Optionally, it can also [describe the difference](#formatDiff) between two
+instances that do not correspond. A `Correspondence<A, E>` is used in an
+assertion about a collection of elements of type `A` (typically the collection
+actually returned by the code under test), checking that it contains (or,
+occasionally, does not contain) certain expected elements of type `E`.
 
-The primary concept of Fuzzy Truth is a `Correspondence`. A correspondence
-determines whether an instance of type `A` corresponds in some way to an
-instance of type `E`. Optionally, it can also [describe the
-difference](#formatDiff) between two instances that do not correspond. A
-`Correspondence<A, E>` is used in an assertion about a collection of elements of
-type `A` (typically the collection actually returned by the code under test),
-checking that it contains (or, occasionally, does not contain) certain expected
-elements of type `E`.
-
-Here's an example correspondence between strings and integers, which tests
-whether the string parses as the integer.
-
-Note that it's important to implement the `toString()` method for readable
-failure messages. See the [javadoc][correspondence-tostring] for more
-information.
+Here's an example correspondence between strings, which tests whether the actual
+strings start with the expected substrings:
 
 ```java
-private static final Correspondence<String, Integer> STRING_PARSES_TO_INTEGER_CORRESPONDENCE =
-    new Correspondence<String, Integer>() {
-      @Override
-      public boolean compare(@Nullable String actual, @Nullable Integer expected) {
-        if (actual == null) {
-          return expected == null;
-        }
-        try {
-          return Integer.decode(actual).equals(expected);
-        } catch (NumberFormatException e) {
-          return false;
-        }
-      }
-      @Override
-      public String toString() {
-        return "parses to";
-      }
-    };
+private static final Correspondence<String, String> STARTS_WITH =
+    Correspondence.from(String::startsWith, "starts with");
 ```
 
+Here's an example correspondence between strings and integers, which tests
+whether the string parses as the integer:
+
+```java
+class ThisTest {
+  private static final Correspondence<String, Integer> STRING_PARSES_TO_INTEGER =
+      Correspondence.from(ThisTest::stringParsesToInteger, "parses to");
+
+  private static boolean stringParsesToInteger(
+      @Nullable String actual, @Nullable Integer expected) {
+    if (actual == null) {
+      return expected == null;
+    }
+    try {
+      return Integer.decode(actual).equals(expected);
+    } catch (NumberFormatException e) {
+      return false;
+    }
+  }
+
+  // ...tests using STRING_PARSES_TO_INTEGER...
+}
+```
+
+The most general factory method for `Correspondence` instances is
+[`Correspondence.from`][correspondence-from]. Other factory methods are
+available for convenience in specific cases, such as
+[`Correspondence.transforming`][correspondence-transforming] for testing the
+elements for equality after some transformation. Here's an example
+correspondence between instances of some `Record` class and integers, which
+tests whether calling `getId` on the record returns the integer:
+
+```java
+private static final Correspondence<MyRecord, Integer> RECORD_HAS_ID =
+    Correspondence.transforming(Record::getId, "has an ID of");
+```
+
+You may want to think about handling of null elements. In the examples above,
+`STRING_PARSES_TO_INTEGER` has explicit null handling such that a null actual
+string corresponds to a null expected integer; `STARTS_WITH` does not, and any
+test which sees a null string will fail.
 
 ## Iterable Example {#iterable}
 
 ```java
 Iterable<String> actual = ImmutableList.of("+64", "+128", "+256", "0x80");
 assertThat(actual)
-    .comparingElementsUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
+    .comparingElementsUsing(STRING_PARSES_TO_INTEGER)
     .containsExactly(64, 128, 256, 128)
     .inOrder();
 ```
@@ -72,7 +92,7 @@ semantics are used for lookups.
 ```java
 Map<String, String> actual = ImmutableMap.of("abc", "123", "def", "456");
 assertThat(actual)
-    .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
+    .comparingValuesUsing(STRING_PARSES_TO_INTEGER)
     .containsExactly("def", 456, "abc", 123);
 ```
 
@@ -86,7 +106,7 @@ equality semantics are used for lookups.
 Multimap<String, String> actual =
     ImmutableListMultimap.of("abc", "123", "def", "456", "def", "789");
 assertThat(actual)
-    .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
+    .comparingValuesUsing(STRING_PARSES_TO_INTEGER)
     .containsEntry("def", 789);
 ```
 
@@ -101,11 +121,11 @@ failing tests easier.
 
 If you are making an assertion about an `Iterable`, and you know of key some
 function which uniquely indexes the expected elements, then you can use the
-`displayingDiffsPairedBy` method to tell Fuzzy Truth about it. For example, if
-you have a type called `Record`, and you're making an assertion about an
-`Iterable<Record>` using a `Correspondence` called `RECORD_EQUIVALENCE`, and the
-expected records have unique IDs returned by a `getId()` method, then you could
-write this:
+[`displayingDiffsPairedBy`][iterable-displaying-diffs] method to tell Fuzzy
+Truth about it. For example, if you have a type called `Record`, and you're
+making an assertion about an `Iterable<Record>` using a `Correspondence` called
+`RECORD_EQUIVALENCE`, and the expected records have unique IDs returned by a
+`getId()` method, then you could write this:
 
 ```java
 assertThat(actualRecords)
@@ -128,14 +148,30 @@ fails.)
 
 ### Enabling formatted diffs between elements {#formatDiff}
 
-<!-- TODO(b/119038898): Suggest using formattingDiffsUsing instead of overriding
-     formatDiff, once implemented. -->
+Your `Correspondence` instance may optionally provide functionality which takes
+an actual and an expected element and returns a `String` describing how they
+differ. For example, a `Correspondence` that describes whether two instances of
+a value type are equivalent might provide diff-formatting to describe which
+properties of the value types are different. You can supply this functionality
+using the [`formattingDiffsUsing`][correspondence-formatting-diffs].
 
-Your `Correspondence` subclass may optionally implement the `formatDiff` method,
-which takes an actual and an expected element and returns a `String` describing
-how they differ. For example, a `Correspondence` that describes whether two
-instances of a value type are equivalent might implement `formatDiff` to
-describe which properties of the value types are different.
+Here's an example correspondence between `Record` instances:
+
+```java
+class RecordTestHelper {
+
+  static final Correspondence<Record, Record> RECORD_EQUIVALENCE =
+      Correspondence.from(MyRecordTestHelper::recordsEquivalent, "is equivalent to")
+          .formattingDiffsUsing(MyRecordTestHelper::formatRecordDiff);
+
+  static boolean recordsEquivalent(@Nullable MyRecord actual, @Nullable MyRecord expected) {
+    // code to check whether records should be considered equivalent for testing purposes
+  }
+  static String formatRecordDiff(@Nullable MyRecord actual, @Nullable MyRecord expected) {
+    // code to format the diff between the records
+  }
+}
+```
 
 When you do this, Fuzzy Truth will include these formatted diffs in failure
 messages whenever it can usefully do so. For example, when an assertion about a
@@ -146,6 +182,10 @@ you need to [enable pairing, as shown above](#displayingDiffsPairedBy).
 
 
 [protocol buffers]: https://developers.google.com/protocol-buffers/
-[correspondence-tostring]: http://google.github.io/truth/api/latest/com/google/common/truth/Correspondence.html#toString()
+[correspondence-class]: http://google.github.io/truth/api/latest/com/google/common/truth/Correspondence.html
+[correspondence-from]: http://google.github.io/truth/api/latest/com/google/common/truth/Correspondence.html#from-com.google.common.truth.Correspondence.BinaryPredicate-java.lang.String-
+[correspondence-transforming]: http://google.github.io/truth/api/latest/com/google/common/truth/Correspondence.html#transforming-com.google.common.base.Function-java-lang-String-
+[correspondence-formatting-diffs]: http://google.github.io/truth/api/latest/com/google/common/truth/Correspondence.html#formattingDiffsUsing-com.google.common.truth.Correspondence.DiffFormatter-
+[iterable-displaying-diffs]: http://google.github.io/truth/api/latest/com/google/common/truth/IterableSubject.UsingCorrespondence.html#displayingDiffsPairedBy-com.google.common.base.Function-
 [value types]: https://github.com/google/auto/blob/master/value/userguide/index.md
 

--- a/fuzzy.md
+++ b/fuzzy.md
@@ -10,7 +10,7 @@ Fuzzy Truth extends Truth to allow you to make assertions about `Iterable`,
 `Map`, and `Multimap` subjects, where the values are compared using something
 other than object equality. This mechanism is integral to the APIs for comparing
 collections of doubles and floats using [approximate equality](floating_point)
-and of [protocol buffers], but the framework is quite general.
+and of [protocol buffers](protobufs), but the framework is quite general.
 
 ## Correspondence {#correspondence}
 
@@ -180,8 +180,14 @@ it will show a diff between the value it got and the one it expected. For this
 to work for an assertion about an `Iterable` (with more than one missing value)
 you need to [enable pairing, as shown above](#displayingDiffsPairedBy).
 
+## Protocol buffers
 
-[protocol buffers]: https://developers.google.com/protocol-buffers/
+If you want to assert about a proto, an `Iterable` of protos, or a `Map` or
+`Multimap` with proto values, you should normally use [Proto Truth](protobufs).
+It is built on top of Fuzzy Truth and allows you to express most assertions more
+concisely.
+
+
 [correspondence-class]: http://google.github.io/truth/api/latest/com/google/common/truth/Correspondence.html
 [correspondence-from]: http://google.github.io/truth/api/latest/com/google/common/truth/Correspondence.html#from-com.google.common.truth.Correspondence.BinaryPredicate-java.lang.String-
 [correspondence-transforming]: http://google.github.io/truth/api/latest/com/google/common/truth/Correspondence.html#transforming-com.google.common.base.Function-java-lang-String-


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Change the javadoc of Correspondence and fuzzy.md to recommend factory methods over subclassing.

The empty constructor is explicitly added just so that we can add javadoc recommending against it. (We could deprecate it, but I don't think we want to go that far, and anyway I think it probably wouldn't do much good as folks shouldn't be explicitly calling it.)

Also includes some minor improvements such as adding more links to fuzzy.md and reordering the code in the examples in javadoc more logically.

RELNOTES=The officially recommended way of creating Correspondence instances is now to use the factory methods, rather than subclassing.

49abc54d576c237d05957c3cb4dffe43082e1014

-------

<p> Include the reference to Proto Truth in the github version of fuzzy.md.

I can't see any reason for this to be Google-internal any more.

Also change the link at the top of the page to refer to the Proto Truth docs (which refer to the protobuf docs) instead of to the protobuf docs (since this seems more helpful).

0ca0a7d0593b589ad9cc7774db8fb2d3c63fa951