### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/AbstractArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/AbstractArraySubject.java
@@ -27,9 +27,12 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Christian Gruber (cgruber@israfil.net)
  */
 abstract class AbstractArraySubject<S extends AbstractArraySubject<S, T>, T> extends Subject<S, T> {
+  private final T actual;
+
   AbstractArraySubject(
       FailureMetadata metadata, @NullableDecl T actual, @NullableDecl String typeDescription) {
     super(metadata, actual, typeDescription);
+    this.actual = actual;
   }
 
   /** Fails if the array is not empty (i.e. {@code array.length > 0}). */
@@ -57,6 +60,6 @@ abstract class AbstractArraySubject<S extends AbstractArraySubject<S, T>, T> ext
   }
 
   private int length() {
-    return Array.getLength(actual());
+    return Array.getLength(actual);
   }
 }

--- a/core/src/main/java/com/google/common/truth/AtomicLongMapSubject.java
+++ b/core/src/main/java/com/google/common/truth/AtomicLongMapSubject.java
@@ -29,8 +29,11 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Kurt Alfred Kluever
  */
 public final class AtomicLongMapSubject extends Subject<AtomicLongMapSubject, AtomicLongMap<?>> {
+  private final AtomicLongMap<?> actual;
+
   AtomicLongMapSubject(FailureMetadata metadata, @NullableDecl AtomicLongMap<?> map) {
     super(metadata, map);
+    this.actual = map;
   }
 
   /**
@@ -57,14 +60,14 @@ public final class AtomicLongMapSubject extends Subject<AtomicLongMapSubject, At
 
   /** Fails if the {@link AtomicLongMap} is not empty. */
   public void isEmpty() {
-    if (!actual().isEmpty()) {
+    if (!actual.isEmpty()) {
       failWithActual(simpleFact("expected to be empty"));
     }
   }
 
   /** Fails if the {@link AtomicLongMap} is empty. */
   public void isNotEmpty() {
-    if (actual().isEmpty()) {
+    if (actual.isEmpty()) {
       failWithoutActual(simpleFact("expected not to be empty"));
     }
   }
@@ -72,24 +75,24 @@ public final class AtomicLongMapSubject extends Subject<AtomicLongMapSubject, At
   /** Fails if the {@link AtomicLongMap} does not have the given size. */
   public void hasSize(int expectedSize) {
     checkArgument(expectedSize >= 0, "expectedSize (%s) must be >= 0", expectedSize);
-    check("size()").that(actual().size()).isEqualTo(expectedSize);
+    check("size()").that(actual.size()).isEqualTo(expectedSize);
   }
 
   /** Fails if the {@link AtomicLongMap} does not have the given sum. */
   public void hasSum(long expectedSum) {
-    check("sum()").that(actual().sum()).isEqualTo(expectedSum);
+    check("sum()").that(actual.sum()).isEqualTo(expectedSum);
   }
 
   /** Fails if the {@link AtomicLongMap} does not contain the given key. */
   public void containsKey(Object key) {
     checkNotNull(key, "AtomicLongMap does not support null keys");
-    check("asMap().keySet()").that(actual().asMap().keySet()).contains(key);
+    check("asMap().keySet()").that(actual.asMap().keySet()).contains(key);
   }
 
   /** Fails if the {@link AtomicLongMap} contains the given key. */
   public void doesNotContainKey(Object key) {
     checkNotNull(key, "AtomicLongMap does not support null keys");
-    check("asMap().keySet()").that(actual().asMap().keySet()).doesNotContain(key);
+    check("asMap().keySet()").that(actual.asMap().keySet()).doesNotContain(key);
   }
 
   /*
@@ -111,7 +114,7 @@ public final class AtomicLongMapSubject extends Subject<AtomicLongMapSubject, At
    */
   public void containsEntry(Object key, long value) {
     checkNotNull(key, "AtomicLongMap does not support null keys");
-    long actualValue = ((AtomicLongMap<Object>) actual()).get(key);
+    long actualValue = ((AtomicLongMap<Object>) actual).get(key);
     if (actualValue != value) {
       failWithActual("expected to contain entry", immutableEntry(key, value));
     }
@@ -121,7 +124,7 @@ public final class AtomicLongMapSubject extends Subject<AtomicLongMapSubject, At
   /** Fails if the {@link AtomicLongMap} contains the given entry. */
   public void doesNotContainEntry(Object key, long value) {
     checkNotNull(key, "AtomicLongMap does not support null keys");
-    long actualValue = ((AtomicLongMap<Object>) actual()).get(key);
+    long actualValue = ((AtomicLongMap<Object>) actual).get(key);
     if (actualValue == value) {
       failWithActual("expected not to contain entry", immutableEntry(key, value));
     }

--- a/core/src/main/java/com/google/common/truth/BigDecimalSubject.java
+++ b/core/src/main/java/com/google/common/truth/BigDecimalSubject.java
@@ -27,8 +27,11 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Kurt Alfred Kluever
  */
 public final class BigDecimalSubject extends ComparableSubject<BigDecimalSubject, BigDecimal> {
+  private final BigDecimal actual;
+
   BigDecimalSubject(FailureMetadata metadata, @NullableDecl BigDecimal actual) {
     super(metadata, actual);
+    this.actual = actual;
   }
 
   /**
@@ -90,7 +93,7 @@ public final class BigDecimalSubject extends ComparableSubject<BigDecimalSubject
   }
 
   private void compareValues(BigDecimal expected) {
-    if (actual().compareTo(expected) != 0) {
+    if (actual.compareTo(expected) != 0) {
       failWithoutActual(fact("expected", expected), butWas(), simpleFact("(scale is ignored)"));
     }
   }

--- a/core/src/main/java/com/google/common/truth/BooleanSubject.java
+++ b/core/src/main/java/com/google/common/truth/BooleanSubject.java
@@ -25,24 +25,27 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Christian Gruber (cgruber@israfil.net)
  */
 public final class BooleanSubject extends Subject<BooleanSubject, Boolean> {
+  private final Boolean actual;
+
   BooleanSubject(FailureMetadata metadata, @NullableDecl Boolean actual) {
     super(metadata, actual);
+    this.actual = actual;
   }
 
   /** Fails if the subject is false or {@code null}. */
   public void isTrue() {
-    if (actual() == null) {
+    if (actual == null) {
       isEqualTo(true); // fails
-    } else if (!actual()) {
+    } else if (!actual) {
       failWithoutActual(simpleFact("expected to be true"));
     }
   }
 
   /** Fails if the subject is true or {@code null}. */
   public void isFalse() {
-    if (actual() == null) {
+    if (actual == null) {
       isEqualTo(false); // fails
-    } else if (actual()) {
+    } else if (actual) {
       failWithoutActual(simpleFact("expected to be false"));
     }
   }

--- a/core/src/main/java/com/google/common/truth/ClassSubject.java
+++ b/core/src/main/java/com/google/common/truth/ClassSubject.java
@@ -25,8 +25,11 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  */
 @GwtIncompatible("reflection")
 public final class ClassSubject extends Subject<ClassSubject, Class<?>> {
+  private final Class<?> actual;
+
   ClassSubject(FailureMetadata metadata, @NullableDecl Class<?> o) {
     super(metadata, o);
+    this.actual = o;
   }
 
   /**
@@ -34,7 +37,7 @@ public final class ClassSubject extends Subject<ClassSubject, Class<?>> {
    * class or interface.
    */
   public void isAssignableTo(Class<?> clazz) {
-    if (!clazz.isAssignableFrom(actual())) {
+    if (!clazz.isAssignableFrom(actual)) {
       failWithActual("expected to be assignable to", clazz.getName());
     }
   }

--- a/core/src/main/java/com/google/common/truth/ComparableSubject.java
+++ b/core/src/main/java/com/google/common/truth/ComparableSubject.java
@@ -29,20 +29,23 @@ public abstract class ComparableSubject<S extends ComparableSubject<S, T>, T ext
    * Constructor for use by subclasses. If you want to create an instance of this class itself, call
    * {@link Subject#check}{@code .that(actual)}.
    */
+  private final T actual;
+
   protected ComparableSubject(FailureMetadata metadata, @NullableDecl T actual) {
     super(metadata, actual);
+    this.actual = actual;
   }
 
   /** Checks that the subject is in {@code range}. */
   public final void isIn(Range<T> range) {
-    if (!range.contains(actual())) {
+    if (!range.contains(actual)) {
       failWithActual("expected to be in range", range);
     }
   }
 
   /** Checks that the subject is <i>not</i> in {@code range}. */
   public final void isNotIn(Range<T> range) {
-    if (range.contains(actual())) {
+    if (range.contains(actual)) {
       failWithActual("expected not to be in range", range);
     }
   }
@@ -55,7 +58,7 @@ public abstract class ComparableSubject<S extends ComparableSubject<S, T>, T ext
    * #isEqualTo(Object)}.
    */
   public void isEquivalentAccordingToCompareTo(T expected) {
-    if (actual().compareTo(expected) != 0) {
+    if (actual.compareTo(expected) != 0) {
       failWithActual("expected value that sorts equal to", expected);
     }
   }
@@ -67,7 +70,7 @@ public abstract class ComparableSubject<S extends ComparableSubject<S, T>, T ext
    * other}.
    */
   public final void isGreaterThan(T other) {
-    if (actual().compareTo(other) <= 0) {
+    if (actual.compareTo(other) <= 0) {
       failWithActual("expected to be greater than", other);
     }
   }
@@ -79,7 +82,7 @@ public abstract class ComparableSubject<S extends ComparableSubject<S, T>, T ext
    * other}.
    */
   public final void isLessThan(T other) {
-    if (actual().compareTo(other) >= 0) {
+    if (actual.compareTo(other) >= 0) {
       failWithActual("expected to be less than", other);
     }
   }
@@ -90,7 +93,7 @@ public abstract class ComparableSubject<S extends ComparableSubject<S, T>, T ext
    * <p>Use {@link #isLessThan} to check that the subject is less than {@code other}.
    */
   public final void isAtMost(T other) {
-    if (actual().compareTo(other) > 0) {
+    if (actual.compareTo(other) > 0) {
       failWithActual("expected to be at most", other);
     }
   }
@@ -101,7 +104,7 @@ public abstract class ComparableSubject<S extends ComparableSubject<S, T>, T ext
    * <p>Use {@link #isGreaterThan} to check that the subject is greater than {@code other}.
    */
   public final void isAtLeast(T other) {
-    if (actual().compareTo(other) < 0) {
+    if (actual.compareTo(other) < 0) {
       failWithActual("expected to be at least", other);
     }
   }

--- a/core/src/main/java/com/google/common/truth/DoubleSubject.java
+++ b/core/src/main/java/com/google/common/truth/DoubleSubject.java
@@ -36,8 +36,11 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 public final class DoubleSubject extends ComparableSubject<DoubleSubject, Double> {
   private static final long NEG_ZERO_BITS = doubleToLongBits(-0.0);
 
+  private final Double actual;
+
   DoubleSubject(FailureMetadata metadata, @NullableDecl Double actual) {
     super(metadata, actual);
+    this.actual = actual;
   }
 
   /**
@@ -105,7 +108,7 @@ public final class DoubleSubject extends ComparableSubject<DoubleSubject, Double
     return new TolerantDoubleComparison() {
       @Override
       public void of(double expected) {
-        Double actual = actual();
+        Double actual = DoubleSubject.this.actual;
         checkNotNull(
             actual, "actual value cannot be null. tolerance=%s expected=%s", tolerance, expected);
         checkTolerance(tolerance);
@@ -144,7 +147,7 @@ public final class DoubleSubject extends ComparableSubject<DoubleSubject, Double
     return new TolerantDoubleComparison() {
       @Override
       public void of(double expected) {
-        Double actual = actual();
+        Double actual = DoubleSubject.this.actual;
         checkNotNull(
             actual, "actual value cannot be null. tolerance=%s expected=%s", tolerance, expected);
         checkTolerance(tolerance);
@@ -216,7 +219,7 @@ public final class DoubleSubject extends ComparableSubject<DoubleSubject, Double
 
   /** Asserts that the subject is zero (i.e. it is either {@code 0.0} or {@code -0.0}). */
   public final void isZero() {
-    if (actual() == null || actual().doubleValue() != 0.0) {
+    if (actual == null || actual.doubleValue() != 0.0) {
       failWithActual(simpleFact("expected zero"));
     }
   }
@@ -226,9 +229,9 @@ public final class DoubleSubject extends ComparableSubject<DoubleSubject, Double
    * {@code -0.0} or {@code null}).
    */
   public final void isNonZero() {
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual(simpleFact("expected a double other than zero"));
-    } else if (actual().doubleValue() == 0.0) {
+    } else if (actual.doubleValue() == 0.0) {
       failWithActual(simpleFact("expected not to be zero"));
     }
   }
@@ -253,7 +256,7 @@ public final class DoubleSubject extends ComparableSubject<DoubleSubject, Double
    * Double#NEGATIVE_INFINITY}, or {@link Double#NaN}.
    */
   public final void isFinite() {
-    if (actual() == null || actual().isNaN() || actual().isInfinite()) {
+    if (actual == null || actual.isNaN() || actual.isInfinite()) {
       failWithActual(simpleFact("expected to be finite"));
     }
   }
@@ -263,7 +266,7 @@ public final class DoubleSubject extends ComparableSubject<DoubleSubject, Double
    * {@link Double#POSITIVE_INFINITY} or {@link Double#NEGATIVE_INFINITY}).
    */
   public final void isNotNaN() {
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual(simpleFact("expected a double other than NaN"));
     } else {
       isNotEqualTo(NaN);

--- a/core/src/main/java/com/google/common/truth/FloatSubject.java
+++ b/core/src/main/java/com/google/common/truth/FloatSubject.java
@@ -36,8 +36,11 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 public final class FloatSubject extends ComparableSubject<FloatSubject, Float> {
   private static final int NEG_ZERO_BITS = floatToIntBits(-0.0f);
 
+  private final Float actual;
+
   FloatSubject(FailureMetadata metadata, @NullableDecl Float actual) {
     super(metadata, actual);
+    this.actual = actual;
   }
 
   /**
@@ -105,7 +108,7 @@ public final class FloatSubject extends ComparableSubject<FloatSubject, Float> {
     return new TolerantFloatComparison() {
       @Override
       public void of(float expected) {
-        Float actual = actual();
+        Float actual = FloatSubject.this.actual;
         checkNotNull(
             actual, "actual value cannot be null. tolerance=%s expected=%s", tolerance, expected);
         checkTolerance(tolerance);
@@ -144,7 +147,7 @@ public final class FloatSubject extends ComparableSubject<FloatSubject, Float> {
     return new TolerantFloatComparison() {
       @Override
       public void of(float expected) {
-        Float actual = actual();
+        Float actual = FloatSubject.this.actual;
         checkNotNull(
             actual, "actual value cannot be null. tolerance=%s expected=%s", tolerance, expected);
         checkTolerance(tolerance);
@@ -214,7 +217,7 @@ public final class FloatSubject extends ComparableSubject<FloatSubject, Float> {
 
   /** Asserts that the subject is zero (i.e. it is either {@code 0.0f} or {@code -0.0f}). */
   public final void isZero() {
-    if (actual() == null || actual().floatValue() != 0.0f) {
+    if (actual == null || actual.floatValue() != 0.0f) {
       failWithActual(simpleFact("expected zero"));
     }
   }
@@ -224,9 +227,9 @@ public final class FloatSubject extends ComparableSubject<FloatSubject, Float> {
    * {@code -0.0f} or {@code null}).
    */
   public final void isNonZero() {
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual(simpleFact("expected a float other than zero"));
-    } else if (actual().floatValue() == 0.0f) {
+    } else if (actual.floatValue() == 0.0f) {
       failWithActual(simpleFact("expected not to be zero"));
     }
   }
@@ -251,7 +254,7 @@ public final class FloatSubject extends ComparableSubject<FloatSubject, Float> {
    * Float#NEGATIVE_INFINITY}, or {@link Float#NaN}.
    */
   public final void isFinite() {
-    if (actual() == null || actual().isNaN() || actual().isInfinite()) {
+    if (actual == null || actual.isNaN() || actual.isInfinite()) {
       failWithActual(simpleFact("expected to be finite"));
     }
   }
@@ -261,7 +264,7 @@ public final class FloatSubject extends ComparableSubject<FloatSubject, Float> {
    * Float#POSITIVE_INFINITY} or {@link Float#NEGATIVE_INFINITY}).
    */
   public final void isNotNaN() {
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual(simpleFact("expected a float other than NaN"));
     } else {
       isNotEqualTo(NaN);

--- a/core/src/main/java/com/google/common/truth/GuavaOptionalSubject.java
+++ b/core/src/main/java/com/google/common/truth/GuavaOptionalSubject.java
@@ -30,29 +30,32 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Christian Gruber
  */
 public final class GuavaOptionalSubject extends Subject<GuavaOptionalSubject, Optional<?>> {
+  private final Optional<?> actual;
+
   GuavaOptionalSubject(
       FailureMetadata metadata,
       @NullableDecl Optional<?> actual,
       @NullableDecl String typeDescription) {
     super(metadata, actual, typeDescription);
+    this.actual = actual;
   }
 
   /** Fails if the {@link Optional}{@code <T>} is absent or the subject is null. */
   public void isPresent() {
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual(simpleFact("expected present optional"));
-    } else if (!actual().isPresent()) {
+    } else if (!actual.isPresent()) {
       failWithoutActual(simpleFact("expected to be present"));
     }
   }
 
   /** Fails if the {@link Optional}{@code <T>} is present or the subject is null. */
   public void isAbsent() {
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual(simpleFact("expected absent optional"));
-    } else if (actual().isPresent()) {
+    } else if (actual.isPresent()) {
       failWithoutActual(
-          simpleFact("expected to be absent"), fact("but was present with value", actual().get()));
+          simpleFact("expected to be absent"), fact("but was present with value", actual.get()));
     }
   }
 
@@ -70,12 +73,12 @@ public final class GuavaOptionalSubject extends Subject<GuavaOptionalSubject, Op
     if (expected == null) {
       throw new NullPointerException("Optional cannot have a null value.");
     }
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual("expected an optional with value", expected);
-    } else if (!actual().isPresent()) {
+    } else if (!actual.isPresent()) {
       failWithoutActual(fact("expected to have value", expected), simpleFact("but was absent"));
     } else {
-      checkNoNeedToDisplayBothValues("get()").that(actual().get()).isEqualTo(expected);
+      checkNoNeedToDisplayBothValues("get()").that(actual.get()).isEqualTo(expected);
     }
   }
 }

--- a/core/src/main/java/com/google/common/truth/MapSubject.java
+++ b/core/src/main/java/com/google/common/truth/MapSubject.java
@@ -52,14 +52,17 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  */
 // Can't be final since SortedMapSubject extends it
 public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
+  private final Map<?, ?> actual;
+
   MapSubject(FailureMetadata metadata, @NullableDecl Map<?, ?> map) {
     super(metadata, map);
+    this.actual = map;
   }
 
   /** Fails if the subject is not equal to the given object. */
   @Override
   public void isEqualTo(@NullableDecl Object other) {
-    if (Objects.equal(actual(), other)) {
+    if (Objects.equal(actual, other)) {
       return;
     }
 
@@ -83,14 +86,14 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
 
   /** Fails if the map is not empty. */
   public void isEmpty() {
-    if (!actual().isEmpty()) {
+    if (!actual.isEmpty()) {
       failWithActual(simpleFact("expected to be empty"));
     }
   }
 
   /** Fails if the map is empty. */
   public void isNotEmpty() {
-    if (actual().isEmpty()) {
+    if (actual.isEmpty()) {
       failWithoutActual(simpleFact("expected not to be empty"));
     }
   }
@@ -98,26 +101,26 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
   /** Fails if the map does not have the given size. */
   public void hasSize(int expectedSize) {
     checkArgument(expectedSize >= 0, "expectedSize (%s) must be >= 0", expectedSize);
-    check("size()").that(actual().size()).isEqualTo(expectedSize);
+    check("size()").that(actual.size()).isEqualTo(expectedSize);
   }
 
   /** Fails if the map does not contain the given key. */
   public void containsKey(@NullableDecl Object key) {
-    check("keySet()").that(actual().keySet()).contains(key);
+    check("keySet()").that(actual.keySet()).contains(key);
   }
 
   /** Fails if the map contains the given key. */
   public void doesNotContainKey(@NullableDecl Object key) {
-    check("keySet()").that(actual().keySet()).doesNotContain(key);
+    check("keySet()").that(actual.keySet()).doesNotContain(key);
   }
 
   /** Fails if the map does not contain the given entry. */
   public void containsEntry(@NullableDecl Object key, @NullableDecl Object value) {
     Entry<Object, Object> entry = Maps.immutableEntry(key, value);
-    if (!actual().entrySet().contains(entry)) {
+    if (!actual.entrySet().contains(entry)) {
       List<Object> keyList = Lists.newArrayList(key);
       List<Object> valueList = Lists.newArrayList(value);
-      if (hasMatchingToStringPair(actual().keySet(), keyList)) {
+      if (hasMatchingToStringPair(actual.keySet(), keyList)) {
         failWithoutActual(
             simpleFact(
                 lenientFormat(
@@ -127,8 +130,8 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
                     entry,
                     objectToTypeName(entry),
                     countDuplicatesAndAddTypeInfo(
-                        retainMatchingToString(actual().keySet(), keyList /* itemsToCheck */)))));
-      } else if (hasMatchingToStringPair(actual().values(), valueList)) {
+                        retainMatchingToString(actual.keySet(), keyList /* itemsToCheck */)))));
+      } else if (hasMatchingToStringPair(actual.values(), valueList)) {
         failWithoutActual(
             simpleFact(
                 lenientFormat(
@@ -138,9 +141,9 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
                     entry,
                     objectToTypeName(entry),
                     countDuplicatesAndAddTypeInfo(
-                        retainMatchingToString(actual().values(), valueList /* itemsToCheck */)))));
-      } else if (actual().containsKey(key)) {
-        Object actualValue = actual().get(key);
+                        retainMatchingToString(actual.values(), valueList /* itemsToCheck */)))));
+      } else if (actual.containsKey(key)) {
+        Object actualValue = actual.get(key);
         /*
          * In the case of a null expected or actual value, clarify that the key *is* present and
          * *is* expected to be present. That is, get() isn't returning null to indicate that the key
@@ -152,9 +155,9 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
         }
         // See the comment on IterableSubject's use of failEqualityCheckForEqualsWithoutDescription.
         check.that(actualValue).failEqualityCheckForEqualsWithoutDescription(value);
-      } else if (actual().containsValue(value)) {
+      } else if (actual.containsValue(value)) {
         Set<Object> keys = new LinkedHashSet<>();
-        for (Entry<?, ?> actualEntry : actual().entrySet()) {
+        for (Entry<?, ?> actualEntry : actual.entrySet()) {
           if (Objects.equal(actualEntry.getValue(), value)) {
             keys.add(actualEntry.getKey());
           }
@@ -174,7 +177,7 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
   /** Fails if the map contains the given entry. */
   public void doesNotContainEntry(@NullableDecl Object key, @NullableDecl Object value) {
     checkNoNeedToDisplayBothValues("entrySet()")
-        .that(actual().entrySet())
+        .that(actual.entrySet())
         .doesNotContain(immutableEntry(key, value));
   }
 
@@ -231,7 +234,7 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
   @CanIgnoreReturnValue
   public Ordered containsExactlyEntriesIn(Map<?, ?> expectedMap) {
     if (expectedMap.isEmpty()) {
-      if (actual().isEmpty()) {
+      if (actual.isEmpty()) {
         return IN_ORDER;
       } else {
         isEmpty(); // fails
@@ -266,7 +269,7 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
   private boolean containsEntriesInAnyOrder(
       Map<?, ?> expectedMap, String failVerb, boolean allowUnexpected) {
     MapDifference<Object, Object, Object> diff =
-        MapDifference.create(actual(), expectedMap, allowUnexpected, EQUALITY);
+        MapDifference.create(actual, expectedMap, allowUnexpected, EQUALITY);
     if (diff.isEmpty()) {
       return true;
     }
@@ -456,9 +459,9 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
     public void inOrder() {
       // We're using the fact that Sets.intersection keeps the order of the first set.
       List<?> expectedKeyOrder =
-          Lists.newArrayList(Sets.intersection(expectedMap.keySet(), actual().keySet()));
+          Lists.newArrayList(Sets.intersection(expectedMap.keySet(), actual.keySet()));
       List<?> actualKeyOrder =
-          Lists.newArrayList(Sets.intersection(actual().keySet(), expectedMap.keySet()));
+          Lists.newArrayList(Sets.intersection(actual.keySet(), expectedMap.keySet()));
       if (!actualKeyOrder.equals(expectedKeyOrder)) {
         failWithoutActual(
             simpleFact(
@@ -529,7 +532,7 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
      * the given value.
      */
     public void containsEntry(@NullableDecl Object expectedKey, @NullableDecl E expectedValue) {
-      if (actual().containsKey(expectedKey)) {
+      if (actual.containsKey(expectedKey)) {
         // Found matching key.
         A actualValue = getCastSubject().get(expectedKey);
         Correspondence.ExceptionStore exceptions = Correspondence.ExceptionStore.forMapValues();
@@ -610,7 +613,7 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
      */
     public void doesNotContainEntry(
         @NullableDecl Object excludedKey, @NullableDecl E excludedValue) {
-      if (actual().containsKey(excludedKey)) {
+      if (actual.containsKey(excludedKey)) {
         // Found matching key. Fail if the value matches, too.
         A actualValue = getCastSubject().get(excludedKey);
         Correspondence.ExceptionStore exceptions = Correspondence.ExceptionStore.forMapValues();
@@ -686,7 +689,7 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
     @CanIgnoreReturnValue
     public <K, V extends E> Ordered containsExactlyEntriesIn(Map<K, V> expectedMap) {
       if (expectedMap.isEmpty()) {
-        if (actual().isEmpty()) {
+        if (actual.isEmpty()) {
           return IN_ORDER;
         } else {
           isEmpty(); // fails
@@ -773,7 +776,7 @@ public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
 
     @SuppressWarnings("unchecked") // throwing ClassCastException is the correct behaviour
     private Map<?, A> getCastSubject() {
-      return (Map<?, A>) actual();
+      return (Map<?, A>) actual;
     }
   }
 }

--- a/core/src/main/java/com/google/common/truth/MultisetSubject.java
+++ b/core/src/main/java/com/google/common/truth/MultisetSubject.java
@@ -27,8 +27,11 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  */
 public final class MultisetSubject extends IterableSubject {
 
+  private final Multiset<?> actual;
+
   MultisetSubject(FailureMetadata metadata, @NullableDecl Multiset<?> multiset) {
     super(metadata, multiset);
+    this.actual = multiset;
   }
 
   @Deprecated
@@ -41,7 +44,7 @@ public final class MultisetSubject extends IterableSubject {
   /** Fails if the element does not have the given count. */
   public final void hasCount(@NullableDecl Object element, int expectedCount) {
     checkArgument(expectedCount >= 0, "expectedCount(%s) must be >= 0", expectedCount);
-    int actualCount = ((Multiset<?>) actual()).count(element);
+    int actualCount = ((Multiset<?>) actual).count(element);
     check("count(%s)", element).that(actualCount).isEqualTo(expectedCount);
   }
 }

--- a/core/src/main/java/com/google/common/truth/ObjectArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/ObjectArraySubject.java
@@ -24,12 +24,15 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Christian Gruber
  */
 public final class ObjectArraySubject<T> extends AbstractArraySubject<ObjectArraySubject<T>, T[]> {
+  private final T[] actual;
+
   ObjectArraySubject(
       FailureMetadata metadata, @NullableDecl T[] o, @NullableDecl String typeDescription) {
     super(metadata, o, typeDescription);
+    this.actual = o;
   }
 
   public IterableSubject asList() {
-    return checkNoNeedToDisplayBothValues("asList()").that(Arrays.asList(actual()));
+    return checkNoNeedToDisplayBothValues("asList()").that(Arrays.asList(actual));
   }
 }

--- a/core/src/main/java/com/google/common/truth/PrimitiveBooleanArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveBooleanArraySubject.java
@@ -25,12 +25,15 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  */
 public final class PrimitiveBooleanArraySubject
     extends AbstractArraySubject<PrimitiveBooleanArraySubject, boolean[]> {
+  private final boolean[] actual;
+
   PrimitiveBooleanArraySubject(
       FailureMetadata metadata, @NullableDecl boolean[] o, @NullableDecl String typeDescription) {
     super(metadata, o, typeDescription);
+    this.actual = o;
   }
 
   public IterableSubject asList() {
-    return checkNoNeedToDisplayBothValues("asList()").that(Booleans.asList(actual()));
+    return checkNoNeedToDisplayBothValues("asList()").that(Booleans.asList(actual));
   }
 }

--- a/core/src/main/java/com/google/common/truth/PrimitiveByteArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveByteArraySubject.java
@@ -25,12 +25,15 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  */
 public final class PrimitiveByteArraySubject
     extends AbstractArraySubject<PrimitiveByteArraySubject, byte[]> {
+  private final byte[] actual;
+
   PrimitiveByteArraySubject(
       FailureMetadata metadata, @NullableDecl byte[] o, @NullableDecl String typeDescription) {
     super(metadata, o, typeDescription);
+    this.actual = o;
   }
 
   public IterableSubject asList() {
-    return checkNoNeedToDisplayBothValues("asList()").that(Bytes.asList(actual()));
+    return checkNoNeedToDisplayBothValues("asList()").that(Bytes.asList(actual));
   }
 }

--- a/core/src/main/java/com/google/common/truth/PrimitiveCharArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveCharArraySubject.java
@@ -25,12 +25,15 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  */
 public final class PrimitiveCharArraySubject
     extends AbstractArraySubject<PrimitiveCharArraySubject, char[]> {
+  private final char[] actual;
+
   PrimitiveCharArraySubject(
       FailureMetadata metadata, @NullableDecl char[] o, @NullableDecl String typeDescription) {
     super(metadata, o, typeDescription);
+    this.actual = o;
   }
 
   public IterableSubject asList() {
-    return checkNoNeedToDisplayBothValues("asList()").that(Chars.asList(actual()));
+    return checkNoNeedToDisplayBothValues("asList()").that(Chars.asList(actual));
   }
 }

--- a/core/src/main/java/com/google/common/truth/PrimitiveDoubleArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveDoubleArraySubject.java
@@ -32,9 +32,12 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  */
 public final class PrimitiveDoubleArraySubject
     extends AbstractArraySubject<PrimitiveDoubleArraySubject, double[]> {
+  private final double[] actual;
+
   PrimitiveDoubleArraySubject(
       FailureMetadata metadata, @NullableDecl double[] o, @NullableDecl String typeDescription) {
     super(metadata, o, typeDescription);
+    this.actual = o;
   }
 
   /**
@@ -294,7 +297,7 @@ public final class PrimitiveDoubleArraySubject
   private IterableSubject iterableSubject() {
     return checkNoNeedToDisplayBothValues("asList()")
         .about(iterablesWithCustomDoubleToString())
-        .that(Doubles.asList(actual()));
+        .that(Doubles.asList(actual));
   }
 
   /*
@@ -315,6 +318,7 @@ public final class PrimitiveDoubleArraySubject
   }
 
   private final class IterableSubjectWithInheritedToString extends IterableSubject {
+
     IterableSubjectWithInheritedToString(FailureMetadata metadata, Iterable<?> actual) {
       super(metadata, actual);
     }

--- a/core/src/main/java/com/google/common/truth/PrimitiveFloatArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveFloatArraySubject.java
@@ -32,9 +32,12 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  */
 public final class PrimitiveFloatArraySubject
     extends AbstractArraySubject<PrimitiveFloatArraySubject, float[]> {
+  private final float[] actual;
+
   PrimitiveFloatArraySubject(
       FailureMetadata metadata, @NullableDecl float[] o, @NullableDecl String typeDescription) {
     super(metadata, o, typeDescription);
+    this.actual = o;
   }
 
   /**
@@ -299,7 +302,7 @@ public final class PrimitiveFloatArraySubject
   private IterableSubject iterableSubject() {
     return checkNoNeedToDisplayBothValues("asList()")
         .about(iterablesWithCustomFloatToString())
-        .that(Floats.asList(actual()));
+        .that(Floats.asList(actual));
   }
 
   /*
@@ -320,6 +323,7 @@ public final class PrimitiveFloatArraySubject
   }
 
   private final class IterableSubjectWithInheritedToString extends IterableSubject {
+
     IterableSubjectWithInheritedToString(FailureMetadata metadata, Iterable<?> actual) {
       super(metadata, actual);
     }

--- a/core/src/main/java/com/google/common/truth/PrimitiveIntArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveIntArraySubject.java
@@ -25,12 +25,15 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  */
 public final class PrimitiveIntArraySubject
     extends AbstractArraySubject<PrimitiveIntArraySubject, int[]> {
+  private final int[] actual;
+
   PrimitiveIntArraySubject(
       FailureMetadata metadata, @NullableDecl int[] o, @NullableDecl String typeDescription) {
     super(metadata, o, typeDescription);
+    this.actual = o;
   }
 
   public IterableSubject asList() {
-    return checkNoNeedToDisplayBothValues("asList()").that(Ints.asList(actual()));
+    return checkNoNeedToDisplayBothValues("asList()").that(Ints.asList(actual));
   }
 }

--- a/core/src/main/java/com/google/common/truth/PrimitiveLongArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveLongArraySubject.java
@@ -25,12 +25,15 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  */
 public final class PrimitiveLongArraySubject
     extends AbstractArraySubject<PrimitiveLongArraySubject, long[]> {
+  private final long[] actual;
+
   PrimitiveLongArraySubject(
       FailureMetadata metadata, @NullableDecl long[] o, @NullableDecl String typeDescription) {
     super(metadata, o, typeDescription);
+    this.actual = o;
   }
 
   public IterableSubject asList() {
-    return checkNoNeedToDisplayBothValues("asList()").that(Longs.asList(actual()));
+    return checkNoNeedToDisplayBothValues("asList()").that(Longs.asList(actual));
   }
 }

--- a/core/src/main/java/com/google/common/truth/PrimitiveShortArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveShortArraySubject.java
@@ -25,12 +25,15 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  */
 public final class PrimitiveShortArraySubject
     extends AbstractArraySubject<PrimitiveShortArraySubject, short[]> {
+  private final short[] actual;
+
   PrimitiveShortArraySubject(
       FailureMetadata metadata, @NullableDecl short[] o, @NullableDecl String typeDescription) {
     super(metadata, o, typeDescription);
+    this.actual = o;
   }
 
   public IterableSubject asList() {
-    return checkNoNeedToDisplayBothValues("asList()").that(Shorts.asList(actual()));
+    return checkNoNeedToDisplayBothValues("asList()").that(Shorts.asList(actual));
   }
 }

--- a/core/src/main/java/com/google/common/truth/StringSubject.java
+++ b/core/src/main/java/com/google/common/truth/StringSubject.java
@@ -38,8 +38,11 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
    * Constructor for use by subclasses. If you want to create an instance of this class itself, call
    * {@link Subject#check}{@code .that(actual)}.
    */
+  private final String actual;
+
   protected StringSubject(FailureMetadata metadata, @NullableDecl String string) {
     super(metadata, string);
+    this.actual = string;
   }
 
   /** @deprecated Use {@link #isEqualTo} instead. String comparison is consistent with equality. */
@@ -52,23 +55,23 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
   /** Fails if the string does not have the given length. */
   public void hasLength(int expectedLength) {
     checkArgument(expectedLength >= 0, "expectedLength(%s) must be >= 0", expectedLength);
-    check("length()").that(actual().length()).isEqualTo(expectedLength);
+    check("length()").that(actual.length()).isEqualTo(expectedLength);
   }
 
   /** Fails if the string is not equal to the zero-length "empty string." */
   public void isEmpty() {
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual(simpleFact("expected empty string"));
-    } else if (!actual().isEmpty()) {
+    } else if (!actual.isEmpty()) {
       failWithActual(simpleFact("expected to be empty"));
     }
   }
 
   /** Fails if the string is equal to the zero-length "empty string." */
   public void isNotEmpty() {
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual(simpleFact("expected nonempty string"));
-    } else if (actual().isEmpty()) {
+    } else if (actual.isEmpty()) {
       failWithoutActual(simpleFact("expected not to be empty"));
     }
   }
@@ -76,9 +79,9 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
   /** Fails if the string does not contain the given sequence. */
   public void contains(CharSequence string) {
     checkNotNull(string);
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual("expected a string that contains", string);
-    } else if (!actual().contains(string)) {
+    } else if (!actual.contains(string)) {
       failWithActual("expected to contain", string);
     }
   }
@@ -86,9 +89,9 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
   /** Fails if the string contains the given sequence. */
   public void doesNotContain(CharSequence string) {
     checkNotNull(string);
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual("expected a string that does not contain", string);
-    } else if (actual().contains(string)) {
+    } else if (actual.contains(string)) {
       failWithActual("expected not to contain", string);
     }
   }
@@ -96,9 +99,9 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
   /** Fails if the string does not start with the given string. */
   public void startsWith(String string) {
     checkNotNull(string);
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual("expected a string that starts with", string);
-    } else if (!actual().startsWith(string)) {
+    } else if (!actual.startsWith(string)) {
       failWithActual("expected to start with", string);
     }
   }
@@ -106,9 +109,9 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
   /** Fails if the string does not end with the given string. */
   public void endsWith(String string) {
     checkNotNull(string);
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual("expected a string that ends with", string);
-    } else if (!actual().endsWith(string)) {
+    } else if (!actual.endsWith(string)) {
       failWithActual("expected to end with", string);
     }
   }
@@ -117,7 +120,7 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
 
   /** Fails if the string does not match the given regex. */
   public void matches(String regex) {
-    if (!actual().matches(regex)) {
+    if (!actual.matches(regex)) {
       failWithActual("expected to match", regex);
     }
   }
@@ -125,14 +128,14 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
   /** Fails if the string does not match the given regex. */
   @GwtIncompatible("java.util.regex.Pattern")
   public void matches(Pattern regex) {
-    if (!regex.matcher(actual()).matches()) {
+    if (!regex.matcher(actual).matches()) {
       failWithActual("expected to match", regex);
     }
   }
 
   /** Fails if the string matches the given regex. */
   public void doesNotMatch(String regex) {
-    if (actual().matches(regex)) {
+    if (actual.matches(regex)) {
       failWithActual("expected not to match", regex);
     }
   }
@@ -140,7 +143,7 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
   /** Fails if the string matches the given regex. */
   @GwtIncompatible("java.util.regex.Pattern")
   public void doesNotMatch(Pattern regex) {
-    if (regex.matcher(actual()).matches()) {
+    if (regex.matcher(actual).matches()) {
       failWithActual("expected not to match", regex);
     }
   }
@@ -148,14 +151,14 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
   /** Fails if the string does not contain a match on the given regex. */
   @GwtIncompatible("java.util.regex.Pattern")
   public void containsMatch(Pattern regex) {
-    if (!regex.matcher(actual()).find()) {
+    if (!regex.matcher(actual).find()) {
       failWithActual("expected to contain a match for", regex);
     }
   }
 
   /** Fails if the string does not contain a match on the given regex. */
   public void containsMatch(String regex) {
-    if (!Platform.containsMatch(actual(), regex)) {
+    if (!Platform.containsMatch(actual, regex)) {
       failWithActual("expected to contain a match for", regex);
     }
   }
@@ -163,7 +166,7 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
   /** Fails if the string contains a match on the given regex. */
   @GwtIncompatible("java.util.regex.Pattern")
   public void doesNotContainMatch(Pattern regex) {
-    Matcher matcher = regex.matcher(actual());
+    Matcher matcher = regex.matcher(actual);
     if (matcher.find()) {
       failWithoutActual(
           fact("expected not to contain a match for", regex),
@@ -174,7 +177,7 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
 
   /** Fails if the string contains a match on the given regex. */
   public void doesNotContainMatch(String regex) {
-    if (Platform.containsMatch(actual(), regex)) {
+    if (Platform.containsMatch(actual, regex)) {
       failWithActual("expected not to contain a match for", regex);
     }
   }
@@ -206,7 +209,7 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
      * <p>Example: "abc" is equal to "ABC", but not to "abcd".
      */
     public void isEqualTo(String expected) {
-      if (actual() == null) {
+      if (actual == null) {
         if (expected != null) {
           failWithoutActual(
               fact("expected a string that is equal to", expected),
@@ -217,7 +220,7 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
         if (expected == null) {
           failWithoutActual(
               fact("expected", "null (null reference)"), butWas(), simpleFact("(case is ignored)"));
-        } else if (!actual().equalsIgnoreCase(expected)) {
+        } else if (!actual.equalsIgnoreCase(expected)) {
           failWithoutActual(fact("expected", expected), butWas(), simpleFact("(case is ignored)"));
         }
       }
@@ -228,14 +231,14 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
      * equality is the same as for the {@link #isEqualTo} method.
      */
     public void isNotEqualTo(String unexpected) {
-      if (actual() == null) {
+      if (actual == null) {
         if (unexpected == null) {
           failWithoutActual(
               fact("expected a string that is not equal to", "null (null reference)"),
               simpleFact("(case is ignored)"));
         }
       } else {
-        if (unexpected != null && actual().equalsIgnoreCase(unexpected)) {
+        if (unexpected != null && actual.equalsIgnoreCase(unexpected)) {
           failWithoutActual(
               fact("expected not to be", unexpected), butWas(), simpleFact("(case is ignored)"));
         }
@@ -246,7 +249,7 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
     public void contains(CharSequence expectedSequence) {
       checkNotNull(expectedSequence);
       String expected = expectedSequence.toString();
-      if (actual() == null) {
+      if (actual == null) {
         failWithoutActual(
             fact("expected a string that contains", expected),
             butWas(),
@@ -261,7 +264,7 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
     public void doesNotContain(CharSequence expectedSequence) {
       checkNotNull(expectedSequence);
       String expected = expectedSequence.toString();
-      if (actual() == null) {
+      if (actual == null) {
         failWithoutActual(
             fact("expected a string that does not contain", expected),
             butWas(),
@@ -277,7 +280,7 @@ public class StringSubject extends ComparableSubject<StringSubject, String> {
         // TODO(b/79459427): Fix for J2CL discrepancy when string is empty
         return true;
       }
-      String subject = actual();
+      String subject = actual;
       for (int subjectOffset = 0;
           subjectOffset <= subject.length() - string.length();
           subjectOffset++) {

--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -715,7 +715,11 @@ public class Subject<S extends Subject<S, T>, T> {
    * Returns a builder for creating a derived subject but without providing information about how
    * the derived subject will relate to the current subject. In most cases, you should provide such
    * information by using {@linkplain #check(String, Object...) the other overload}.
+   *
+   * @deprecated Use {@linkplain #check(String, Object...) the other overload}, which requires you
+   *     to supply more information to include in any failure messages.
    */
+  @Deprecated
   protected final StandardSubjectBuilder check() {
     return new StandardSubjectBuilder(metadata.updateForCheckCall());
   }

--- a/core/src/main/java/com/google/common/truth/TableSubject.java
+++ b/core/src/main/java/com/google/common/truth/TableSubject.java
@@ -30,20 +30,23 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Kurt Alfred Kluever
  */
 public final class TableSubject extends Subject<TableSubject, Table<?, ?, ?>> {
+  private final Table<?, ?, ?> actual;
+
   TableSubject(FailureMetadata metadata, @NullableDecl Table<?, ?, ?> table) {
     super(metadata, table);
+    this.actual = table;
   }
 
   /** Fails if the table is not empty. */
   public void isEmpty() {
-    if (!actual().isEmpty()) {
+    if (!actual.isEmpty()) {
       failWithActual(simpleFact("expected to be empty"));
     }
   }
 
   /** Fails if the table is empty. */
   public void isNotEmpty() {
-    if (actual().isEmpty()) {
+    if (actual.isEmpty()) {
       failWithoutActual(simpleFact("expected not to be empty"));
     }
   }
@@ -51,19 +54,19 @@ public final class TableSubject extends Subject<TableSubject, Table<?, ?, ?>> {
   /** Fails if the table does not have the given size. */
   public final void hasSize(int expectedSize) {
     checkArgument(expectedSize >= 0, "expectedSize(%s) must be >= 0", expectedSize);
-    check("size()").that(actual().size()).isEqualTo(expectedSize);
+    check("size()").that(actual.size()).isEqualTo(expectedSize);
   }
 
   /** Fails if the table does not contain a mapping for the given row key and column key. */
   public void contains(@NullableDecl Object rowKey, @NullableDecl Object columnKey) {
-    if (!actual().contains(rowKey, columnKey)) {
+    if (!actual.contains(rowKey, columnKey)) {
       fail("contains mapping for row/column", rowKey, columnKey);
     }
   }
 
   /** Fails if the table contains a mapping for the given row key and column key. */
   public void doesNotContain(@NullableDecl Object rowKey, @NullableDecl Object columnKey) {
-    if (actual().contains(rowKey, columnKey)) {
+    if (actual.contains(rowKey, columnKey)) {
       fail("does not contain mapping for row/column", rowKey, columnKey);
     }
   }
@@ -77,7 +80,7 @@ public final class TableSubject extends Subject<TableSubject, Table<?, ?, ?>> {
   /** Fails if the table does not contain the given cell. */
   public void containsCell(Cell<?, ?, ?> cell) {
     checkNotNull(cell);
-    checkNoNeedToDisplayBothValues("cellSet()").that(actual().cellSet()).contains(cell);
+    checkNoNeedToDisplayBothValues("cellSet()").that(actual.cellSet()).contains(cell);
   }
 
   /** Fails if the table contains the given cell. */
@@ -89,21 +92,21 @@ public final class TableSubject extends Subject<TableSubject, Table<?, ?, ?>> {
   /** Fails if the table contains the given cell. */
   public void doesNotContainCell(Cell<?, ?, ?> cell) {
     checkNotNull(cell);
-    checkNoNeedToDisplayBothValues("cellSet()").that(actual().cellSet()).doesNotContain(cell);
+    checkNoNeedToDisplayBothValues("cellSet()").that(actual.cellSet()).doesNotContain(cell);
   }
 
   /** Fails if the table does not contain the given row key. */
   public void containsRow(@NullableDecl Object rowKey) {
-    check("rowKeySet()").that(actual().rowKeySet()).contains(rowKey);
+    check("rowKeySet()").that(actual.rowKeySet()).contains(rowKey);
   }
 
   /** Fails if the table does not contain the given column key. */
   public void containsColumn(@NullableDecl Object columnKey) {
-    check("columnKeySet()").that(actual().columnKeySet()).contains(columnKey);
+    check("columnKeySet()").that(actual.columnKeySet()).contains(columnKey);
   }
 
   /** Fails if the table does not contain the given value. */
   public void containsValue(@NullableDecl Object value) {
-    check("values()").that(actual().values()).contains(value);
+    check("values()").that(actual.values()).contains(value);
   }
 }

--- a/core/src/main/java/com/google/common/truth/ThrowableSubject.java
+++ b/core/src/main/java/com/google/common/truth/ThrowableSubject.java
@@ -25,6 +25,14 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 public class ThrowableSubject extends Subject<ThrowableSubject, Throwable> {
   private final Throwable actual;
 
+  /**
+   * Constructor for use by subclasses. If you want to create an instance of this class itself, call
+   * {@link Subject#check}{@code .that(throwable)}.
+   */
+  protected ThrowableSubject(FailureMetadata metadata, @NullableDecl Throwable throwable) {
+    this(metadata, throwable, null);
+  }
+
   ThrowableSubject(
       FailureMetadata metadata,
       @NullableDecl Throwable throwable,

--- a/core/src/main/java/com/google/common/truth/ThrowableSubject.java
+++ b/core/src/main/java/com/google/common/truth/ThrowableSubject.java
@@ -23,11 +23,14 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Kurt Alfred Kluever
  */
 public class ThrowableSubject extends Subject<ThrowableSubject, Throwable> {
+  private final Throwable actual;
+
   ThrowableSubject(
       FailureMetadata metadata,
       @NullableDecl Throwable throwable,
       @NullableDecl String typeDescription) {
     super(metadata, throwable, typeDescription);
+    this.actual = throwable;
   }
 
   /*
@@ -38,13 +41,13 @@ public class ThrowableSubject extends Subject<ThrowableSubject, Throwable> {
   /** Returns a {@code StringSubject} to make assertions about the throwable's message. */
   public final StringSubject hasMessageThat() {
     StandardSubjectBuilder check = check("getMessage()");
-    if (actual() instanceof ErrorWithFacts && ((ErrorWithFacts) actual()).facts().size() > 1) {
+    if (actual instanceof ErrorWithFacts && ((ErrorWithFacts) actual).facts().size() > 1) {
       check =
           check.withMessage(
               "(Note from Truth: When possible, instead of asserting on the full message, assert"
                   + " about individual facts by using ExpectFailure.assertThat.)");
     }
-    return check.that(actual().getMessage());
+    return check.that(actual.getMessage());
   }
 
   /**
@@ -57,7 +60,7 @@ public class ThrowableSubject extends Subject<ThrowableSubject, Throwable> {
     // e.g. assertThat(new Exception()).hCT().hCT()....
     // TODO(diamondm) in keeping with other subjects' behavior this should still NPE if the subject
     // *itself* is null, since there's no context to lose. See also b/37645583
-    if (actual() == null) {
+    if (actual == null) {
       check("getCause()").fail("Causal chain is not deep enough - add a .isNotNull() check?");
       return ignoreCheck()
           .that(
@@ -69,6 +72,6 @@ public class ThrowableSubject extends Subject<ThrowableSubject, Throwable> {
                 }
               });
     }
-    return check("getCause()").that(actual().getCause());
+    return check("getCause()").that(actual.getCause());
   }
 }

--- a/core/src/main/java/com/google/common/truth/TruthFailureSubject.java
+++ b/core/src/main/java/com/google/common/truth/TruthFailureSubject.java
@@ -66,20 +66,23 @@ public final class TruthFailureSubject extends ThrowableSubject {
         }
       };
 
+  private final Throwable actual;
+
   TruthFailureSubject(
       FailureMetadata metadata,
       @NullableDecl Throwable throwable,
       @NullableDecl String typeDescription) {
     super(metadata, throwable, typeDescription);
+    this.actual = throwable;
   }
 
   /** Returns a subject for the list of fact keys. */
   public IterableSubject factKeys() {
-    if (!(actual() instanceof ErrorWithFacts)) {
+    if (!(actual instanceof ErrorWithFacts)) {
       failWithActual(simpleFact("expected a failure thrown by Truth's new failure API"));
       return ignoreCheck().that(ImmutableList.of());
     }
-    ErrorWithFacts error = (ErrorWithFacts) actual();
+    ErrorWithFacts error = (ErrorWithFacts) actual;
     return check("factKeys()").that(getFactKeys(error));
   }
 
@@ -128,11 +131,11 @@ public final class TruthFailureSubject extends ThrowableSubject {
 
   private StringSubject doFactValue(String key, @NullableDecl Integer index) {
     checkNotNull(key);
-    if (!(actual() instanceof ErrorWithFacts)) {
+    if (!(actual instanceof ErrorWithFacts)) {
       failWithActual(simpleFact("expected a failure thrown by Truth's new failure API"));
       return ignoreCheck().that("");
     }
-    ErrorWithFacts error = (ErrorWithFacts) actual();
+    ErrorWithFacts error = (ErrorWithFacts) actual;
 
     /*
      * We don't care as much about including the actual Throwable and its facts in these because

--- a/core/src/test/java/com/google/common/truth/ExpectFailureTest.java
+++ b/core/src/test/java/com/google/common/truth/ExpectFailureTest.java
@@ -141,17 +141,20 @@ public class ExpectFailureTest {
   }
 
   private static class BadSubject extends Subject<BadSubject, Integer> {
+    private final Integer actual;
+
     BadSubject(FailureMetadata failureMetadat, Integer actual) {
       super(failureMetadat, actual);
+      this.actual = actual;
     }
 
     @Override
     public void isEqualTo(Object expected) {
-      if (!actual().equals(expected)) {
+      if (!actual.equals(expected)) {
         failWithoutActual(
-            simpleFact(lenientFormat("expected <%s> is equal to <%s>", actual(), expected)));
+            simpleFact(lenientFormat("expected <%s> is equal to <%s>", actual, expected)));
         failWithoutActual(
-            simpleFact(lenientFormat("expected <%s> is equal to <%s>", expected, actual())));
+            simpleFact(lenientFormat("expected <%s> is equal to <%s>", expected, actual)));
       }
     }
 

--- a/core/src/test/java/com/google/common/truth/extension/EmployeeSubject.java
+++ b/core/src/test/java/com/google/common/truth/extension/EmployeeSubject.java
@@ -43,36 +43,39 @@ public final class EmployeeSubject extends Subject<EmployeeSubject, Employee> {
   private static final Subject.Factory<EmployeeSubject, Employee> EMPLOYEE_SUBJECT_FACTORY =
       EmployeeSubject::new;
 
+  private final Employee actual;
+
   private EmployeeSubject(FailureMetadata failureMetadata, @NullableDecl Employee subject) {
     super(failureMetadata, subject);
+    this.actual = subject;
   }
 
   // User-defined test assertion SPI below this point
 
   public void hasName(String name) {
-    check("name()").that(actual().name()).isEqualTo(name);
+    check("name()").that(actual.name()).isEqualTo(name);
   }
 
   public void hasUsername(String username) {
-    check("username()").that(actual().username()).isEqualTo(username);
+    check("username()").that(actual.username()).isEqualTo(username);
   }
 
   public void hasId(long id) {
-    check("id()").that(actual().id()).isEqualTo(id);
+    check("id()").that(actual.id()).isEqualTo(id);
   }
 
   public void hasLocation(Employee.Location location) {
-    check("location()").that(actual().location()).isEqualTo(location);
+    check("location()").that(actual.location()).isEqualTo(location);
   }
 
   public void isCeo() {
-    if (!actual().isCeo()) {
+    if (!actual.isCeo()) {
       failWithActual(simpleFact("expected to be CEO"));
     }
   }
 
   public void isNotCeo() {
-    if (actual().isCeo()) {
+    if (actual.isCeo()) {
       failWithActual(simpleFact("expected not to be CEO"));
     }
   }

--- a/extensions/java8/src/main/java/com/google/common/truth/OptionalDoubleSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/OptionalDoubleSubject.java
@@ -28,30 +28,33 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  */
 public final class OptionalDoubleSubject extends Subject<OptionalDoubleSubject, OptionalDouble> {
 
+  private final OptionalDouble actual;
+
   OptionalDoubleSubject(
       FailureMetadata failureMetadata,
       @NullableDecl OptionalDouble subject,
       @NullableDecl String typeDescription) {
     super(failureMetadata, subject, typeDescription);
+    this.actual = subject;
   }
 
   /** Fails if the {@link OptionalDouble} is empty or the subject is null. */
   public void isPresent() {
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual(simpleFact("expected present optional"));
-    } else if (!actual().isPresent()) {
+    } else if (!actual.isPresent()) {
       failWithoutActual(simpleFact("expected to be present"));
     }
   }
 
   /** Fails if the {@link OptionalDouble} is present or the subject is null. */
   public void isEmpty() {
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual(simpleFact("expected empty optional"));
-    } else if (actual().isPresent()) {
+    } else if (actual.isPresent()) {
       failWithoutActual(
           simpleFact("expected to be empty"),
-          fact("but was present with value", actual().getAsDouble()));
+          fact("but was present with value", actual.getAsDouble()));
     }
   }
 
@@ -64,13 +67,13 @@ public final class OptionalDoubleSubject extends Subject<OptionalDoubleSubject, 
    * modification from its input or returning a well-defined literal or constant value.
    */
   public void hasValue(double expected) {
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual("expected an optional with value", expected);
-    } else if (!actual().isPresent()) {
+    } else if (!actual.isPresent()) {
       failWithoutActual(fact("expected to have value", expected), simpleFact("but was absent"));
     } else {
       checkNoNeedToDisplayBothValues("getAsDouble()")
-          .that(actual().getAsDouble())
+          .that(actual.getAsDouble())
           .isEqualTo(expected);
     }
   }
@@ -80,11 +83,11 @@ public final class OptionalDoubleSubject extends Subject<OptionalDoubleSubject, 
    * immediately if the subject is empty.
    */
   public DoubleSubject hasValueThat() {
-    if (actual() == null || !actual().isPresent()) {
+    if (actual == null || !actual.isPresent()) {
       isPresent(); // fails
       return ignoreCheck().that(0.0);
     } else {
-      return check("getAsDouble()").that(actual().getAsDouble());
+      return check("getAsDouble()").that(actual.getAsDouble());
     }
   }
 

--- a/extensions/java8/src/main/java/com/google/common/truth/OptionalIntSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/OptionalIntSubject.java
@@ -27,30 +27,33 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Ben Douglass
  */
 public final class OptionalIntSubject extends Subject<OptionalIntSubject, OptionalInt> {
+  private final OptionalInt actual;
+
   OptionalIntSubject(
       FailureMetadata failureMetadata,
       @NullableDecl OptionalInt subject,
       @NullableDecl String typeDescription) {
     super(failureMetadata, subject, typeDescription);
+    this.actual = subject;
   }
 
   /** Fails if the {@link OptionalInt} is empty or the subject is null. */
   public void isPresent() {
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual(simpleFact("expected present optional"));
-    } else if (!actual().isPresent()) {
+    } else if (!actual.isPresent()) {
       failWithoutActual(simpleFact("expected to be present"));
     }
   }
 
   /** Fails if the {@link OptionalInt} is present or the subject is null. */
   public void isEmpty() {
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual(simpleFact("expected empty optional"));
-    } else if (actual().isPresent()) {
+    } else if (actual.isPresent()) {
       failWithoutActual(
           simpleFact("expected to be empty"),
-          fact("but was present with value", actual().getAsInt()));
+          fact("but was present with value", actual.getAsInt()));
     }
   }
 
@@ -59,12 +62,12 @@ public final class OptionalIntSubject extends Subject<OptionalIntSubject, Option
    * sophisticated comparisons can be done using {@link #hasValueThat()}.
    */
   public void hasValue(int expected) {
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual("expected an optional with value", expected);
-    } else if (!actual().isPresent()) {
+    } else if (!actual.isPresent()) {
       failWithoutActual(fact("expected to have value", expected), simpleFact("but was absent"));
     } else {
-      checkNoNeedToDisplayBothValues("getAsInt()").that(actual().getAsInt()).isEqualTo(expected);
+      checkNoNeedToDisplayBothValues("getAsInt()").that(actual.getAsInt()).isEqualTo(expected);
     }
   }
 
@@ -73,11 +76,11 @@ public final class OptionalIntSubject extends Subject<OptionalIntSubject, Option
    * immediately if the subject is empty.
    */
   public IntegerSubject hasValueThat() {
-    if (actual() == null || !actual().isPresent()) {
+    if (actual == null || !actual.isPresent()) {
       isPresent(); // fails
       return ignoreCheck().that(0);
     } else {
-      return check("getAsInt()").that(actual().getAsInt());
+      return check("getAsInt()").that(actual.getAsInt());
     }
   }
 

--- a/extensions/java8/src/main/java/com/google/common/truth/OptionalLongSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/OptionalLongSubject.java
@@ -27,30 +27,33 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Ben Douglass
  */
 public final class OptionalLongSubject extends Subject<OptionalLongSubject, OptionalLong> {
+  private final OptionalLong actual;
+
   OptionalLongSubject(
       FailureMetadata failureMetadata,
       @NullableDecl OptionalLong subject,
       @NullableDecl String typeDescription) {
     super(failureMetadata, subject, typeDescription);
+    this.actual = subject;
   }
 
   /** Fails if the {@link OptionalLong} is empty or the subject is null. */
   public void isPresent() {
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual(simpleFact("expected present optional"));
-    } else if (!actual().isPresent()) {
+    } else if (!actual.isPresent()) {
       failWithoutActual(simpleFact("expected to be present"));
     }
   }
 
   /** Fails if the {@link OptionalLong} is present or the subject is null. */
   public void isEmpty() {
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual(simpleFact("expected empty optional"));
-    } else if (actual().isPresent()) {
+    } else if (actual.isPresent()) {
       failWithoutActual(
           simpleFact("expected to be empty"),
-          fact("but was present with value", actual().getAsLong()));
+          fact("but was present with value", actual.getAsLong()));
     }
   }
 
@@ -59,12 +62,12 @@ public final class OptionalLongSubject extends Subject<OptionalLongSubject, Opti
    * sophisticated comparisons can be done using {@link #hasValueThat()}.
    */
   public void hasValue(long expected) {
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual("expected an optional with value", expected);
-    } else if (!actual().isPresent()) {
+    } else if (!actual.isPresent()) {
       failWithoutActual(fact("expected to have value", expected), simpleFact("but was absent"));
     } else {
-      checkNoNeedToDisplayBothValues("getAsLong()").that(actual().getAsLong()).isEqualTo(expected);
+      checkNoNeedToDisplayBothValues("getAsLong()").that(actual.getAsLong()).isEqualTo(expected);
     }
   }
 
@@ -73,11 +76,11 @@ public final class OptionalLongSubject extends Subject<OptionalLongSubject, Opti
    * immediately if the subject is empty.
    */
   public LongSubject hasValueThat() {
-    if (actual() == null || !actual().isPresent()) {
+    if (actual == null || !actual.isPresent()) {
       isPresent(); // fails
       return ignoreCheck().that(0L);
     } else {
-      return check("getAsLong()").that(actual().getAsLong());
+      return check("getAsLong()").that(actual.getAsLong());
     }
   }
 

--- a/extensions/java8/src/main/java/com/google/common/truth/OptionalSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/OptionalSubject.java
@@ -27,31 +27,34 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Christian Gruber
  */
 public final class OptionalSubject extends Subject<OptionalSubject, Optional<?>> {
+  private final Optional<?> actual;
+
   OptionalSubject(
       FailureMetadata failureMetadata,
       @NullableDecl Optional<?> subject,
       @NullableDecl String typeDescription) {
     super(failureMetadata, subject, typeDescription);
+    this.actual = subject;
   }
 
   // TODO(cpovirk): Consider making OptionalIntSubject and OptionalLongSubject delegate to this.
 
   /** Fails if the {@link Optional}{@code <T>} is empty or the subject is null. */
   public void isPresent() {
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual(simpleFact("expected present optional"));
-    } else if (!actual().isPresent()) {
+    } else if (!actual.isPresent()) {
       failWithoutActual(simpleFact("expected to be present"));
     }
   }
 
   /** Fails if the {@link Optional}{@code <T>} is present or the subject is null. */
   public void isEmpty() {
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual(simpleFact("expected empty optional"));
-    } else if (actual().isPresent()) {
+    } else if (actual.isPresent()) {
       failWithoutActual(
-          simpleFact("expected to be empty"), fact("but was present with value", actual().get()));
+          simpleFact("expected to be empty"), fact("but was present with value", actual.get()));
     }
   }
 
@@ -69,12 +72,12 @@ public final class OptionalSubject extends Subject<OptionalSubject, Optional<?>>
     if (expected == null) {
       throw new NullPointerException("Optional cannot have a null value.");
     }
-    if (actual() == null) {
+    if (actual == null) {
       failWithActual("expected an optional with value", expected);
-    } else if (!actual().isPresent()) {
+    } else if (!actual.isPresent()) {
       failWithoutActual(fact("expected to have value", expected), simpleFact("but was empty"));
     } else {
-      checkNoNeedToDisplayBothValues("get()").that(actual().get()).isEqualTo(expected);
+      checkNoNeedToDisplayBothValues("get()").that(actual.get()).isEqualTo(expected);
     }
   }
 

--- a/extensions/liteproto/src/main/java/com/google/common/truth/extensions/proto/LiteProtoSubject.java
+++ b/extensions/liteproto/src/main/java/com/google/common/truth/extensions/proto/LiteProtoSubject.java
@@ -61,8 +61,11 @@ public class LiteProtoSubject<S extends LiteProtoSubject<S, M>, M extends Messag
     return MessageLiteSubjectFactory.INSTANCE;
   }
 
+  private final M actual;
+
   protected LiteProtoSubject(FailureMetadata failureMetadata, @NullableDecl M messageLite) {
     super(failureMetadata, messageLite);
+    this.actual = messageLite;
   }
 
   // It is wrong to compare protos using their string representations. The MessageLite runtime
@@ -89,7 +92,7 @@ public class LiteProtoSubject<S extends LiteProtoSubject<S, M>, M extends Messag
 
   @Override
   protected String actualCustomStringRepresentation() {
-    return getTrimmedToString(actual());
+    return getTrimmedToString(actual);
   }
 
   /**
@@ -99,19 +102,19 @@ public class LiteProtoSubject<S extends LiteProtoSubject<S, M>, M extends Messag
   @Override
   public void isEqualTo(@NullableDecl Object expected) {
     // TODO(user): Do better here when MessageLite descriptors are available.
-    if (Objects.equal(actual(), expected)) {
+    if (Objects.equal(actual, expected)) {
       return;
     }
 
-    if (actual() == null || expected == null) {
+    if (actual == null || expected == null) {
       super.isEqualTo(expected);
-    } else if (actual().getClass() != expected.getClass()) {
+    } else if (actual.getClass() != expected.getClass()) {
       failWithoutActual(
           simpleFact(
               lenientFormat(
                   "Not true that (%s) %s is equal to the expected (%s) object. "
                       + "They are not of the same class.",
-                  actual().getClass().getName(),
+                  actual.getClass().getName(),
                   internalCustomName() != null ? internalCustomName() + " (proto)" : "proto",
                   expected.getClass().getName())));
     } else {
@@ -119,7 +122,7 @@ public class LiteProtoSubject<S extends LiteProtoSubject<S, M>, M extends Messag
        * TODO(cpovirk): If we someday let subjects override formatActualOrExpected(), change this
        * class to do so, and make this code path always delegate to super.isEqualTo().
        */
-      String ourString = getTrimmedToString(actual());
+      String ourString = getTrimmedToString(actual);
       String theirString = getTrimmedToString((MessageLite) expected);
       if (!ourString.equals(theirString)) {
         check().that(ourString).isEqualTo(theirString); // fails
@@ -141,15 +144,15 @@ public class LiteProtoSubject<S extends LiteProtoSubject<S, M>, M extends Messag
 
   @Override
   public void isNotEqualTo(@NullableDecl Object expected) {
-    if (Objects.equal(actual(), expected)) {
-      if (actual() == null) {
+    if (Objects.equal(actual, expected)) {
+      if (actual == null) {
         super.isNotEqualTo(expected);
       } else {
         failWithoutActual(
             simpleFact(
                 lenientFormat(
                     "Not true that protos are different. Both are (%s) <%s>.",
-                    actual().getClass().getName(), getTrimmedToString(actual()))));
+                    actual.getClass().getName(), getTrimmedToString(actual))));
       }
     }
   }
@@ -165,12 +168,12 @@ public class LiteProtoSubject<S extends LiteProtoSubject<S, M>, M extends Messag
 
   /** Checks whether the subject is a {@link MessageLite} with no fields set. */
   public void isEqualToDefaultInstance() {
-    if (actual() == null) {
+    if (actual == null) {
       failWithoutActual(
           simpleFact(
               lenientFormat(
                   "Not true that %s is a default proto instance. It is null.", actualAsString())));
-    } else if (!actual().equals(actual().getDefaultInstanceForType())) {
+    } else if (!actual.equals(actual.getDefaultInstanceForType())) {
       failWithoutActual(
           simpleFact(
               lenientFormat(
@@ -181,12 +184,12 @@ public class LiteProtoSubject<S extends LiteProtoSubject<S, M>, M extends Messag
 
   /** Checks whether the subject is not equivalent to a {@link MessageLite} with no fields set. */
   public void isNotEqualToDefaultInstance() {
-    if (actual() != null && actual().equals(actual().getDefaultInstanceForType())) {
+    if (actual != null && actual.equals(actual.getDefaultInstanceForType())) {
       failWithoutActual(
           simpleFact(
               lenientFormat(
                   "Not true that (%s) %s is not a default proto instance. It has no set values.",
-                  actual().getClass().getName(), actualAsString())));
+                  actual.getClass().getName(), actualAsString())));
     }
   }
 
@@ -195,7 +198,7 @@ public class LiteProtoSubject<S extends LiteProtoSubject<S, M>, M extends Messag
    * {@code build()}, which itself fails if required fields aren't set.
    */
   public void hasAllRequiredFields() {
-    if (!actual().isInitialized()) {
+    if (!actual.isInitialized()) {
       // MessageLite doesn't support reflection so this is the best we can do.
       failWithoutActual(
           simpleFact(
@@ -213,10 +216,11 @@ public class LiteProtoSubject<S extends LiteProtoSubject<S, M>, M extends Messag
    * assertThat(myProto).serializedSize().isAtLeast(16)}, etc.
    */
   public IntegerSubject serializedSize() {
-    return check("getSerializedSize()").that(actual().getSerializedSize());
+    return check("getSerializedSize()").that(actual.getSerializedSize());
   }
 
   static final class MessageLiteSubject extends LiteProtoSubject<MessageLiteSubject, MessageLite> {
+
     MessageLiteSubject(FailureMetadata failureMetadata, @NullableDecl MessageLite messageLite) {
       super(failureMetadata, messageLite);
     }

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosSubject.java
@@ -56,6 +56,7 @@ public class IterableOfProtosSubject<
         S extends IterableOfProtosSubject<S, M, C>, M extends Message, C extends Iterable<M>>
     extends Subject<S, C> {
 
+  private final C actual;
   private final FluentEqualityConfig config;
 
   /** Default implementation of {@link IterableOfProtosSubject}. */
@@ -117,6 +118,7 @@ public class IterableOfProtosSubject<
   IterableOfProtosSubject(
       FailureMetadata failureMetadata, FluentEqualityConfig config, @NullableDecl C messages) {
     super(failureMetadata, messages);
+    this.actual = messages;
     this.config = config;
   }
 
@@ -125,7 +127,7 @@ public class IterableOfProtosSubject<
   //////////////////////////////////////////////////////////////////////////////////////////////////
 
   private final IterableSubject delegate() {
-    IterableSubject delegate = check().that(actual());
+    IterableSubject delegate = check().that(actual);
     if (internalCustomName() != null) {
       delegate = delegate.named(internalCustomName());
     }
@@ -480,7 +482,7 @@ public class IterableOfProtosSubject<
   IterableOfProtosFluentAssertion<M> usingConfig(FluentEqualityConfig newConfig) {
     Subject.Factory<IterableOfMessagesSubject<M>, Iterable<M>> factory =
         iterableOfMessages(newConfig);
-    IterableOfMessagesSubject<M> newSubject = check().about(factory).that(actual());
+    IterableOfMessagesSubject<M> newSubject = check().about(factory).that(actual);
     if (internalCustomName() != null) {
       newSubject = newSubject.named(internalCustomName());
     }
@@ -1019,7 +1021,7 @@ public class IterableOfProtosSubject<
               subject
                   .config
                   .withExpectedMessages(messages)
-                  .<M>toCorrespondence(FieldScopeUtil.getSingleDescriptor(subject.actual())));
+                  .<M>toCorrespondence(FieldScopeUtil.getSingleDescriptor(subject.actual)));
       if (keyFunction != null) {
         usingCorrespondence = usingCorrespondence.displayingDiffsPairedBy(keyFunction);
       }

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubject.java
@@ -56,6 +56,7 @@ public class MapWithProtoValuesSubject<
         S extends MapWithProtoValuesSubject<S, K, M, C>, K, M extends Message, C extends Map<K, M>>
     extends Subject<S, C> {
 
+  private final C actual;
   private final FluentEqualityConfig config;
 
   /** Default implementation of {@link MapWithProtoValuesSubject}. */
@@ -80,6 +81,7 @@ public class MapWithProtoValuesSubject<
   MapWithProtoValuesSubject(
       FailureMetadata failureMetadata, FluentEqualityConfig config, @NullableDecl C map) {
     super(failureMetadata, map);
+    this.actual = map;
     this.config = config;
   }
 
@@ -100,7 +102,7 @@ public class MapWithProtoValuesSubject<
   //////////////////////////////////////////////////////////////////////////////////////////////////
 
   private final MapSubject delegate() {
-    MapSubject delegate = check().that(actual());
+    MapSubject delegate = check().that(actual);
     if (internalCustomName() != null) {
       delegate = delegate.named(internalCustomName());
     }
@@ -210,7 +212,7 @@ public class MapWithProtoValuesSubject<
   MapWithProtoValuesFluentAssertion<M> usingConfig(FluentEqualityConfig newConfig) {
     Subject.Factory<MapWithMessageValuesSubject<K, M>, Map<K, M>> factory =
         mapWithProtoValues(newConfig);
-    MapWithMessageValuesSubject<K, M> newSubject = check().about(factory).that(actual());
+    MapWithMessageValuesSubject<K, M> newSubject = check().about(factory).that(actual);
     if (internalCustomName() != null) {
       newSubject = newSubject.named(internalCustomName());
     }
@@ -740,7 +742,7 @@ public class MapWithProtoValuesSubject<
     return comparingValuesUsing(
         config
             .withExpectedMessages(expectedValues)
-            .<M>toCorrespondence(FieldScopeUtil.getSingleDescriptor(actual().values())));
+            .<M>toCorrespondence(FieldScopeUtil.getSingleDescriptor(actual.values())));
   }
 
   // The UsingCorrespondence methods have conflicting erasure with default MapSubject methods,

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubject.java
@@ -60,6 +60,7 @@ public class MultimapWithProtoValuesSubject<
         C extends Multimap<K, M>>
     extends Subject<S, C> {
 
+  private final C actual;
   private final FluentEqualityConfig config;
 
   /** Default implementation of {@link MultimapWithProtoValuesSubject}. */
@@ -101,6 +102,7 @@ public class MultimapWithProtoValuesSubject<
   MultimapWithProtoValuesSubject(
       FailureMetadata failureMetadata, FluentEqualityConfig config, @NullableDecl C multimap) {
     super(failureMetadata, multimap);
+    this.actual = multimap;
     this.config = config;
   }
 
@@ -109,7 +111,7 @@ public class MultimapWithProtoValuesSubject<
   //////////////////////////////////////////////////////////////////////////////////////////////////
 
   private final MultimapSubject delegate() {
-    MultimapSubject delegate = check().that(actual());
+    MultimapSubject delegate = check().that(actual);
     if (internalCustomName() != null) {
       delegate = delegate.named(internalCustomName());
     }
@@ -187,9 +189,8 @@ public class MultimapWithProtoValuesSubject<
    */
   public IterableOfProtosSubject<?, M, Iterable<M>> valuesForKey(@NullableDecl Object key) {
     Subject.Factory<IterableValuesForKey<M>, Iterable<M>> factory =
-        iterableOfProtos(
-            "Values for key <" + key + "> (<" + actual() + ">) in " + actualAsString());
-    return check().about(factory).that(((Multimap<Object, M>) actual()).get(key));
+        iterableOfProtos("Values for key <" + key + "> (<" + actual + ">) in " + actualAsString());
+    return check().about(factory).that(((Multimap<Object, M>) actual).get(key));
   }
 
   /**
@@ -255,7 +256,7 @@ public class MultimapWithProtoValuesSubject<
   MultimapWithProtoValuesFluentAssertion<M> usingConfig(FluentEqualityConfig newConfig) {
     Subject.Factory<MultimapWithMessageValuesSubject<K, M>, Multimap<K, M>> factory =
         multimapWithMessageValues(newConfig);
-    MultimapWithMessageValuesSubject<K, M> newSubject = check().about(factory).that(actual());
+    MultimapWithMessageValuesSubject<K, M> newSubject = check().about(factory).that(actual);
     if (internalCustomName() != null) {
       newSubject = newSubject.named(internalCustomName());
     }
@@ -789,7 +790,7 @@ public class MultimapWithProtoValuesSubject<
     return comparingValuesUsing(
         config
             .withExpectedMessages(expectedValues)
-            .<M>toCorrespondence(FieldScopeUtil.getSingleDescriptor(actual().values())));
+            .<M>toCorrespondence(FieldScopeUtil.getSingleDescriptor(actual.values())));
   }
 
   // The UsingCorrespondence methods have conflicting erasure with default MapSubject methods,

--- a/extensions/re2j/src/main/java/com/google/common/truth/extensions/re2j/Re2jSubjects.java
+++ b/extensions/re2j/src/main/java/com/google/common/truth/extensions/re2j/Re2jSubjects.java
@@ -59,18 +59,21 @@ public final class Re2jSubjects {
           }
         };
 
+    private final String actual;
+
     private Re2jStringSubject(FailureMetadata failureMetadata, String subject) {
       super(failureMetadata, subject);
+      this.actual = subject;
     }
 
     @Override
     protected String actualCustomStringRepresentation() {
-      return quote(actual());
+      return quote(actual);
     }
 
     /** Fails if the string does not match the given regex. */
     public void matches(String regex) {
-      if (!Pattern.matches(regex, actual())) {
+      if (!Pattern.matches(regex, actual)) {
         failWithActual("expected to match ", regex);
       }
     }
@@ -78,14 +81,14 @@ public final class Re2jSubjects {
     /** Fails if the string does not match the given regex. */
     @GwtIncompatible("com.google.re2j.Pattern")
     public void matches(Pattern regex) {
-      if (!regex.matcher(actual()).matches()) {
+      if (!regex.matcher(actual).matches()) {
         failWithActual("expected to match ", regex);
       }
     }
 
     /** Fails if the string matches the given regex. */
     public void doesNotMatch(String regex) {
-      if (Pattern.matches(regex, actual())) {
+      if (Pattern.matches(regex, actual)) {
         failWithActual("expected to fail to match", regex);
       }
     }
@@ -93,7 +96,7 @@ public final class Re2jSubjects {
     /** Fails if the string matches the given regex. */
     @GwtIncompatible("com.google.re2j.Pattern")
     public void doesNotMatch(Pattern regex) {
-      if (regex.matcher(actual()).matches()) {
+      if (regex.matcher(actual).matches()) {
         failWithActual("expected to fail to match", regex);
       }
     }
@@ -101,7 +104,7 @@ public final class Re2jSubjects {
     /** Fails if the string does not contain a match on the given regex. */
     @GwtIncompatible("com.google.re2j.Pattern")
     public void containsMatch(Pattern pattern) {
-      if (!pattern.matcher(actual()).find()) {
+      if (!pattern.matcher(actual).find()) {
         failWithoutActual(
             simpleFact(
                 lenientFormat(
@@ -111,7 +114,7 @@ public final class Re2jSubjects {
 
     /** Fails if the string does not contain a match on the given regex. */
     public void containsMatch(String regex) {
-      if (!doContainsMatch(actual(), regex)) {
+      if (!doContainsMatch(actual, regex)) {
         failWithoutActual(
             simpleFact(
                 lenientFormat(
@@ -122,7 +125,7 @@ public final class Re2jSubjects {
     /** Fails if the string contains a match on the given regex. */
     @GwtIncompatible("com.google.re2j.Pattern")
     public void doesNotContainMatch(Pattern pattern) {
-      if (pattern.matcher(actual()).find()) {
+      if (pattern.matcher(actual).find()) {
         failWithoutActual(
             simpleFact(
                 lenientFormat(
@@ -132,7 +135,7 @@ public final class Re2jSubjects {
 
     /** Fails if the string contains a match on the given regex. */
     public void doesNotContainMatch(String regex) {
-      if (doContainsMatch(actual(), regex)) {
+      if (doContainsMatch(actual, regex)) {
         failWithoutActual(
             simpleFact(
                 lenientFormat(


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Instead of calling Subject.actual(), store the actual value in a field, and read that.

actual() is being removed.

0da24de521fea85b76cc4255eb95314260569ce5

-------

<p> Deprecate the no-arg Subject.check().

We've migrated users to the other overload when it was practical to automate, and we've manually cleaned up the remaining third-party users to convince ourselves that there's no especially low-hanging fruit left. Users don't need to migrate off this overload, but we can try to prevent it from attracting more usages. (We also have a code-review-time check that suggests a replacement in the simple case.)

f826f86206f49dc32b91166db3078837ed1125a5

-------

<p> Permit users to extend ThrowableSubject.

https://github.com/google/truth/issues/217

RELNOTES=Exposed the constructor of `ThrowableSubject` to subclasses. Note that actually extending `ThrowableSubject` won't fully work until we remove the type parameters from `Subject`.

8c913aee44bd16c82300057e64c5cffd62d6bda4