### PR TITLE
Moe Sync

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ url: "https://google.github.io"
 baseurl: '/truth'
 markdown: kramdown
 repository: google/truth
-version: "0.43"
+version: "0.44"
 
 title: Truth
 tagline: Fluent assertions for Java
@@ -26,7 +26,7 @@ nav:
       url: /comparison
   - item:
       name: Javadoc
-      url: /api/0.43/
+      url: /api/0.44/
   - item:
       name: FAQ
       url: /faq

--- a/fuzzy.md
+++ b/fuzzy.md
@@ -27,8 +27,8 @@ Here's an example correspondence between strings, which tests whether the actual
 strings start with the expected substrings:
 
 ```java
-private static final Correspondence<String, String> STARTS_WITH =
-    Correspondence.from(String::startsWith, "starts with");
+private static final Correspondence<String, String> CONTAINS_SUBSTRING =
+    Correspondence.from(String::contains, "contains");
 ```
 
 Here's an example correspondence between strings and integers, which tests
@@ -70,8 +70,8 @@ private static final Correspondence<MyRecord, Integer> RECORD_HAS_ID =
 
 You may want to think about handling of null elements. In the examples above,
 `STRING_PARSES_TO_INTEGER` has explicit null handling such that a null actual
-string corresponds to a null expected integer; `STARTS_WITH` does not, and any
-test which sees a null string will fail.
+string corresponds to a null expected integer; `CONTAINS_SUBSTRING` does not,
+and any test which sees a null string will fail.
 
 ## Iterable Example {#iterable}
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update latest version of Truth.

107f9dd2ef268ee4af0de2351dc02ffcfa938dad

-------

<p> Replace String::startsWith with String::contains in Correspondence examples.

The examples all (I believe) compile as given, but the startsWith examples don't compile if you inline them. For example, my javac won't compile
    assertThat(ImmutableList.of("bark", "food"))
        .comparingElementsUsing(Correspondence.from(String::startsWith, "starts with"))
        .containsExactly("foo", "bar");
which might cause confusion. (This is because there are two overloads of startsWith and it seems that javac can't figure out the correct overload and infer the type parameters for Correspondence.from at the same time. If you add the type parameters, i.e.
    assertThat(ImmutableList.of("bark", "food"))
        .comparingElementsUsing(
            Correspondence.<String, String>from(String::startsWith, "starts with"))
        .containsExactly("foo", "bar");
then it does compile.)

I'd prefer to keep the examples clean by ducking that issue.

677bffa7b0fcf21437b1a651ae0a63ea2bb42d4d