### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/AtomicLongMapSubject.java
+++ b/core/src/main/java/com/google/common/truth/AtomicLongMapSubject.java
@@ -113,7 +113,7 @@ public final class AtomicLongMapSubject extends Subject<AtomicLongMapSubject, At
     checkNotNull(key, "AtomicLongMap does not support null keys");
     long actualValue = ((AtomicLongMap<Object>) actual()).get(key);
     if (actualValue != value) {
-      fail("contains entry", immutableEntry(key, value));
+      failWithActual("expected to contain entry", immutableEntry(key, value));
     }
   }
 
@@ -123,7 +123,7 @@ public final class AtomicLongMapSubject extends Subject<AtomicLongMapSubject, At
     checkNotNull(key, "AtomicLongMap does not support null keys");
     long actualValue = ((AtomicLongMap<Object>) actual()).get(key);
     if (actualValue == value) {
-      fail("does not contain entry", immutableEntry(key, value));
+      failWithActual("expected not to contain entry", immutableEntry(key, value));
     }
   }
 

--- a/core/src/main/java/com/google/common/truth/Expect.java
+++ b/core/src/main/java/com/google/common/truth/Expect.java
@@ -214,15 +214,6 @@ public final class Expect extends StandardSubjectBuilder implements TestRule {
     return new Expect(new ExpectationGatherer());
   }
 
-  /**
-   * <i>To be deprecated in favor of {@link #create}, which also enables stack traces.</i>
-   *
-   * <p>Creates a new instance.
-   */
-  public static Expect createAndEnableStackTrace() {
-    return create();
-  }
-
   private Expect(ExpectationGatherer gatherer) {
     super(FailureMetadata.forFailureStrategy(gatherer));
     this.gatherer = checkNotNull(gatherer);

--- a/core/src/main/java/com/google/common/truth/MapSubject.java
+++ b/core/src/main/java/com/google/common/truth/MapSubject.java
@@ -166,7 +166,7 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
                         + "However, the following keys are mapped to <%s>: %s",
                     actualAsString(), entry, value, keys)));
       } else {
-        fail("contains entry", entry);
+        failWithActual("expected to contain entry", entry);
       }
     }
   }

--- a/core/src/main/java/com/google/common/truth/MathUtil.java
+++ b/core/src/main/java/com/google/common/truth/MathUtil.java
@@ -19,7 +19,7 @@ package com.google.common.truth;
 import com.google.common.primitives.Doubles;
 
 /** Math utilities to be shared by numeric subjects. */
-public final class MathUtil {
+final class MathUtil {
   private MathUtil() {}
 
   /**

--- a/core/src/main/java/com/google/common/truth/MultimapSubject.java
+++ b/core/src/main/java/com/google/common/truth/MultimapSubject.java
@@ -142,7 +142,7 @@ public class MultimapSubject extends Subject<MultimapSubject, Multimap<?, ?>> {
                         + "However, the following keys are mapped to <%s>: %s",
                     actualAsString(), entry, value, keys)));
       } else {
-        fail("contains entry", Maps.immutableEntry(key, value));
+        failWithActual("expected to contain entry", Maps.immutableEntry(key, value));
       }
     }
   }

--- a/core/src/main/java/com/google/common/truth/SortedMapSubject.java
+++ b/core/src/main/java/com/google/common/truth/SortedMapSubject.java
@@ -56,7 +56,7 @@ public final class SortedMapSubject extends MapSubject {
   /** Fails if the map's first key is not equal to the given key. */
   public void hasFirstKey(@NullableDecl Object key) {
     if (actualAsNavigableMap().isEmpty()) {
-      fail("has first key", key);
+      failWithActual("expected to have first key", key);
       return;
     }
 
@@ -83,7 +83,7 @@ public final class SortedMapSubject extends MapSubject {
   public void hasFirstEntry(@NullableDecl Object key, @NullableDecl Object value) {
     Entry<Object, Object> expectedEntry = Maps.immutableEntry(key, value);
     if (actualAsNavigableMap().isEmpty()) {
-      fail("has first entry", expectedEntry);
+      failWithActual("expected to have first entry", expectedEntry);
       return;
     }
 
@@ -146,7 +146,7 @@ public final class SortedMapSubject extends MapSubject {
   /** Fails if the map's last key is not equal to the given key. */
   public void hasLastKey(@NullableDecl Object key) {
     if (actualAsNavigableMap().isEmpty()) {
-      fail("has last key", key);
+      failWithActual("expected to have last key", key);
       return;
     }
 
@@ -173,7 +173,7 @@ public final class SortedMapSubject extends MapSubject {
   public void hasLastEntry(@NullableDecl Object key, @NullableDecl Object value) {
     Entry<Object, Object> expectedEntry = Maps.immutableEntry(key, value);
     if (actualAsNavigableMap().isEmpty()) {
-      fail("has last entry", expectedEntry);
+      failWithActual("expected to have last entry", expectedEntry);
       return;
     }
 

--- a/core/src/main/java/com/google/common/truth/SortedSetSubject.java
+++ b/core/src/main/java/com/google/common/truth/SortedSetSubject.java
@@ -49,7 +49,7 @@ public final class SortedSetSubject extends IterableSubject {
   /** Fails if the subject does not have the given first element. */
   public void hasFirstElement(@NullableDecl Object element) {
     if (actualAsNavigableSet().isEmpty()) {
-      fail("has first element", element);
+      failWithActual("expected to have first element", element);
       return;
     }
 
@@ -75,7 +75,7 @@ public final class SortedSetSubject extends IterableSubject {
   /** Fails if the subject does not have the given last element. */
   public void hasLastElement(@NullableDecl Object element) {
     if (actualAsNavigableSet().isEmpty()) {
-      fail("has last element", element);
+      failWithActual("expected to have last element", element);
       return;
     }
 

--- a/core/src/test/java/com/google/common/truth/AtomicLongMapSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/AtomicLongMapSubjectTest.java
@@ -189,9 +189,9 @@ public final class AtomicLongMapSubjectTest extends BaseSubjectTestCase {
     AtomicLongMap<String> actual = AtomicLongMap.create();
     actual.getAndIncrement("kurt");
     expectFailureWhenTestingThat(actual).containsEntry("greg", 2);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{kurt=1}> contains entry <greg=2>");
+    assertFailureKeys("expected to contain entry", "but was");
+    assertFailureValue("expected to contain entry", "greg=2");
+    assertFailureValue("but was", "{kurt=1}");
   }
 
   @Test
@@ -217,9 +217,9 @@ public final class AtomicLongMapSubjectTest extends BaseSubjectTestCase {
     AtomicLongMap<String> actual = AtomicLongMap.create();
     actual.getAndIncrement("kurt");
     expectFailureWhenTestingThat(actual).doesNotContainEntry("kurt", 1);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{kurt=1}> does not contain entry <kurt=1>");
+    assertFailureKeys("expected not to contain entry", "but was");
+    assertFailureValue("expected not to contain entry", "kurt=1");
+    assertFailureValue("but was", "{kurt=1}");
   }
 
   @Test
@@ -254,9 +254,9 @@ public final class AtomicLongMapSubjectTest extends BaseSubjectTestCase {
     AtomicLongMap<String> actual = AtomicLongMap.create();
     actual.getAndIncrement("kurt");
     expectFailureWhenTestingThat(actual).containsEntry("kurt", 2);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{kurt=1}> contains entry <kurt=2>");
+    assertFailureKeys("expected to contain entry", "but was");
+    assertFailureValue("expected to contain entry", "kurt=2");
+    assertFailureValue("but was", "{kurt=1}");
   }
 
   private AtomicLongMapSubject expectFailureWhenTestingThat(AtomicLongMap<?> actual) {

--- a/core/src/test/java/com/google/common/truth/ComparableSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/ComparableSubjectTest.java
@@ -18,6 +18,7 @@ package com.google.common.truth;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.ExpectFailure.assertThat;
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.Range;
@@ -199,7 +200,7 @@ public class ComparableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void namedComparableType() {
-    assertThat(new ComparableType(2)).named("comparable").isLessThan(new ComparableType(3));
+    assertWithMessage("comparable").that(new ComparableType(2)).isLessThan(new ComparableType(3));
   }
 
   private static final class ComparableType implements Comparable<ComparableType> {

--- a/core/src/test/java/com/google/common/truth/ExpectFailureWithStackTraceTest.java
+++ b/core/src/test/java/com/google/common/truth/ExpectFailureWithStackTraceTest.java
@@ -40,7 +40,7 @@ public class ExpectFailureWithStackTraceTest {
 
   /** Expect class that can examine the error message */
   public static class FailingExpect implements TestRule {
-    final Expect delegate = Expect.createAndEnableStackTrace();
+    final Expect delegate = Expect.create();
 
     @Override
     public Statement apply(Statement base, Description description) {

--- a/core/src/test/java/com/google/common/truth/ExpectWithStackTest.java
+++ b/core/src/test/java/com/google/common/truth/ExpectWithStackTest.java
@@ -28,7 +28,7 @@ import org.junit.runners.model.Statement;
 
 @RunWith(JUnit4.class)
 public class ExpectWithStackTest {
-  private final Expect expectWithTrace = Expect.createAndEnableStackTrace();
+  private final Expect expectWithTrace = Expect.create();
 
   @Rule public final TestRuleVerifier verifyAssertionError = new TestRuleVerifier(expectWithTrace);
 

--- a/core/src/test/java/com/google/common/truth/IterableSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/IterableSubjectTest.java
@@ -273,9 +273,9 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
     CountsToStringCalls o = new CountsToStringCalls();
     List<Object> actual = asList(o, 1);
     List<Object> expected = asList(1, o);
-    assertThat(actual).containsAllIn(expected);
+    assertThat(actual).containsAtLeastElementsIn(expected);
     assertThat(o.calls).isEqualTo(0);
-    expectFailureWhenTestingThat(actual).containsAllIn(expected).inOrder();
+    expectFailureWhenTestingThat(actual).containsAtLeastElementsIn(expected).inOrder();
     assertThat(o.calls).isGreaterThan(0);
   }
 
@@ -446,9 +446,9 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAllInIterable() {
-    assertThat(asList(1, 2, 3)).containsAllIn(asList(1, 2));
+    assertThat(asList(1, 2, 3)).containsAtLeastElementsIn(asList(1, 2));
 
-    expectFailureWhenTestingThat(asList(1, 2, 3)).containsAllIn(asList(1, 2, 4));
+    expectFailureWhenTestingThat(asList(1, 2, 3)).containsAtLeastElementsIn(asList(1, 2, 4));
     assertFailureKeys("missing (1)", "---", "expected to contain at least", "but was");
     assertFailureValue("missing (1)", "4");
     assertFailureValue("expected to contain at least", "[1, 2, 4]");
@@ -456,7 +456,8 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAllInCanUseFactPerElement() {
-    expectFailureWhenTestingThat(asList("abc")).containsAllIn(asList("123\n456", "789"));
+    expectFailureWhenTestingThat(asList("abc"))
+        .containsAtLeastElementsIn(asList("123\n456", "789"));
     assertFailureKeys("missing (2)", "#1", "#2", "---", "expected to contain at least", "but was");
     assertFailureValue("#1", "123\n456");
     assertFailureValue("#2", "789");
@@ -469,9 +470,10 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAllInArray() {
-    assertThat(asList(1, 2, 3)).containsAllIn(new Integer[] {1, 2});
+    assertThat(asList(1, 2, 3)).containsAtLeastElementsIn(new Integer[] {1, 2});
 
-    expectFailureWhenTestingThat(asList(1, 2, 3)).containsAllIn(new Integer[] {1, 2, 4});
+    expectFailureWhenTestingThat(asList(1, 2, 3))
+        .containsAtLeastElementsIn(new Integer[] {1, 2, 4});
     assertFailureKeys("missing (1)", "---", "expected to contain at least", "but was");
     assertFailureValue("missing (1)", "4");
     assertFailureValue("expected to contain at least", "[1, 2, 4]");

--- a/core/src/test/java/com/google/common/truth/IterableSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/IterableSubjectTest.java
@@ -239,22 +239,22 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAllOfWithMany() {
-    assertThat(asList(1, 2, 3)).containsAllOf(1, 2);
+    assertThat(asList(1, 2, 3)).containsAtLeast(1, 2);
   }
 
   @Test
   public void iterableContainsAllOfWithDuplicates() {
-    assertThat(asList(1, 2, 2, 2, 3)).containsAllOf(2, 2);
+    assertThat(asList(1, 2, 2, 2, 3)).containsAtLeast(2, 2);
   }
 
   @Test
   public void iterableContainsAllOfWithNull() {
-    assertThat(asList(1, null, 3)).containsAllOf(3, (Integer) null);
+    assertThat(asList(1, null, 3)).containsAtLeast(3, (Integer) null);
   }
 
   @Test
   public void iterableContainsAllOfWithNullAtThirdAndFinalPosition() {
-    assertThat(asList(1, null, 3)).containsAllOf(1, 3, (Object) null);
+    assertThat(asList(1, null, 3)).containsAtLeast(1, 3, (Object) null);
   }
 
   /*
@@ -281,7 +281,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAllOfFailure() {
-    expectFailureWhenTestingThat(asList(1, 2, 3)).containsAllOf(1, 2, 4);
+    expectFailureWhenTestingThat(asList(1, 2, 3)).containsAtLeast(1, 2, 4);
     assertFailureKeys("missing (1)", "---", "expected to contain at least", "but was");
     assertFailureValue("missing (1)", "4");
     assertFailureValue("expected to contain at least", "[1, 2, 4]");
@@ -289,19 +289,19 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAllOfWithExtras() {
-    expectFailureWhenTestingThat(asList("y", "x")).containsAllOf("x", "y", "z");
+    expectFailureWhenTestingThat(asList("y", "x")).containsAtLeast("x", "y", "z");
     assertFailureValue("missing (1)", "z");
   }
 
   @Test
   public void iterableContainsAllOfWithExtraCopiesOfOutOfOrder() {
-    expectFailureWhenTestingThat(asList("y", "x")).containsAllOf("x", "y", "y");
+    expectFailureWhenTestingThat(asList("y", "x")).containsAtLeast("x", "y", "y");
     assertFailureValue("missing (1)", "y");
   }
 
   @Test
   public void iterableContainsAllOfWithDuplicatesFailure() {
-    expectFailureWhenTestingThat(asList(1, 2, 3)).containsAllOf(1, 2, 2, 2, 3, 4);
+    expectFailureWhenTestingThat(asList(1, 2, 3)).containsAtLeast(1, 2, 2, 2, 3, 4);
     assertFailureValue("missing (3)", "2 [2 copies], 4");
   }
 
@@ -311,40 +311,40 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
    */
   @Test
   public void iterableContainsAllOfWithDuplicateMissingElements() {
-    expectFailureWhenTestingThat(asList(1, 2)).containsAllOf(4, 4, 4);
+    expectFailureWhenTestingThat(asList(1, 2)).containsAtLeast(4, 4, 4);
     assertFailureValue("missing (3)", "4 [3 copies]");
   }
 
   @Test
   public void iterableContainsAllOfWithNullFailure() {
-    expectFailureWhenTestingThat(asList(1, null, 3)).containsAllOf(1, null, null, 3);
+    expectFailureWhenTestingThat(asList(1, null, 3)).containsAtLeast(1, null, null, 3);
     assertFailureValue("missing (1)", "null");
   }
 
   @Test
   public void iterableContainsAllOfFailsWithSameToStringAndHomogeneousList() {
-    expectFailureWhenTestingThat(asList(1L, 2L)).containsAllOf(1, 2);
+    expectFailureWhenTestingThat(asList(1L, 2L)).containsAtLeast(1, 2);
     assertFailureValue("missing (2)", "1, 2 (java.lang.Integer)");
     assertFailureValue("though it did contain (2)", "1, 2 (java.lang.Long)");
   }
 
   @Test
   public void iterableContainsAllOfFailsWithSameToStringAndHomogeneousListWithDuplicates() {
-    expectFailureWhenTestingThat(asList(1L, 2L, 2L)).containsAllOf(1, 1, 2);
+    expectFailureWhenTestingThat(asList(1L, 2L, 2L)).containsAtLeast(1, 1, 2);
     assertFailureValue("missing (3)", "1 [2 copies], 2 (java.lang.Integer)");
     assertFailureValue("though it did contain (3)", "1, 2 [2 copies] (java.lang.Long)");
   }
 
   @Test
   public void iterableContainsAllOfFailsWithSameToStringAndHomogeneousListWithNull() {
-    expectFailureWhenTestingThat(asList("null", "abc")).containsAllOf("abc", null);
+    expectFailureWhenTestingThat(asList("null", "abc")).containsAtLeast("abc", null);
     assertFailureValue("missing (1)", "null (null type)");
     assertFailureValue("though it did contain (1)", "null (java.lang.String)");
   }
 
   @Test
   public void iterableContainsAllOfFailsWithSameToStringAndHeterogeneousListWithDuplicates() {
-    expectFailureWhenTestingThat(asList(1, 2, 2L, 3L, 3L)).containsAllOf(2L, 2L, 3, 3);
+    expectFailureWhenTestingThat(asList(1, 2, 2L, 3L, 3L)).containsAtLeast(2L, 2L, 3, 3);
     assertFailureValue("missing (3)", "2 (java.lang.Long), 3 (java.lang.Integer) [2 copies]");
     assertFailureValue(
         "though it did contain (3)", "2 (java.lang.Integer), 3 (java.lang.Long) [2 copies]");
@@ -352,7 +352,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAllOfFailsWithEmptyString() {
-    expectFailureWhenTestingThat(asList("a", null)).containsAllOf("", null);
+    expectFailureWhenTestingThat(asList("a", null)).containsAtLeast("", null);
 
     assertFailureKeys("missing (1)", "---", "expected to contain at least", "but was");
     assertFailureValue("missing (1)", "");
@@ -360,29 +360,29 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAllOfInOrder() {
-    assertThat(asList(3, 2, 5)).containsAllOf(3, 2, 5).inOrder();
+    assertThat(asList(3, 2, 5)).containsAtLeast(3, 2, 5).inOrder();
   }
 
   @Test
   public void iterableContainsAllOfInOrderWithGaps() {
-    assertThat(asList(3, 2, 5)).containsAllOf(3, 5).inOrder();
-    assertThat(asList(3, 2, 2, 4, 5)).containsAllOf(3, 2, 2, 5).inOrder();
-    assertThat(asList(3, 1, 4, 1, 5)).containsAllOf(3, 1, 5).inOrder();
-    assertThat(asList("x", "y", "y", "z")).containsAllOf("x", "y", "z").inOrder();
-    assertThat(asList("x", "x", "y", "z")).containsAllOf("x", "y", "z").inOrder();
-    assertThat(asList("z", "x", "y", "z")).containsAllOf("x", "y", "z").inOrder();
-    assertThat(asList("x", "x", "y", "z", "x")).containsAllOf("x", "y", "z", "x").inOrder();
+    assertThat(asList(3, 2, 5)).containsAtLeast(3, 5).inOrder();
+    assertThat(asList(3, 2, 2, 4, 5)).containsAtLeast(3, 2, 2, 5).inOrder();
+    assertThat(asList(3, 1, 4, 1, 5)).containsAtLeast(3, 1, 5).inOrder();
+    assertThat(asList("x", "y", "y", "z")).containsAtLeast("x", "y", "z").inOrder();
+    assertThat(asList("x", "x", "y", "z")).containsAtLeast("x", "y", "z").inOrder();
+    assertThat(asList("z", "x", "y", "z")).containsAtLeast("x", "y", "z").inOrder();
+    assertThat(asList("x", "x", "y", "z", "x")).containsAtLeast("x", "y", "z", "x").inOrder();
   }
 
   @Test
   public void iterableContainsAllOfInOrderWithNull() {
-    assertThat(asList(3, null, 5)).containsAllOf(3, null, 5).inOrder();
-    assertThat(asList(3, null, 7, 5)).containsAllOf(3, null, 5).inOrder();
+    assertThat(asList(3, null, 5)).containsAtLeast(3, null, 5).inOrder();
+    assertThat(asList(3, null, 7, 5)).containsAtLeast(3, null, 5).inOrder();
   }
 
   @Test
   public void iterableContainsAllOfInOrderWithFailure() {
-    expectFailureWhenTestingThat(asList(1, null, 3)).containsAllOf(null, 1, 3).inOrder();
+    expectFailureWhenTestingThat(asList(1, null, 3)).containsAtLeast(null, 1, 3).inOrder();
     assertFailureKeys(
         "required elements were all found, but order was wrong",
         "expected order for required elements",
@@ -407,7 +407,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
           }
         };
 
-    assertThat(oneShot).containsAllOf(1, null, 3).inOrder();
+    assertThat(oneShot).containsAtLeast(1, null, 3).inOrder();
   }
 
   @Test
@@ -426,7 +426,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
           }
         };
 
-    expectFailureWhenTestingThat(iterable).containsAllOf(1, 3, (Object) null).inOrder();
+    expectFailureWhenTestingThat(iterable).containsAtLeast(1, 3, (Object) null).inOrder();
     assertFailureKeys(
         "required elements were all found, but order was wrong",
         "expected order for required elements",
@@ -436,7 +436,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void iterableContainsAllOfInOrderWrongOrderAndMissing() {
-    expectFailureWhenTestingThat(asList(1, 2)).containsAllOf(2, 1, 3).inOrder();
+    expectFailureWhenTestingThat(asList(1, 2)).containsAtLeast(2, 1, 3).inOrder();
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/MapSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/MapSubjectTest.java
@@ -879,9 +879,9 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   public void containsEntryFailure() {
     ImmutableMap<String, String> actual = ImmutableMap.of("kurt", "kluever");
     expectFailureWhenTestingThat(actual).containsEntry("greg", "kick");
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{kurt=kluever}> contains entry <greg=kick>");
+    assertFailureKeys("expected to contain entry", "but was");
+    assertFailureValue("expected to contain entry", "greg=kick");
+    assertFailureValue("but was", "{kurt=kluever}");
   }
 
   @Test
@@ -913,9 +913,9 @@ public class MapSubjectTest extends BaseSubjectTestCase {
   public void containsNullKeyAndValue() {
     ImmutableMap<String, String> actual = ImmutableMap.of("kurt", "kluever");
     expectFailureWhenTestingThat(actual).containsEntry(null, null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{kurt=kluever}> contains entry <null=null>");
+    assertFailureKeys("expected to contain entry", "but was");
+    assertFailureValue("expected to contain entry", "null=null");
+    assertFailureValue("but was", "{kurt=kluever}");
   }
 
   @Test
@@ -1829,10 +1829,10 @@ public class MapSubjectTest extends BaseSubjectTestCase {
         .comparingValuesUsing(WITHIN_10_OF)
         .containsAtLeastEntriesIn(expected);
     assertFailureKeys(
-        "Not true that <{abc=35, def=null, ghi=95}> contains at least one entry that has a key that "
-            + "is equal to and a value that is within 10 of the key and value of each entry of "
-            + "<{abc=30, def=60, ghi=90}>. It has the following entries with matching keys but "
-            + "different values: {def=(expected 60 but got null)}",
+        "Not true that <{abc=35, def=null, ghi=95}> contains at least one entry that has a key"
+            + " that is equal to and a value that is within 10 of the key and value of each entry"
+            + " of <{abc=30, def=60, ghi=90}>. It has the following entries with matching keys but"
+            + " different values: {def=(expected 60 but got null)}",
         "additionally, one or more exceptions were thrown while comparing values",
         "first exception",
         "additionally, one or more exceptions were thrown while formatting diffs",

--- a/core/src/test/java/com/google/common/truth/MultimapSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/MultimapSubjectTest.java
@@ -398,7 +398,7 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
 
     assertThat(multimap).valuesForKey(3).hasSize(3);
     assertThat(multimap).valuesForKey(4).containsExactly("four", "five");
-    assertThat(multimap).valuesForKey(3).containsAllOf("one", "six").inOrder();
+    assertThat(multimap).valuesForKey(3).containsAtLeast("one", "six").inOrder();
     assertThat(multimap).valuesForKey(5).isEmpty();
   }
 

--- a/core/src/test/java/com/google/common/truth/MultimapSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/MultimapSubjectTest.java
@@ -314,9 +314,9 @@ public class MultimapSubjectTest extends BaseSubjectTestCase {
   public void containsEntryFailure() {
     ImmutableMultimap<String, String> multimap = ImmutableMultimap.of("kurt", "kluever");
     expectFailureWhenTestingThat(multimap).containsEntry("daniel", "ploch");
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{kurt=[kluever]}> contains entry <daniel=ploch>");
+    assertFailureKeys("expected to contain entry", "but was");
+    assertFailureValue("expected to contain entry", "daniel=ploch");
+    assertFailureValue("but was", "{kurt=[kluever]}");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/MultisetSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/MultisetSubjectTest.java
@@ -16,6 +16,7 @@
 package com.google.common.truth;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.Multiset;
@@ -38,7 +39,7 @@ public class MultisetSubjectTest extends BaseSubjectTestCase {
     assertThat(multiset).hasCount("kluever", 1);
     assertThat(multiset).hasCount("alfred", 0);
 
-    assertThat(multiset).named("name").hasCount("kurt", 2);
+    assertWithMessage("name").that(multiset).hasCount("kurt", 2);
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/PrimitiveBooleanArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveBooleanArraySubjectTest.java
@@ -43,7 +43,7 @@ public class PrimitiveBooleanArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void asList() {
-    assertThat(array(true, true, false)).asList().containsAllOf(true, false);
+    assertThat(array(true, true, false)).asList().containsAtLeast(true, false);
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/PrimitiveByteArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveByteArraySubjectTest.java
@@ -46,7 +46,7 @@ public class PrimitiveByteArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void asList() {
-    assertThat(array(BYTE_0, BYTE_1, BYTE_2)).asList().containsAllOf(BYTE_0, BYTE_2);
+    assertThat(array(BYTE_0, BYTE_1, BYTE_2)).asList().containsAtLeast(BYTE_0, BYTE_2);
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/PrimitiveCharArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveCharArraySubjectTest.java
@@ -43,7 +43,7 @@ public class PrimitiveCharArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void asList() {
-    assertThat(array('a', 'q', 'z')).asList().containsAllOf('a', 'z');
+    assertThat(array('a', 'q', 'z')).asList().containsAtLeast('a', 'z');
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/PrimitiveIntArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveIntArraySubjectTest.java
@@ -45,7 +45,7 @@ public class PrimitiveIntArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void asList() {
-    assertThat(array(5, 2, 9)).asList().containsAllOf(2, 9);
+    assertThat(array(5, 2, 9)).asList().containsAtLeast(2, 9);
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/PrimitiveLongArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveLongArraySubjectTest.java
@@ -43,7 +43,7 @@ public class PrimitiveLongArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void asList() {
-    assertThat(array(5, 2, 9)).asList().containsAllOf(2L, 9L);
+    assertThat(array(5, 2, 9)).asList().containsAtLeast(2L, 9L);
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/PrimitiveShortArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveShortArraySubjectTest.java
@@ -43,12 +43,12 @@ public class PrimitiveShortArraySubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void asList() {
-    assertThat(array(1, 1, 0)).asList().containsAllOf((short) 1, (short) 0);
+    assertThat(array(1, 1, 0)).asList().containsAtLeast((short) 1, (short) 0);
   }
 
   @Test
   public void asListWithoutCastingFails() {
-    expectFailureWhenTestingThat(array(1, 1, 0)).asList().containsAllOf(1, 0);
+    expectFailureWhenTestingThat(array(1, 1, 0)).asList().containsAtLeast(1, 0);
     assertFailureKeys(
         "value of",
         "missing (2)",

--- a/core/src/test/java/com/google/common/truth/SortedMapSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/SortedMapSubjectTest.java
@@ -68,35 +68,35 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
-  public void hasFirstLastKey_empty_1() {
+  public void hasFirstKey_empty() {
     expectFailureWhenTestingThat(ImmutableSortedMap.of()).hasFirstKey(1);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{}> has first key <1>");
+    assertFailureKeys("expected to have first key", "but was");
+    assertFailureValue("expected to have first key", "1");
+    assertFailureValue("but was", "{}");
   }
 
   @Test
-  public void hasFirstLastKey_empty_2() {
+  public void hasLastKey_empty() {
     expectFailureWhenTestingThat(ImmutableSortedMap.of()).hasLastKey(1);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{}> has last key <1>");
+    assertFailureKeys("expected to have last key", "but was");
+    assertFailureValue("expected to have last key", "1");
+    assertFailureValue("but was", "{}");
   }
 
   @Test
-  public void hasFirstLastKey_empty_3() {
+  public void hasFirstKey_empty_null() {
     expectFailureWhenTestingThat(ImmutableSortedMap.of()).hasFirstKey(null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{}> has first key <null>");
+    assertFailureKeys("expected to have first key", "but was");
+    assertFailureValue("expected to have first key", "null");
+    assertFailureValue("but was", "{}");
   }
 
   @Test
-  public void hasFirstLastKey_empty_4() {
+  public void hasLastKey_empty_null() {
     expectFailureWhenTestingThat(ImmutableSortedMap.of()).hasLastKey(null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{}> has last key <null>");
+    assertFailureKeys("expected to have last key", "but was");
+    assertFailureValue("expected to have last key", "null");
+    assertFailureValue("but was", "{}");
   }
 
   @Test
@@ -154,36 +154,35 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
-  public void hasFirstLastEntry_empty() {
+  public void hasFirstEntry_empty() {
     expectFailureWhenTestingThat(ImmutableSortedMap.of()).hasFirstEntry(1, 0);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{}> has first entry <1=0>");
+    assertFailureKeys("expected to have first entry", "but was");
+    assertFailureValue("expected to have first entry", "1=0");
+    assertFailureValue("but was", "{}");
   }
 
   @Test
-  public void hasFirstLastEntry_empty_2() {
-
+  public void hasLastEntry_empty() {
     expectFailureWhenTestingThat(ImmutableSortedMap.of()).hasLastEntry(1, 0);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{}> has last entry <1=0>");
+    assertFailureKeys("expected to have last entry", "but was");
+    assertFailureValue("expected to have last entry", "1=0");
+    assertFailureValue("but was", "{}");
   }
 
   @Test
-  public void hasFirstLastEntry_empty_3() {
+  public void hasFirstEntry_empty_null() {
     expectFailureWhenTestingThat(ImmutableSortedMap.of()).hasFirstEntry(null, null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{}> has first entry <null=null>");
+    assertFailureKeys("expected to have first entry", "but was");
+    assertFailureValue("expected to have first entry", "null=null");
+    assertFailureValue("but was", "{}");
   }
 
   @Test
-  public void hasFirstLastEntry_empty_4() {
+  public void hasLastEntry_empty_null() {
     expectFailureWhenTestingThat(ImmutableSortedMap.of()).hasLastEntry(null, null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <{}> has last entry <null=null>");
+    assertFailureKeys("expected to have last entry", "but was");
+    assertFailureValue("expected to have last entry", "null=null");
+    assertFailureValue("but was", "{}");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/SortedMapSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/SortedMapSubjectTest.java
@@ -16,6 +16,7 @@
 package com.google.common.truth;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static java.util.Collections.unmodifiableSortedMap;
 
 import com.google.common.collect.ImmutableSortedMap;
@@ -56,7 +57,7 @@ public class SortedMapSubjectTest extends BaseSubjectTestCase {
   @Test
   public void verifyNamed() {
     @SuppressWarnings("unused")
-    SortedMapSubject unused = assertThat(ImmutableSortedMap.of()).named("foo");
+    SortedMapSubject unused = assertWithMessage("foo").that(ImmutableSortedMap.of());
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/SortedSetSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/SortedSetSubjectTest.java
@@ -68,35 +68,35 @@ public class SortedSetSubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
-  public void hasFirstLastElement_empty() {
+  public void hasFirstElement_empty() {
     expectFailureWhenTestingThat(ImmutableSortedSet.of()).hasFirstElement(1);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <[]> has first element <1>");
+    assertFailureKeys("expected to have first element", "but was");
+    assertFailureValue("expected to have first element", "1");
+    assertFailureValue("but was", "[]");
   }
 
   @Test
-  public void hasFirstLastElement_empty_2() {
+  public void hasLastElement_empty() {
     expectFailureWhenTestingThat(ImmutableSortedSet.of()).hasLastElement(1);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <[]> has last element <1>");
+    assertFailureKeys("expected to have last element", "but was");
+    assertFailureValue("expected to have last element", "1");
+    assertFailureValue("but was", "[]");
   }
 
   @Test
-  public void hasFirstLastElement_empty_3() {
+  public void hasFirstElement_empty_null() {
     expectFailureWhenTestingThat(ImmutableSortedSet.of()).hasFirstElement(null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <[]> has first element <null>");
+    assertFailureKeys("expected to have first element", "but was");
+    assertFailureValue("expected to have first element", "null");
+    assertFailureValue("but was", "[]");
   }
 
   @Test
-  public void hasFirstLastElement_empty_4() {
+  public void hasLastElement_empty_null() {
     expectFailureWhenTestingThat(ImmutableSortedSet.of()).hasLastElement(null);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo("Not true that <[]> has last element <null>");
+    assertFailureKeys("expected to have last element", "but was");
+    assertFailureValue("expected to have last element", "null");
+    assertFailureValue("but was", "[]");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/SortedSetSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/SortedSetSubjectTest.java
@@ -16,6 +16,7 @@
 package com.google.common.truth;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static java.util.Collections.unmodifiableSortedSet;
 
 import com.google.common.collect.ImmutableSortedSet;
@@ -56,7 +57,7 @@ public class SortedSetSubjectTest extends BaseSubjectTestCase {
   @Test
   public void verifyNamed() {
     @SuppressWarnings("unused")
-    SortedSetSubject unused = assertThat(ImmutableSortedSet.of()).named("foo");
+    SortedSetSubject unused = assertWithMessage("foo").that(ImmutableSortedSet.of());
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/SubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/SubjectTest.java
@@ -119,7 +119,7 @@ public class SubjectTest extends BaseSubjectTestCase {
         }
 
         subject.isSameAs(null);
-        subject.isNotSameAs(new Object());
+        subject.isNotSameInstanceAs(new Object());
 
         if (!(subject instanceof IterableSubject)) { // b/36000148
           subject.isNotIn(ImmutableList.<Object>of());
@@ -251,13 +251,13 @@ public class SubjectTest extends BaseSubjectTestCase {
   @Test
   public void isNotSameAsWithNulls() {
     Object o = null;
-    assertThat(o).isNotSameAs("a");
+    assertThat(o).isNotSameInstanceAs("a");
   }
 
   @Test
   public void isNotSameAsFailureWithNulls() {
     Object o = null;
-    expectFailure.whenTesting().that(o).isNotSameAs(null);
+    expectFailure.whenTesting().that(o).isNotSameInstanceAs(null);
     assertFailureKeys("expected not to be specific instance");
     assertFailureValue("expected not to be specific instance", "null");
   }
@@ -266,14 +266,14 @@ public class SubjectTest extends BaseSubjectTestCase {
   public void isNotSameAsWithObjects() {
     Object a = new Object();
     Object b = new Object();
-    assertThat(a).isNotSameAs(b);
+    assertThat(a).isNotSameInstanceAs(b);
   }
 
   @Test
   public void isNotSameAsFailureWithSameObject() {
     Object a = OBJECT_1;
     Object b = a;
-    expectFailure.whenTesting().that(a).isNotSameAs(b);
+    expectFailure.whenTesting().that(a).isNotSameInstanceAs(b);
     assertFailureKeys("expected not to be specific instance");
     assertFailureValue("expected not to be specific instance", "Object 1");
   }
@@ -282,7 +282,7 @@ public class SubjectTest extends BaseSubjectTestCase {
   public void isNotSameAsWithComparableObjects_nonString() {
     Object a = UnsignedInteger.valueOf(42);
     Object b = UnsignedInteger.fromIntBits(42);
-    assertThat(a).isNotSameAs(b);
+    assertThat(a).isNotSameInstanceAs(b);
   }
 
   @Test
@@ -290,14 +290,14 @@ public class SubjectTest extends BaseSubjectTestCase {
   public void isNotSameAsWithComparableObjects() {
     Object a = "ab";
     Object b = new StringBuilder("ab").toString();
-    assertThat(a).isNotSameAs(b);
+    assertThat(a).isNotSameInstanceAs(b);
   }
 
   @Test
   public void isNotSameAsWithDifferentTypesAndSameToString() {
     Object a = "true";
     Object b = true;
-    assertThat(a).isNotSameAs(b);
+    assertThat(a).isNotSameInstanceAs(b);
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/ThrowableSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/ThrowableSubjectTest.java
@@ -16,6 +16,7 @@
 package com.google.common.truth;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.io.IOException;
 import org.junit.Test;
@@ -137,7 +138,7 @@ public class ThrowableSubjectTest extends BaseSubjectTestCase {
   }
 
   private static void assertErrorHasActualAsCause(Throwable actual, AssertionError failure) {
-    assertThat(failure.getCause()).named("AssertionError's cause").isEqualTo(actual);
+    assertWithMessage("AssertionError's cause").that(failure.getCause()).isEqualTo(actual);
   }
 
   private ThrowableSubject expectFailureWhenTestingThat(Throwable actual) {

--- a/core/src/test/java/com/google/common/truth/gwt/Inventory.java
+++ b/core/src/test/java/com/google/common/truth/gwt/Inventory.java
@@ -29,7 +29,6 @@ import com.google.common.truth.IterableSubject;
 import com.google.common.truth.ListMultimapSubject;
 import com.google.common.truth.LongSubject;
 import com.google.common.truth.MapSubject;
-import com.google.common.truth.MathUtil;
 import com.google.common.truth.MultimapSubject;
 import com.google.common.truth.MultisetSubject;
 import com.google.common.truth.ObjectArraySubject;
@@ -68,7 +67,6 @@ public class Inventory {
   ListMultimapSubject listMultimapSubject;
   LongSubject longSubject;
   MapSubject mapSubject;
-  MathUtil mathUtil;
   MultimapSubject multimapSubject;
   MultisetSubject multisetSubject;
   ObjectArraySubject objectArraySubject;

--- a/extensions/java8/src/main/java/com/google/common/truth/IntStreamSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/IntStreamSubject.java
@@ -117,7 +117,7 @@ public final class IntStreamSubject extends Subject<IntStreamSubject, IntStream>
   @SuppressWarnings("GoodTime") // false positive; b/122617528
   @CanIgnoreReturnValue
   public Ordered containsAllOf(int first, int second, int... rest) {
-    return check().that(actualList).containsAllOf(first, second, box(rest));
+    return check().that(actualList).containsAtLeast(first, second, box(rest));
   }
 
   /**

--- a/extensions/java8/src/main/java/com/google/common/truth/IntStreamSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/IntStreamSubject.java
@@ -131,7 +131,7 @@ public final class IntStreamSubject extends Subject<IntStreamSubject, IntStream>
    */
   @CanIgnoreReturnValue
   public Ordered containsAllIn(Iterable<?> expected) {
-    return check().that(actualList).containsAllIn(expected);
+    return check().that(actualList).containsAtLeastElementsIn(expected);
   }
 
   /**

--- a/extensions/java8/src/main/java/com/google/common/truth/LongStreamSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/LongStreamSubject.java
@@ -131,7 +131,7 @@ public final class LongStreamSubject extends Subject<LongStreamSubject, LongStre
    */
   @CanIgnoreReturnValue
   public Ordered containsAllIn(Iterable<?> expected) {
-    return check().that(actualList).containsAllIn(expected);
+    return check().that(actualList).containsAtLeastElementsIn(expected);
   }
 
   /**

--- a/extensions/java8/src/main/java/com/google/common/truth/LongStreamSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/LongStreamSubject.java
@@ -117,7 +117,7 @@ public final class LongStreamSubject extends Subject<LongStreamSubject, LongStre
   @SuppressWarnings("GoodTime") // false positive; b/122617528
   @CanIgnoreReturnValue
   public Ordered containsAllOf(long first, long second, long... rest) {
-    return check().that(actualList).containsAllOf(first, second, box(rest));
+    return check().that(actualList).containsAtLeast(first, second, box(rest));
   }
 
   /**

--- a/extensions/java8/src/main/java/com/google/common/truth/StreamSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/StreamSubject.java
@@ -129,7 +129,7 @@ public final class StreamSubject extends Subject<StreamSubject, Stream<?>> {
    */
   @CanIgnoreReturnValue
   public Ordered containsAllIn(Iterable<?> expected) {
-    return check().that(actualList).containsAllIn(expected);
+    return check().that(actualList).containsAtLeastElementsIn(expected);
   }
 
   /**

--- a/extensions/java8/src/main/java/com/google/common/truth/StreamSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/StreamSubject.java
@@ -115,7 +115,7 @@ public final class StreamSubject extends Subject<StreamSubject, Stream<?>> {
   @CanIgnoreReturnValue
   public Ordered containsAllOf(
       @NullableDecl Object first, @NullableDecl Object second, @NullableDecl Object... rest) {
-    return check().that(actualList).containsAllOf(first, second, rest);
+    return check().that(actualList).containsAtLeast(first, second, rest);
   }
 
   /**

--- a/extensions/liteproto/src/test/java/com/google/common/truth/extensions/proto/LiteProtoSubjectTest.java
+++ b/extensions/liteproto/src/test/java/com/google/common/truth/extensions/proto/LiteProtoSubjectTest.java
@@ -142,7 +142,7 @@ public class LiteProtoSubjectTest {
   @Test
   public void testSubjectMethods() {
     expectThat(config.nonEmptyMessage()).isSameAs(config.nonEmptyMessage());
-    expectThat(config.nonEmptyMessage().toBuilder()).isNotSameAs(config.nonEmptyMessage());
+    expectThat(config.nonEmptyMessage().toBuilder()).isNotSameInstanceAs(config.nonEmptyMessage());
 
     expectThat(config.nonEmptyMessage()).isInstanceOf(MessageLite.class);
     expectThat(config.nonEmptyMessage().toBuilder()).isInstanceOf(MessageLite.Builder.class);

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosSubject.java
@@ -198,7 +198,7 @@ public class IterableOfProtosSubject<
       @NullableDecl Object firstExpected,
       @NullableDecl Object secondExpected,
       @NullableDecl Object... restOfExpected) {
-    return delegate().containsAllOf(firstExpected, secondExpected, restOfExpected);
+    return delegate().containsAtLeast(firstExpected, secondExpected, restOfExpected);
   }
 
   /**

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosSubject.java
@@ -194,7 +194,7 @@ public class IterableOfProtosSubject<
    * within the actual elements, but they are not required to be consecutive.
    */
   @CanIgnoreReturnValue
-  public Ordered containsAllOf(
+  public Ordered containsAtLeast(
       @NullableDecl Object firstExpected,
       @NullableDecl Object secondExpected,
       @NullableDecl Object... restOfExpected) {
@@ -211,13 +211,64 @@ public class IterableOfProtosSubject<
    * within the actual elements, but they are not required to be consecutive.
    */
   @CanIgnoreReturnValue
-  public Ordered containsAllIn(Iterable<?> expected) {
+  public Ordered containsAtLeastElementsIn(Iterable<?> expected) {
     return delegate().containsAtLeastElementsIn(expected);
   }
 
   /**
    * Checks that the actual iterable contains at least all of the expected elements or fails. If an
    * element appears more than once in the expected elements then it must appear at least that
+   * number of times in the actual elements.
+   *
+   * <p>To also test that the contents appear in the given order, make a call to {@code inOrder()}
+   * on the object returned by this method. The expected elements must appear in the given order
+   * within the actual elements, but they are not required to be consecutive.
+   */
+  @CanIgnoreReturnValue
+  public Ordered containsAtLeastElementsIn(Object[] expected) {
+    return delegate().containsAtLeastElementsIn(expected);
+  }
+
+  /**
+   * <i>To be deprecated in favor of {@link #containsAtLeast}.</i>
+   *
+   * <p>Checks that the actual iterable contains at least all of the expected elements or fails. If
+   * an element appears more than once in the expected elements to this call then it must appear at
+   * least that number of times in the actual elements.
+   *
+   * <p>To also test that the contents appear in the given order, make a call to {@code inOrder()}
+   * on the object returned by this method. The expected elements must appear in the given order
+   * within the actual elements, but they are not required to be consecutive.
+   */
+  @CanIgnoreReturnValue
+  public Ordered containsAllOf(
+      @NullableDecl Object firstExpected,
+      @NullableDecl Object secondExpected,
+      @NullableDecl Object... restOfExpected) {
+    return delegate().containsAllOf(firstExpected, secondExpected, restOfExpected);
+  }
+
+  /**
+   * <i>To be deprecated in favor of {@link #containsAtLeastElementsIn(Iterable)}.</i>
+   *
+   * <p>Checks that the actual iterable contains at least all of the expected elements or fails. If
+   * an element appears more than once in the expected elements then it must appear at least that
+   * number of times in the actual elements.
+   *
+   * <p>To also test that the contents appear in the given order, make a call to {@code inOrder()}
+   * on the object returned by this method. The expected elements must appear in the given order
+   * within the actual elements, but they are not required to be consecutive.
+   */
+  @CanIgnoreReturnValue
+  public Ordered containsAllIn(Iterable<?> expected) {
+    return delegate().containsAllIn(expected);
+  }
+
+  /**
+   * <i>To be deprecated in favor of {@link #containsAtLeastElementsIn(Object[])}.</i>
+   *
+   * <p>Checks that the actual iterable contains at least all of the expected elements or fails. If
+   * an element appears more than once in the expected elements then it must appear at least that
    * number of times in the actual elements.
    *
    * <p>To also test that the contents appear in the given order, make a call to {@code inOrder()}
@@ -375,7 +426,7 @@ public class IterableOfProtosSubject<
    * non-null key then the they are paired up. (Elements with null keys are not paired.) The failure
    * message will show paired elements together, and a diff will be shown.
    *
-   * <p>The expected elements given in the assertion should be uniquely keyed by {@link
+   * <p>The expected elements given in the assertion should be uniquely keyed by {@code
    * keyFunction}. If multiple missing elements have the same key then the pairing will be skipped.
    *
    * <p>Useful key functions will have the property that key equality is less strict than the
@@ -983,6 +1034,25 @@ public class IterableOfProtosSubject<
 
     @Override
     @CanIgnoreReturnValue
+    public Ordered containsAtLeast(
+        @NullableDecl M first, @NullableDecl M second, @NullableDecl M... rest) {
+      return delegate(Lists.asList(first, second, rest)).containsAtLeast(first, second, rest);
+    }
+
+    @Override
+    @CanIgnoreReturnValue
+    public Ordered containsAtLeastElementsIn(Iterable<? extends M> expected) {
+      return delegate(expected).containsAtLeastElementsIn(expected);
+    }
+
+    @Override
+    @CanIgnoreReturnValue
+    public Ordered containsAtLeastElementsIn(M[] expected) {
+      return delegate(Arrays.asList(expected)).containsAtLeastElementsIn(expected);
+    }
+
+    @Override
+    @CanIgnoreReturnValue
     public Ordered containsAllOf(
         @NullableDecl M first, @NullableDecl M second, @NullableDecl M... rest) {
       return delegate(Lists.asList(first, second, rest)).containsAllOf(first, second, rest);
@@ -1269,6 +1339,22 @@ public class IterableOfProtosSubject<
     @Override
     public Ordered containsExactlyElementsIn(M[] expected) {
       return usingCorrespondence().containsExactlyElementsIn(expected);
+    }
+
+    @Override
+    public Ordered containsAtLeast(
+        @NullableDecl M first, @NullableDecl M second, @NullableDecl M... rest) {
+      return usingCorrespondence().containsAtLeast(first, second, rest);
+    }
+
+    @Override
+    public Ordered containsAtLeastElementsIn(Iterable<? extends M> expected) {
+      return usingCorrespondence().containsAtLeastElementsIn(expected);
+    }
+
+    @Override
+    public Ordered containsAtLeastElementsIn(M[] expected) {
+      return usingCorrespondence().containsAtLeastElementsIn(expected);
     }
 
     @Override

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosSubject.java
@@ -212,7 +212,7 @@ public class IterableOfProtosSubject<
    */
   @CanIgnoreReturnValue
   public Ordered containsAllIn(Iterable<?> expected) {
-    return delegate().containsAllIn(expected);
+    return delegate().containsAtLeastElementsIn(expected);
   }
 
   /**
@@ -226,7 +226,7 @@ public class IterableOfProtosSubject<
    */
   @CanIgnoreReturnValue
   public Ordered containsAllIn(Object[] expected) {
-    return delegate().containsAllIn(expected);
+    return delegate().containsAtLeastElementsIn(expected);
   }
 
   /**

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosUsingCorrespondence.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosUsingCorrespondence.java
@@ -117,7 +117,7 @@ public interface IterableOfProtosUsingCorrespondence<M extends Message> {
    * subject, but they are not required to be consecutive.
    */
   @CanIgnoreReturnValue
-  Ordered containsAllOf(@NullableDecl M first, @NullableDecl M second, @NullableDecl M... rest);
+  Ordered containsAtLeast(@NullableDecl M first, @NullableDecl M second, @NullableDecl M... rest);
 
   /**
    * Checks that the subject contains elements that corresponds to all of the expected elements,
@@ -129,10 +129,52 @@ public interface IterableOfProtosUsingCorrespondence<M extends Message> {
    * subject, but they are not required to be consecutive.
    */
   @CanIgnoreReturnValue
-  Ordered containsAllIn(Iterable<? extends M> expected);
+  Ordered containsAtLeastElementsIn(Iterable<? extends M> expected);
 
   /**
    * Checks that the subject contains elements that corresponds to all of the expected elements,
+   * i.e. that there is a 1:1 mapping between any subset of the actual elements and the expected
+   * elements where each pair of elements correspond.
+   *
+   * <p>To also test that the contents appear in the given order, make a call to {@code inOrder()}
+   * on the object returned by this method. The elements must appear in the given order within the
+   * subject, but they are not required to be consecutive.
+   */
+  @CanIgnoreReturnValue
+  Ordered containsAtLeastElementsIn(M[] expected);
+
+  /**
+   * <i>To be deprecated in favor of {@link #containsAtLeast}.</i>
+   *
+   * <p>Checks that the subject contains elements that corresponds to all of the expected elements,
+   * i.e. that there is a 1:1 mapping between any subset of the actual elements and the expected
+   * elements where each pair of elements correspond.
+   *
+   * <p>To also test that the contents appear in the given order, make a call to {@code inOrder()}
+   * on the object returned by this method. The elements must appear in the given order within the
+   * subject, but they are not required to be consecutive.
+   */
+  @CanIgnoreReturnValue
+  Ordered containsAllOf(@NullableDecl M first, @NullableDecl M second, @NullableDecl M... rest);
+
+  /**
+   * <i>To be deprecated in favor of {@link #containsAtLeastElementsIn(Iterable)}.</i>
+   *
+   * <p>Checks that the subject contains elements that corresponds to all of the expected elements,
+   * i.e. that there is a 1:1 mapping between any subset of the actual elements and the expected
+   * elements where each pair of elements correspond.
+   *
+   * <p>To also test that the contents appear in the given order, make a call to {@code inOrder()}
+   * on the object returned by this method. The elements must appear in the given order within the
+   * subject, but they are not required to be consecutive.
+   */
+  @CanIgnoreReturnValue
+  Ordered containsAllIn(Iterable<? extends M> expected);
+
+  /**
+   * <i>To be deprecated in favor of {@link #containsAtLeastElementsIn(Object[])}.</i>
+   *
+   * <p>Checks that the subject contains elements that corresponds to all of the expected elements,
    * i.e. that there is a 1:1 mapping between any subset of the actual elements and the expected
    * elements where each pair of elements correspond.
    *
@@ -184,5 +226,4 @@ public interface IterableOfProtosUsingCorrespondence<M extends Message> {
    * to any of the given elements.)
    */
   void containsNoneIn(M[] excluded);
-
 }

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/IterableOfProtosSubjectTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/IterableOfProtosSubjectTest.java
@@ -140,6 +140,29 @@ public class IterableOfProtosSubjectTest extends ProtoSubjectTestBase {
   }
 
   @Test
+  public void testPlain_containsAtLeast() {
+    expectThat(listOf(message1, message2, eqIgnoredMessage1))
+        .containsAtLeast(eqMessage1, eqMessage2);
+    expectThat(listOf(message1, message2, eqIgnoredMessage1))
+        .containsAtLeastElementsIn(listOf(eqMessage1, eqMessage2));
+    expectThat(listOf(message1, message2, eqIgnoredMessage1))
+        .containsAtLeastElementsIn(arrayOf(eqMessage1, eqMessage2));
+
+    expectFailureWhenTesting().that(listOf(message1)).containsAtLeast(eqMessage1, eqMessage2);
+    expectThatFailure().isNotNull();
+
+    expectFailureWhenTesting()
+        .that(listOf(message1))
+        .containsAtLeastElementsIn(listOf(eqMessage1, eqMessage2));
+    expectThatFailure().isNotNull();
+
+    expectFailureWhenTesting()
+        .that(listOf(message1))
+        .containsAtLeastElementsIn(arrayOf(eqMessage1, eqMessage2));
+    expectThatFailure().isNotNull();
+  }
+
+  @Test
   public void testPlain_containsExactly() {
     expectThat(listOf(message1, message2)).containsExactly(eqMessage2, eqMessage1);
     expectThat(listOf(message1, message2)).containsExactly(eqMessage1, eqMessage2).inOrder();
@@ -312,6 +335,31 @@ public class IterableOfProtosSubjectTest extends ProtoSubjectTestBase {
         .that(listOf(message1))
         .ignoringRepeatedFieldOrder()
         .containsAllIn(listOf(eqMessage1, eqMessage2));
+    expectThatFailure().isNotNull();
+  }
+
+  @Test
+  public void testFluent_containsAtLeast() {
+    // TODO(peteg): containsAtLeast and containsExactly don't surface Correspondence.toString().
+    // We should add a string test here once they do.
+
+    expectThat(listOf(message1, message2, eqRepeatedMessage2))
+        .ignoringFields(ignoreFieldNumber)
+        .containsAtLeast(eqIgnoredMessage1, eqIgnoredMessage2);
+    expectThat(listOf(message1, message2, eqIgnoredMessage1))
+        .ignoringRepeatedFieldOrder()
+        .containsAtLeastElementsIn(listOf(eqRepeatedMessage1, eqRepeatedMessage2));
+
+    expectFailureWhenTesting()
+        .that(listOf(message1))
+        .ignoringRepeatedFieldOrder()
+        .containsAtLeast(eqMessage1, eqMessage2);
+    expectThatFailure().isNotNull();
+
+    expectFailureWhenTesting()
+        .that(listOf(message1))
+        .ignoringRepeatedFieldOrder()
+        .containsAtLeastElementsIn(listOf(eqMessage1, eqMessage2));
     expectThatFailure().isNotNull();
   }
 

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/OverloadResolutionTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/OverloadResolutionTest.java
@@ -59,7 +59,7 @@ public class OverloadResolutionTest extends ProtoSubjectTestBase {
     Object diffObject = diffMessage;
 
     assertThat(message).isSameAs(object);
-    assertThat(message).isNotSameAs(eqMessage);
+    assertThat(message).isNotSameInstanceAs(eqMessage);
     assertThat(message).isEqualTo(eqMessage);
     assertThat(message).isNotEqualTo(diffMessage);
     assertThat(message).isEqualTo(eqObject);
@@ -84,7 +84,7 @@ public class OverloadResolutionTest extends ProtoSubjectTestBase {
     Object diffObject = diffMessage;
 
     assertThat(object).isSameAs(message);
-    assertThat(object).isNotSameAs(eqObject);
+    assertThat(object).isNotSameInstanceAs(eqObject);
     assertThat(object).isEqualTo(eqObject);
     assertThat(object).isNotEqualTo(diffObject);
     assertThat(object).isEqualTo(eqMessage);

--- a/extensions/re2j/src/main/java/com/google/common/truth/extensions/re2j/Re2jSubjects.java
+++ b/extensions/re2j/src/main/java/com/google/common/truth/extensions/re2j/Re2jSubjects.java
@@ -71,7 +71,7 @@ public final class Re2jSubjects {
     /** Fails if the string does not match the given regex. */
     public void matches(String regex) {
       if (!Pattern.matches(regex, actual())) {
-        fail("matches", regex);
+        failWithActual("expected to match ", regex);
       }
     }
 
@@ -79,14 +79,14 @@ public final class Re2jSubjects {
     @GwtIncompatible("com.google.re2j.Pattern")
     public void matches(Pattern regex) {
       if (!regex.matcher(actual()).matches()) {
-        fail("matches", regex);
+        failWithActual("expected to match ", regex);
       }
     }
 
     /** Fails if the string matches the given regex. */
     public void doesNotMatch(String regex) {
       if (Pattern.matches(regex, actual())) {
-        fail("fails to match", regex);
+        failWithActual("expected to fail to match", regex);
       }
     }
 
@@ -94,7 +94,7 @@ public final class Re2jSubjects {
     @GwtIncompatible("com.google.re2j.Pattern")
     public void doesNotMatch(Pattern regex) {
       if (regex.matcher(actual()).matches()) {
-        fail("fails to match", regex);
+        failWithActual("expected to fail to match", regex);
       }
     }
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Migrate from Expect.createAndEnableStackTrace() to Expect.create().

The two methods are now equivalent. (That is, Expect.create() enables stack traces, too.) Expect.createAndEnableStackTrace() will be deprecated and deleted.

016cc90119806ad50ab2eebd2ad3746d19fc54e8

-------

<p> Remove createAndEnableStackTrace(), which is now equivalent to `create()`.

RELNOTES=Removed deprecated `createAndEnableStackTrace()`. Use `create()`, which also enables stack traces.

2f20220328fd7c9c0328f57e832417c80b345c86

-------

<p> Migrate Truth subjects from the old fail(String, Object) to the new failWithActual(String, Object), tweaking verbs for the new grammar.

Before:
  fail("has foo", expected);

After:
  failWithActual("expected to have foo", expected);

ccbfa097bd6b1b16130ef84a80b5e937942a3565

-------

<p> Migrate from isNotSameAs to isNotSameInstanceAs.

The two behave identically, and isNotSameAs is being removed.

d4ff2dd2248c716bfbc5b30e9fab05db8bac1061

-------

<p> Migrate from containsAllOf to containsAtLeast.

The two behave identically, and containsAllOf is being removed.

7e472970ac61fcb9efa0b13f475b8ae6a104fa74

-------

<p> Migrate from containsAllIn to containsAtLeastElementsIn.

The two behave identically, and containsAllIn is being removed.

cb3bf92dc47a6c9371bdd0310b1e0806c46c75eb

-------

<p> Hide MathUtil externally.

It was deprecated in https://github.com/google/truth/releases/tag/release_0_44

RELNOTES=Removed deprecated `MathUtil`. For similar static methods, see Guava's `DoubleMath.fuzzyEquals`. But callers from custom `Subject` implementations may prefer an approach like `check("score()").that(actual.score()).isWithin(tolerance).of(expected)`.

c41bff041640341eb8736abb880a26bc731b421e

-------

<p> Add containsAtLeast* to Proto Truth, too.

RELNOTES=Added `containsAtLeast*` methods to ProtoTruth, as well.

67d3766c6f0fdaeadb9a82f87da9ec06b1ae969b

-------

<p> Migrate from assertThat(foo).named("foo") to assertWithMessage("foo").that(foo).

(The exact change is slightly different in some cases, like when using custom subjects or check(), but it's always a migration from named(...) to [assert]WithMessage(...).)

named(...) is being removed.

This CL may slightly modify the failure messages produced, but all the old information will still be present.

51e308eb8dc80f06049c8d0517255e895f0b7289