### PR TITLE
Moe Sync

### DIFF
--- a/extensions/java8/src/main/java/com/google/common/truth/IntStreamSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/IntStreamSubject.java
@@ -95,6 +95,7 @@ public final class IntStreamSubject extends Subject<IntStreamSubject, IntStream>
   }
 
   /** Fails if the subject does not contain at least one of the given elements. */
+  @SuppressWarnings("GoodTime") // false positive; b/122617528
   public void containsAnyOf(int first, int second, int... rest) {
     check().that(actualList).containsAnyOf(first, second, box(rest));
   }
@@ -113,6 +114,7 @@ public final class IntStreamSubject extends Subject<IntStreamSubject, IntStream>
    * on the object returned by this method. The expected elements must appear in the given order
    * within the actual elements, but they are not required to be consecutive.
    */
+  @SuppressWarnings("GoodTime") // false positive; b/122617528
   @CanIgnoreReturnValue
   public Ordered containsAllOf(int first, int second, int... rest) {
     return check().that(actualList).containsAllOf(first, second, box(rest));
@@ -164,6 +166,7 @@ public final class IntStreamSubject extends Subject<IntStreamSubject, IntStream>
    * Fails if the subject contains any of the given elements. (Duplicates are irrelevant to this
    * test, which fails if any of the actual elements equal any of the excluded.)
    */
+  @SuppressWarnings("GoodTime") // false positive; b/122617528
   public void containsNoneOf(int first, int second, int... rest) {
     check().that(actualList).containsNoneOf(first, second, box(rest));
   }

--- a/extensions/java8/src/main/java/com/google/common/truth/LongStreamSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/LongStreamSubject.java
@@ -95,6 +95,7 @@ public final class LongStreamSubject extends Subject<LongStreamSubject, LongStre
   }
 
   /** Fails if the subject does not contain at least one of the given elements. */
+  @SuppressWarnings("GoodTime") // false positive; b/122617528
   public void containsAnyOf(long first, long second, long... rest) {
     check().that(actualList).containsAnyOf(first, second, box(rest));
   }
@@ -113,6 +114,7 @@ public final class LongStreamSubject extends Subject<LongStreamSubject, LongStre
    * on the object returned by this method. The expected elements must appear in the given order
    * within the actual elements, but they are not required to be consecutive.
    */
+  @SuppressWarnings("GoodTime") // false positive; b/122617528
   @CanIgnoreReturnValue
   public Ordered containsAllOf(long first, long second, long... rest) {
     return check().that(actualList).containsAllOf(first, second, box(rest));
@@ -164,6 +166,7 @@ public final class LongStreamSubject extends Subject<LongStreamSubject, LongStre
    * Fails if the subject contains any of the given elements. (Duplicates are irrelevant to this
    * test, which fails if any of the actual elements equal any of the excluded.)
    */
+  @SuppressWarnings("GoodTime") // false positive; b/122617528
   public void containsNoneOf(long first, long second, long... rest) {
     check().that(actualList).containsNoneOf(first, second, box(rest));
   }

--- a/extensions/java8/src/main/java/com/google/common/truth/OptionalDoubleSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/OptionalDoubleSubject.java
@@ -84,7 +84,7 @@ public final class OptionalDoubleSubject extends Subject<OptionalDoubleSubject, 
       isPresent(); // fails
       return ignoreCheck().that(0.0);
     } else {
-      return check().that(actual().getAsDouble());
+      return check("getAsDouble()").that(actual().getAsDouble());
     }
   }
 

--- a/extensions/java8/src/main/java/com/google/common/truth/OptionalIntSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/OptionalIntSubject.java
@@ -77,7 +77,7 @@ public final class OptionalIntSubject extends Subject<OptionalIntSubject, Option
       isPresent(); // fails
       return ignoreCheck().that(0);
     } else {
-      return check().that(actual().getAsInt());
+      return check("getAsInt()").that(actual().getAsInt());
     }
   }
 

--- a/extensions/java8/src/main/java/com/google/common/truth/OptionalLongSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/OptionalLongSubject.java
@@ -77,7 +77,7 @@ public final class OptionalLongSubject extends Subject<OptionalLongSubject, Opti
       isPresent(); // fails
       return ignoreCheck().that(0L);
     } else {
-      return check().that(actual().getAsLong());
+      return check("getAsLong()").that(actual().getAsLong());
     }
   }
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Enable GoodTime-API for Truth

f36345902fe92970e9f6c0c9d3c3ac094ada61d0

-------

<p> Migrate Truth Subjects from no-arg check() to the overload that accepts a description.

The overload that accepts a description generally produces better failure messages:
- The first line of the message it produces is something like: "value of: myProto.getResponse()" (where "getResponse()" is taken from the provided description)
- The last line of the message it produces is something like: "myProto was: response: query was throttled" (the full value of myProto)
- And the existing text goes in between.

Additional motivation: We have deprecated the no-arg overload in open-source Truth.

Note that the new overload is available externally as of Truth 0.40.

96b89d40e2d9c6dc83849c288ff03f00da9a834b