### PR TITLE
Upgrade animal sniffer to version 1.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,8 +266,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>animal-sniffer-maven-plugin</artifactId>
-          <!-- Note that 1.17 doesn't work with Java 8: https://github.com/mojohaus/animal-sniffer/issues/53 -->
-          <version>1.16</version>
+          <version>1.18</version>
           <configuration>
             <signature>
               <groupId>org.codehaus.mojo.signature</groupId>


### PR DESCRIPTION
The JDK 8 issue [(https://github.com/mojohaus/animal-sniffer/issues/53](https://github.com/mojohaus/animal-sniffer/issues/53)) mentioned in the POM has been resolved in version [1.18](https://github.com/mojohaus/animal-sniffer/milestone/5?closed=1)

No change in the build observed using JDK 8