### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/Correspondence.java
+++ b/core/src/main/java/com/google/common/truth/Correspondence.java
@@ -79,13 +79,13 @@ public abstract class Correspondence<A, E> {
    * with null arguments. If this causes it to throw a {@link NullPointerException}, then your test
    * will fail. (See {@link Correspondence#compare} for more detail on how exceptions are handled.)
    * In particular, if your predicate is an instance method reference on the actual value (as in the
-   * {@code String::startsWith} example below), your test will fail if it sees null actual values.
+   * {@code String::contains} example below), your test will fail if it sees null actual values.
    *
    * <p>Example using an instance method reference:
    *
    * <pre>{@code
-   * static final Correspondence<String, String> STRING_PREFIX_EQUALITY =
-   *     Correspondence.from(String::startsWith, "starts with");
+   * static final Correspondence<String, String> CONTAINS_SUBSTRING =
+   *     Correspondence.from(String::contains, "contains");
    * }</pre>
    *
    * <p>Example using a static method reference:
@@ -111,7 +111,7 @@ public abstract class Correspondence<A, E> {
    *     and returning whether the actual value corresponds to the expected value in some way
    * @param description should fill the gap in a failure message of the form {@code "not true that
    *     <some actual element> is an element that <description> <some expected element>"}, e.g.
-   *     {@code "starts with"}, {@code "is an instance of"}, or {@code "is equivalent to"}
+   *     {@code "contains"}, {@code "is an instance of"}, or {@code "is equivalent to"}
    */
   public static <A, E> Correspondence<A, E> from(
       BinaryPredicate<A, E> predicate, String description) {

--- a/core/src/main/java/com/google/common/truth/StackTraceCleaner.java
+++ b/core/src/main/java/com/google/common/truth/StackTraceCleaner.java
@@ -68,6 +68,12 @@ final class StackTraceCleaner {
       return;
     }
 
+    /*
+     * TODO(cpovirk): Consider wrapping this whole method in a try-catch in case there are any bugs.
+     * It would be a shame for us to fail to report the "real" assertion failure because we're
+     * instead reporting a bug in Truth's cosmetic stack cleaning.
+     */
+
     // Prevent infinite recursion if there is a reference cycle between Throwables.
     if (seenThrowables.contains(throwable)) {
       return;
@@ -386,7 +392,14 @@ final class StackTraceCleaner {
    * out of stack traces by the cleaner.
    */
   private static boolean isStackTraceCleaningDisabled() {
-    return Boolean.parseBoolean(
-        System.getProperty("com.google.common.truth.disable_stack_trace_cleaning"));
+    // Reading system properties might be forbidden.
+    try {
+      return Boolean.parseBoolean(
+          System.getProperty("com.google.common.truth.disable_stack_trace_cleaning"));
+    } catch (SecurityException e) {
+      // Hope for the best.
+      return false;
+      // TODO(cpovirk): Log a warning? Or is that likely to trigger other violations?
+    }
   }
 }

--- a/core/src/main/java/com/google/common/truth/StackTraceCleaner.java
+++ b/core/src/main/java/com/google/common/truth/StackTraceCleaner.java
@@ -324,7 +324,7 @@ final class StackTraceCleaner {
         "com.google.testing.junit",
         "com.google.testing.testsize",
         "com.google.testing.util"),
-    REFLECTION("Reflective call", "java.lang.reflect", "sun.reflect"),
+    REFLECTION("Reflective call", "java.lang.reflect", "jdk.internal.reflect", "sun.reflect"),
     CONCURRENT_FRAMEWORK(
         "Concurrent framework",
         "com.google.tracing.CurrentContext",

--- a/core/src/test/java/com/google/common/truth/StackTraceCleanerTest.java
+++ b/core/src/test/java/com/google/common/truth/StackTraceCleanerTest.java
@@ -15,8 +15,10 @@
  */
 package com.google.common.truth;
 
+import static com.google.common.truth.ExpectFailure.expectFailure;
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.collect.Range;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runner.Runner;
@@ -40,6 +42,20 @@ import org.junit.runners.model.Statement;
  */
 @RunWith(JUnit4.class)
 public class StackTraceCleanerTest extends BaseSubjectTestCase {
+  @Test
+  public void realWorld() {
+    try {
+      assertThat(0).isEqualTo(1);
+      throw new Error();
+    } catch (AssertionError failure) {
+      assertThat(failure.getStackTrace()).hasLength(1);
+    }
+
+    // ExpectFailure ends up with "extra" frames, but that's probably the right behavior :\
+    AssertionError failure = expectFailure(whenTesting -> whenTesting.that(0).isEqualTo(1));
+    // Currently 3 total frames on the JVM, 4 on Android.
+    assertThat(failure.getStackTrace().length).isIn(Range.closed(3, 4));
+  }
 
   @Test
   public void emptyTrace() {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Replace String::startsWith with String::contains in Correspondence examples.

The examples all (I believe) compile as given, but the startsWith examples don't compile if you inline them. For example, my javac won't compile
    assertThat(ImmutableList.of("bark", "food"))
        .comparingElementsUsing(Correspondence.from(String::startsWith, "starts with"))
        .containsExactly("foo", "bar");
which might cause confusion. (This is because there are two overloads of startsWith and it seems that javac can't figure out the correct overload and infer the type parameters for Correspondence.from at the same time. If you add the type parameters, i.e.
    assertThat(ImmutableList.of("bark", "food"))
        .comparingElementsUsing(
            Correspondence.<String, String>from(String::startsWith, "starts with"))
        .containsExactly("foo", "bar");
then it does compile.)

I'd prefer to keep the examples clean by ducking that issue.

5a257aaf3e2243827f1fc4ab2e8e07eb074d477b

-------

<p> Be tolerant of SecurityException when reading system properties.

602cc2b8499d29aec30fa047a1eda319e33de225

-------

<p> Clean stack traces of reflection under Java 9, too.

Add real-world tests for stack-trace cleaning.
They fail under Java 9 (and hopefully in any other situations in which cleaning doesn't work in practice) without this fix.

7f43c2efa33de55b027d464e1ba17cf229e55dcd

-------

<p> Load classes with the context classloader, rather than Class.forName.

Class.forName occasionally causes problems.

f320a5336cc7fc0a72a163cce2e8c57b4342c0b1