### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/ComparableSubject.java
+++ b/core/src/main/java/com/google/common/truth/ComparableSubject.java
@@ -22,6 +22,12 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * Propositions for {@link Comparable} typed subjects.
  *
  * @author Kurt Alfred Kluever
+ * @param <S> <b>deprecated -</b> the self-type, allowing {@code this}-returning methods to avoid
+ *     needing subclassing. <i>This type parameter will be removed, as the method that needs it is
+ *     being removed. You can prepare for this change by editing your class to refer to raw {@code
+ *     ComparableSubject} today and then, after the removal, editing it to refer to {@code
+ *     ComparableSubject<T>} (with a single type parameter).</i>
+ * @param <T> the type of the object being tested by this {@code ComparableSubject}
  */
 public abstract class ComparableSubject<S extends ComparableSubject<S, T>, T extends Comparable>
     extends Subject<S, T> {

--- a/core/src/main/java/com/google/common/truth/DefaultSubject.java
+++ b/core/src/main/java/com/google/common/truth/DefaultSubject.java
@@ -23,12 +23,12 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *     soon go away, so you may wish to start using raw {@code Subject} now to prepare.
  */
 @Deprecated
-public final class DefaultSubject extends Subject<DefaultSubject, Object> {
+public class DefaultSubject extends Subject<DefaultSubject, Object> {
   /**
    * Constructor for use by subclasses. If you want to create an instance of this class itself, call
    * {@link Subject#check}{@code .that(actual)}.
    */
-  DefaultSubject(FailureMetadata metadata, @NullableDecl Object o) {
+  protected DefaultSubject(FailureMetadata metadata, @NullableDecl Object o) {
     super(metadata, o);
   }
 }

--- a/core/src/main/java/com/google/common/truth/IterableSubject.java
+++ b/core/src/main/java/com/google/common/truth/IterableSubject.java
@@ -846,55 +846,55 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
   }
 
   /**
-   * <i>To be deprecated in favor of {@link #isInStrictOrder()}.</i>
-   *
-   * <p>Fails if the iterable is not strictly ordered, according to the natural ordering of its
+   * Fails if the iterable is not strictly ordered, according to the natural ordering of its
    * elements. Strictly ordered means that each element in the iterable is <i>strictly</i> greater
    * than the element that preceded it.
    *
    * @throws ClassCastException if any pair of elements is not mutually Comparable
    * @throws NullPointerException if any element is null
+   * @deprecated Use {@link #isInStrictOrder()}.
    */
+  @Deprecated
   public final void isStrictlyOrdered() {
     isInStrictOrder();
   }
 
   /**
-   * <i>To be deprecated in favor of {@link #isInStrictOrder(Comparator)}.</i>
-   *
-   * <p>Fails if the iterable is not strictly ordered, according to the given comparator. Strictly
+   * Fails if the iterable is not strictly ordered, according to the given comparator. Strictly
    * ordered means that each element in the iterable is <i>strictly</i> greater than the element
    * that preceded it.
    *
    * @throws ClassCastException if any pair of elements is not mutually Comparable
+   * @deprecated Use {@link #isInStrictOrder(Comparator)}.
    */
+  @Deprecated
   @SuppressWarnings({"unchecked"})
   public final void isStrictlyOrdered(final Comparator<?> comparator) {
     isInStrictOrder(comparator);
   }
 
   /**
-   * <i>To be deprecated in favor of {@link #isInOrder()}.</i>
-   *
-   * <p>Fails if the iterable is not ordered, according to the natural ordering of its elements.
+   * Fails if the iterable is not ordered, according to the natural ordering of its elements.
    * Ordered means that each element in the iterable is greater than or equal to the element that
    * preceded it.
    *
    * @throws ClassCastException if any pair of elements is not mutually Comparable
    * @throws NullPointerException if any element is null
+   * @deprecated Use {@link #isInOrder()}
    */
+  @Deprecated
   public final void isOrdered() {
     isInOrder();
   }
 
   /**
-   * <i>To be deprecated in favor of {@link #isInOrder(Comparator)}.</i>
-   *
-   * <p>Fails if the iterable is not ordered, according to the given comparator. Ordered means that
+   * Fails if the iterable is not ordered, according to the given comparator. Ordered means that
    * each element in the iterable is greater than or equal to the element that preceded it.
    *
    * @throws ClassCastException if any pair of elements is not mutually Comparable
+   * @deprecated Use {@link #isInOrder(Comparator)}.
    */
+  @Deprecated
   @SuppressWarnings({"unchecked"})
   public final void isOrdered(final Comparator<?> comparator) {
     isInOrder(comparator);

--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -66,8 +66,13 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * <p>For information about writing a custom {@link Subject}, see <a
  * href="https://google.github.io/truth/extension">our doc on extensions</a>.
  *
- * @param <S> the self-type, allowing {@code this}-returning methods to avoid needing subclassing
- * @param <T> the type of the object being tested by this {@code Subject}
+ * @param <S> <b>deprecated -</b> the self-type, allowing {@code this}-returning methods to avoid
+ *     needing subclassing. <i>Both type parameters will be removed, as the methods that need them
+ *     are being removed. You can prepare for this change by editing your class to refer to raw
+ *     {@code Subject} today.</i>
+ * @param <T> <b>deprecated -</b> the type of the object being tested by this {@code Subject}.
+ *     <i>Both type parameters will be removed, as the methods that need them are being removed. You
+ *     can prepare for this change by editing your class to refer to raw {@code Subject} today.</i>
  * @author David Saff
  * @author Christian Gruber
  */

--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -411,14 +411,24 @@ public class Subject<S extends Subject<S, T>, T> {
     isNotIn(accumulate(first, second, rest));
   }
 
-  /** @deprecated Prefer {@code #actual()} for direct access to the subject. */
+  /**
+   * Returns the unedited, unformatted raw actual value.
+   *
+   * @deprecated Instead, declare a private field to store the actual value inside your {@link
+   *     Subject} subclass. We will be releasing a tool to automate most migrations.
+   */
   @Deprecated
   protected T getSubject() {
-    // TODO(cgruber): move functionality to actual() and delete when no callers.
     return actual;
   }
 
-  /** Returns the unedited, unformatted raw actual value. */
+  /**
+   * Returns the unedited, unformatted raw actual value.
+   *
+   * @deprecated Instead, declare a private field to store the actual value inside your {@link
+   *     Subject} subclass. We will be releasing a tool to automate most migrations.
+   */
+  @Deprecated
   protected final T actual() {
     return getSubject();
   }

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosSubject.java
@@ -388,14 +388,14 @@ public class IterableOfProtosSubject<
   }
 
   /**
-   * <i>To be deprecated in favor of {@link #isInStrictOrder(Comparator)}.</i>
-   *
-   * <p>Fails if the iterable is not strictly ordered, according to the given comparator. Strictly
+   * Fails if the iterable is not strictly ordered, according to the given comparator. Strictly
    * ordered means that each element in the iterable is <i>strictly</i> greater than the element
    * that preceded it.
    *
    * @throws ClassCastException if any pair of elements is not mutually Comparable
+   * @deprecated Use {@link #isInStrictOrder(Comparator)}.
    */
+  @Deprecated
   public void isStrictlyOrdered(Comparator<?> comparator) {
     delegate().isStrictlyOrdered(comparator);
   }
@@ -407,7 +407,9 @@ public class IterableOfProtosSubject<
    * each element in the iterable is greater than or equal to the element that preceded it.
    *
    * @throws ClassCastException if any pair of elements is not mutually Comparable
+   * @deprecated Use {@link #isInOrder(Comparator)}.
    */
+  @Deprecated
   public void isOrdered(Comparator<?> comparator) {
     delegate().isOrdered(comparator);
   }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Deprecate actual().

RELNOTES=Deprecated `Subject.actual()`. Instead of calling it, declare your own field to store the actual value. We will be releasing a tool to automate most migrations.

6c10f43baed8d30d6022d279d152a8e564afc43c

-------

<p> "Deprecate" the type parameters on Subject (and one type parameter on ComparableSubject).

RELNOTES="Deprecated" the type parameters on `Subject`. To prepare for their removal in the next release, you can edit your code today to refer to the raw `Subject` type. Also "deprecated" the self-type parameter on `ComparableSubject`. Again, you can prepare your code by referring to raw `ComparableSubject` (and later change it to refer to `ComparableSubject<T>` when the class has only one type parameter next release).

8b33b0c26e8f2f858768e3529057559dab91f0ed

-------

<p> Deprecate isOrdered() and isStrictlyOrdered().

Use isInOrder() and isStrictlyInOrder(), which are equivalent.

RELNOTES=Deprecated `isOrdered()` and `isStrictlyOrdered()`. Use `isInOrder()` and `isStrictlyInOrder()`, which are equivalent.

8b92deb58f5af361b39a5336947a05fe300126e1

-------

<p> Temporarily make `DefaultSubject` extensible again, and make Kotlin types extend it instead of `Subject`.

This is to prepare for when we remove the type parameters from `Subject`.

Usually, the way we prepare is by making custom subjects extend from raw `Subject`. However, Kotlin (IIUC) doesn't support declaring a raw type.

That leaves a couple options:

1. Change these references from `Subject<...>` to `Subject` atomically in the same CL in which I remove Subject's type parameters. This should work, but I'd prefer to keep that CL as small as possible -- and external users would likely prefer the ability to do this non-atomically, too.

2. Temporarily extend `DefaultSubject`, which already has no type parameters and thus won't change in the CL that removes the type parameters from `Subject`. Later, after `Subject`'s type parameters are gone, I'll change them to extend the newly parameter-free `Subject`.

This CL implements option 2.

RELNOTES=Temporarily made `DefaultSubject` extensible again. Kotlin subjects can now extend `DefaultSubject` instead of `Subject`. This lets those subjects compile both before and after we remove the type parameters from `Subject`. After we remove the type parameters, Kotlin subjects should extend `Subject` again (with no type parameters), as we'll later remove `DefaultSubject`.

aba89b580da909200fe86a92a0d9ee849c3bcbf8