### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/ExpectFailure.java
+++ b/core/src/main/java/com/google/common/truth/ExpectFailure.java
@@ -173,7 +173,7 @@ public final class ExpectFailure implements Platform.JUnitTestRule {
    * <p>{@code AssertionError failure = expectFailureAbout(myTypes(), whenTesting ->
    * whenTesting.that(myType).hasProperty());}
    */
-  public static <S extends Subject<S, A>, A> AssertionError expectFailureAbout(
+  public static <S extends Subject, A> AssertionError expectFailureAbout(
       final Subject.Factory<S, A> factory,
       final SimpleSubjectBuilderCallback<S, A> assertionCallback) {
     // whenTesting -> assertionCallback.invokeAssertion(whenTesting.about(factory))
@@ -235,7 +235,7 @@ public final class ExpectFailure implements Platform.JUnitTestRule {
    * instead, however if you prefer the {@code .expectFailureAbout()} pattern you can use this
    * interface to pass in an anonymous class.
    */
-  public interface SimpleSubjectBuilderCallback<S extends Subject<S, A>, A> {
+  public interface SimpleSubjectBuilderCallback<S extends Subject, A> {
     void invokeAssertion(SimpleSubjectBuilder<S, A> whenTesting);
   }
 }

--- a/core/src/main/java/com/google/common/truth/SimpleSubjectBuilder.java
+++ b/core/src/main/java/com/google/common/truth/SimpleSubjectBuilder.java
@@ -33,7 +33,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * <p>You won't extend this type. When you write a custom subject, see <a
  * href="https://google.github.io/truth/extension">our doc on extensions</a>.
  */
-public final class SimpleSubjectBuilder<SubjectT extends Subject<SubjectT, ActualT>, ActualT> {
+public final class SimpleSubjectBuilder<SubjectT extends Subject, ActualT> {
   private final FailureMetadata metadata;
   private final Subject.Factory<SubjectT, ActualT> subjectFactory;
 

--- a/core/src/main/java/com/google/common/truth/StandardSubjectBuilder.java
+++ b/core/src/main/java/com/google/common/truth/StandardSubjectBuilder.java
@@ -223,7 +223,7 @@ public class StandardSubjectBuilder {
    * method creates instances of that class. Created subjects use the previously set failure
    * strategy and any previously set failure message.
    */
-  public final <S extends Subject<S, A>, A> SimpleSubjectBuilder<S, A> about(
+  public final <S extends Subject, A> SimpleSubjectBuilder<S, A> about(
       Subject.Factory<S, A> factory) {
     return new SimpleSubjectBuilder<>(metadata(), factory);
   }

--- a/core/src/main/java/com/google/common/truth/StandardSubjectBuilder.java
+++ b/core/src/main/java/com/google/common/truth/StandardSubjectBuilder.java
@@ -197,6 +197,11 @@ public class StandardSubjectBuilder {
     return new AtomicLongMapSubject(metadata(), actual);
   }
 
+  /**
+   * Returns a new instance that will output the given message before the main failure message. If
+   * this method is called multiple times, the messages will appear in the order that they were
+   * specified.
+   */
   public final StandardSubjectBuilder withMessage(@NullableDecl String messageToPrepend) {
     return withMessage("%s", messageToPrepend);
   }

--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -85,7 +85,7 @@ public class Subject<S extends Subject<S, T>, T> {
    * <p>When you write a custom subject, see <a href="https://google.github.io/truth/extension">our doc on
    * extensions</a>. It explains where {@code Subject.Factory} fits into the process.
    */
-  public interface Factory<SubjectT extends Subject<SubjectT, ActualT>, ActualT> {
+  public interface Factory<SubjectT extends Subject, ActualT> {
     /** Creates a new {@link Subject}. */
     SubjectT createSubject(FailureMetadata metadata, ActualT actual);
   }

--- a/core/src/main/java/com/google/common/truth/Truth.java
+++ b/core/src/main/java/com/google/common/truth/Truth.java
@@ -97,20 +97,22 @@ public final class Truth {
   }
 
   /**
-   * Returns a {@link StandardSubjectBuilder} that will prepend the given message to the failure
-   * message in the event of a test failure.
+   * Begins an assertion that, if it fails, will prepend the given message to the failure message.
+   *
+   * <p>This method is a shortcut for {@code assert_().withMessage(...)}.
    */
   public static StandardSubjectBuilder assertWithMessage(String messageToPrepend) {
     return assert_().withMessage(messageToPrepend);
   }
 
   /**
-   * Returns a {@link StandardSubjectBuilder} that will prepend the formatted message using the
-   * specified arguments to the failure message in the event of a test failure.
+   * Begins an assertion that, if it fails, will prepend the given message to the failure message.
    *
    * <p><b>Note:</b> the arguments will be substituted into the format template using {@link
    * com.google.common.base.Strings#lenientFormat Strings.lenientFormat}. Note this only supports
    * the {@code %s} specifier.
+   *
+   * <p>This method is a shortcut for {@code assert_().withMessage(...)}.
    *
    * @throws IllegalArgumentException if the number of placeholders in the format string does not
    *     equal the number of given arguments

--- a/core/src/main/java/com/google/common/truth/Truth.java
+++ b/core/src/main/java/com/google/common/truth/Truth.java
@@ -123,7 +123,7 @@ public final class Truth {
    * Given a factory for some {@code Subject} class, returns a builder whose {@code that(actual)}
    * method creates instances of that class.
    */
-  public static <S extends Subject<S, T>, T> SimpleSubjectBuilder<S, T> assertAbout(
+  public static <S extends Subject, T> SimpleSubjectBuilder<S, T> assertAbout(
       Subject.Factory<S, T> factory) {
     return assert_().about(factory);
   }

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/RecursableDiffEntity.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/RecursableDiffEntity.java
@@ -35,7 +35,7 @@ package com.google.common.truth.extensions.proto;
  */
 abstract class RecursableDiffEntity {
 
-  // Lazily-initialized return values for the resursive properties of the entity.
+  // Lazily-initialized return values for the recursive properties of the entity.
   // null = not initialized yet
   //
   // This essentially implements what @Memoized does, but @AutoValue doesn't support @Memoized on


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Loosen type parameters on Subject.Factory.

This lets Subject subclasses extend raw Subject (instead of Subject<FooSubject, Foo>) to prepare for when we remove Subject's type parameters.

4d43c80d369f4e877660a7998a939ac26b47fffe

-------

<p> Try to clarify docs for combining assertWithMessage and withMessage.

f963b5610ac6b17ba9b27b54c9a38953101c370d

-------

<p> fix(RecursableDiffEntity): typo

Fixes #510

9970a65fe19d943e1540234c89cd91d54f6256bb