### PR TITLE
Moe Sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,19 @@ and [Guava] types, and it is [extensible][extension] to others.
 Truth is owned and maintained by the [Guava] team. It is used in the majority
 of the tests in Google’s own codebase.
 
-Read more at [the main website](https://google.github.io/truth).
+Read more at [the main website](https://truth.dev).
 
 <!-- references -->
 
-[test assertions]: https://google.github.io/truth/benefits#readable-assertions
-[failure messages]: https://google.github.io/truth/benefits#readable-messages
-[comparison]: https://google.github.io/truth/comparison
+[test assertions]: https://truth.dev/benefits#readable-assertions
+[failure messages]: https://truth.dev/benefits#readable-messages
+[comparison]: https://truth.dev/comparison
 [AssertJ]: http://joel-costigliola.github.io/assertj/
-[known_types]: https://google.github.io/truth/known_types
-[extension]: https://google.github.io/truth/extension
+[known_types]: https://truth.dev/known_types
+[extension]: https://truth.dev/extension
 [Guava]: https://github.com/google/guava
 [gh-pages-shield]: https://img.shields.io/badge/main%20site-google.github.io/truth-ff55ff.png?style=flat
-[gh-pages-link]: https://google.github.io/truth/
+[gh-pages-link]: https://truth.dev/
 [travis-shield]: https://img.shields.io/travis/google/truth.png
 [travis-link]: https://travis-ci.org/google/truth
 [maven-shield]: https://img.shields.io/maven-central/v/com.google.truth/truth.png

--- a/core/src/main/java/com/google/common/truth/AbstractArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/AbstractArraySubject.java
@@ -26,11 +26,11 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Christian Gruber (cgruber@israfil.net)
  */
-abstract class AbstractArraySubject<S extends AbstractArraySubject<S, T>, T> extends Subject<S, T> {
-  private final T actual;
+abstract class AbstractArraySubject extends Subject {
+  private final Object actual;
 
   AbstractArraySubject(
-      FailureMetadata metadata, @NullableDecl T actual, @NullableDecl String typeDescription) {
+      FailureMetadata metadata, @NullableDecl Object actual, @NullableDecl String typeDescription) {
     super(metadata, actual, typeDescription);
     this.actual = actual;
   }

--- a/core/src/main/java/com/google/common/truth/AtomicLongMapSubject.java
+++ b/core/src/main/java/com/google/common/truth/AtomicLongMapSubject.java
@@ -28,7 +28,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Kurt Alfred Kluever
  */
-public final class AtomicLongMapSubject extends Subject<AtomicLongMapSubject, AtomicLongMap<?>> {
+public final class AtomicLongMapSubject extends Subject {
   private final AtomicLongMap<?> actual;
 
   AtomicLongMapSubject(FailureMetadata metadata, @NullableDecl AtomicLongMap<?> map) {

--- a/core/src/main/java/com/google/common/truth/BigDecimalSubject.java
+++ b/core/src/main/java/com/google/common/truth/BigDecimalSubject.java
@@ -26,7 +26,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Kurt Alfred Kluever
  */
-public final class BigDecimalSubject extends ComparableSubject<BigDecimalSubject, BigDecimal> {
+public final class BigDecimalSubject extends ComparableSubject<BigDecimal> {
   private final BigDecimal actual;
 
   BigDecimalSubject(FailureMetadata metadata, @NullableDecl BigDecimal actual) {

--- a/core/src/main/java/com/google/common/truth/BooleanSubject.java
+++ b/core/src/main/java/com/google/common/truth/BooleanSubject.java
@@ -24,7 +24,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Christian Gruber (cgruber@israfil.net)
  */
-public final class BooleanSubject extends Subject<BooleanSubject, Boolean> {
+public final class BooleanSubject extends Subject {
   private final Boolean actual;
 
   BooleanSubject(FailureMetadata metadata, @NullableDecl Boolean actual) {

--- a/core/src/main/java/com/google/common/truth/ClassSubject.java
+++ b/core/src/main/java/com/google/common/truth/ClassSubject.java
@@ -24,7 +24,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Kurt Alfred Kluever
  */
 @GwtIncompatible("reflection")
-public final class ClassSubject extends Subject<ClassSubject, Class<?>> {
+public final class ClassSubject extends Subject {
   private final Class<?> actual;
 
   ClassSubject(FailureMetadata metadata, @NullableDecl Class<?> o) {

--- a/core/src/main/java/com/google/common/truth/ComparableSubject.java
+++ b/core/src/main/java/com/google/common/truth/ComparableSubject.java
@@ -22,15 +22,9 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * Propositions for {@link Comparable} typed subjects.
  *
  * @author Kurt Alfred Kluever
- * @param <S> <b>deprecated -</b> the self-type, allowing {@code this}-returning methods to avoid
- *     needing subclassing. <i>This type parameter will be removed, as the method that needs it is
- *     being removed. You can prepare for this change by editing your class to refer to raw {@code
- *     ComparableSubject} today and then, after the removal, editing it to refer to {@code
- *     ComparableSubject<T>} (with a single type parameter).</i>
  * @param <T> the type of the object being tested by this {@code ComparableSubject}
  */
-public abstract class ComparableSubject<S extends ComparableSubject<S, T>, T extends Comparable>
-    extends Subject<S, T> {
+public abstract class ComparableSubject<T extends Comparable> extends Subject {
   /**
    * Constructor for use by subclasses. If you want to create an instance of this class itself, call
    * {@link Subject#check}{@code .that(actual)}.

--- a/core/src/main/java/com/google/common/truth/CustomSubjectBuilder.java
+++ b/core/src/main/java/com/google/common/truth/CustomSubjectBuilder.java
@@ -26,11 +26,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * itself, only on its subtypes, which are the types users actually interact with.)
  *
  * <p>For more information about the methods in this class, see <a
- * href="https://google.github.io/truth/faq#full-chain">this FAQ entry</a>.
+ * href="https://truth.dev/faq#full-chain">this FAQ entry</a>.
  *
  * <h3>For people extending Truth</h3>
  *
- * <p>When you write a custom subject, see <a href="https://google.github.io/truth/extension">our doc on
+ * <p>When you write a custom subject, see <a href="https://truth.dev/extension">our doc on
  * extensions</a>. It explains the cases in which {@code CustomSubjectBuilder} is necessary.
  */
 public abstract class CustomSubjectBuilder {
@@ -40,11 +40,11 @@ public abstract class CustomSubjectBuilder {
    * what kind of {@link Subject} to create.
    *
    * <p>For more information about the fluent chain, see <a
-   * href="https://google.github.io/truth/faq#full-chain">this FAQ entry</a>.
+   * href="https://truth.dev/faq#full-chain">this FAQ entry</a>.
    *
    * <h3>For people extending Truth</h3>
    *
-   * <p>When you write a custom subject, see <a href="https://google.github.io/truth/extension">our doc on
+   * <p>When you write a custom subject, see <a href="https://truth.dev/extension">our doc on
    * extensions</a>. It explains the cases in which {@code CustomSubjectBuilder.Factory} is
    * necessary.
    */

--- a/core/src/main/java/com/google/common/truth/DefaultSubject.java
+++ b/core/src/main/java/com/google/common/truth/DefaultSubject.java
@@ -23,7 +23,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *     soon go away, so you may wish to start using raw {@code Subject} now to prepare.
  */
 @Deprecated
-public class DefaultSubject extends Subject<DefaultSubject, Object> {
+public class DefaultSubject extends Subject {
   /**
    * Constructor for use by subclasses. If you want to create an instance of this class itself, call
    * {@link Subject#check}{@code .that(actual)}.

--- a/core/src/main/java/com/google/common/truth/DoubleSubject.java
+++ b/core/src/main/java/com/google/common/truth/DoubleSubject.java
@@ -33,7 +33,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Kurt Alfred Kluever
  */
-public final class DoubleSubject extends ComparableSubject<DoubleSubject, Double> {
+public final class DoubleSubject extends ComparableSubject<Double> {
   private static final long NEG_ZERO_BITS = doubleToLongBits(-0.0);
 
   private final Double actual;

--- a/core/src/main/java/com/google/common/truth/FailureMetadata.java
+++ b/core/src/main/java/com/google/common/truth/FailureMetadata.java
@@ -61,7 +61,7 @@ public final class FailureMetadata {
    * The data from a call to either (a) a {@link Subject} constructor or (b) {@link Subject#check}.
    */
   private static final class Step {
-    static Step subjectCreation(Subject<?, ?> subject) {
+    static Step subjectCreation(Subject subject) {
       return new Step(checkNotNull(subject), null, null);
     }
 
@@ -78,7 +78,7 @@ public final class FailureMetadata {
      * time we receive it. We *might* be able to make it safe to call if it looks only at actual(),
      * but it might try to look at facts initialized by a subclass, which aren't ready yet.
      */
-    @NullableDecl final Subject<?, ?> subject;
+    @NullableDecl final Subject subject;
 
     @NullableDecl final Function<String, String> descriptionUpdate;
 
@@ -86,7 +86,7 @@ public final class FailureMetadata {
     @NullableDecl final OldAndNewValuesAreSimilar valuesAreSimilar;
 
     private Step(
-        @NullableDecl Subject<?, ?> subject,
+        @NullableDecl Subject subject,
         @NullableDecl Function<String, String> descriptionUpdate,
         @NullableDecl OldAndNewValuesAreSimilar valuesAreSimilar) {
       this.subject = subject;
@@ -124,7 +124,7 @@ public final class FailureMetadata {
    * the initial that(...) call and continuing into any chained calls, like {@link
    * ThrowableSubject#hasMessageThat}.
    */
-  FailureMetadata updateForSubject(Subject<?, ?> subject) {
+  FailureMetadata updateForSubject(Subject subject) {
     ImmutableList<Step> steps = append(this.steps, Step.subjectCreation(subject));
     return derive(messages, steps);
   }

--- a/core/src/main/java/com/google/common/truth/FailureStrategy.java
+++ b/core/src/main/java/com/google/common/truth/FailureStrategy.java
@@ -30,7 +30,7 @@ package com.google.common.truth;
  *   <li>(and some useful only to people who implement custom subjects, described below)
  * </ul>
  *
- * <p>For more information about the fluent chain, see <a href="https://google.github.io/truth/faq#full-chain">this
+ * <p>For more information about the fluent chain, see <a href="https://truth.dev/faq#full-chain">this
  * FAQ entry</a>.
  *
  * <h3>For people extending Truth</h3>

--- a/core/src/main/java/com/google/common/truth/FloatSubject.java
+++ b/core/src/main/java/com/google/common/truth/FloatSubject.java
@@ -33,7 +33,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Kurt Alfred Kluever
  */
-public final class FloatSubject extends ComparableSubject<FloatSubject, Float> {
+public final class FloatSubject extends ComparableSubject<Float> {
   private static final int NEG_ZERO_BITS = floatToIntBits(-0.0f);
 
   private final Float actual;

--- a/core/src/main/java/com/google/common/truth/GuavaOptionalSubject.java
+++ b/core/src/main/java/com/google/common/truth/GuavaOptionalSubject.java
@@ -25,7 +25,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * Propositions for Guava {@link Optional} subjects.
  *
  * <p>If you are looking for a {@code java.util.Optional} subject, please read
- * <a href="http://google.github.io/truth/faq#java8">faq#java8</a>
+ * <a href="https://truth.dev/faq#java8">faq#java8</a>
  *
  * @author Christian Gruber
  */

--- a/core/src/main/java/com/google/common/truth/GuavaOptionalSubject.java
+++ b/core/src/main/java/com/google/common/truth/GuavaOptionalSubject.java
@@ -29,7 +29,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Christian Gruber
  */
-public final class GuavaOptionalSubject extends Subject<GuavaOptionalSubject, Optional<?>> {
+public final class GuavaOptionalSubject extends Subject {
   private final Optional<?> actual;
 
   GuavaOptionalSubject(

--- a/core/src/main/java/com/google/common/truth/IntegerSubject.java
+++ b/core/src/main/java/com/google/common/truth/IntegerSubject.java
@@ -24,7 +24,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Christian Gruber (cgruber@israfil.net)
  * @author Kurt Alfred Kluever
  */
-public class IntegerSubject extends ComparableSubject<IntegerSubject, Integer> {
+public class IntegerSubject extends ComparableSubject<Integer> {
   // TODO(kak): Make this package-protected?
   /**
    * Constructor for use by subclasses. If you want to create an instance of this class itself, call

--- a/core/src/main/java/com/google/common/truth/IterableSubject.java
+++ b/core/src/main/java/com/google/common/truth/IterableSubject.java
@@ -88,7 +88,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Pete Gillin
  */
 // Can't be final since MultisetSubject and SortedSetSubject extend it
-public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
+public class IterableSubject extends Subject {
 
   private final Iterable<?> actual;
 
@@ -944,7 +944,8 @@ public class IterableSubject extends Subject<IterableSubject, Iterable<?>> {
   /** @deprecated You probably meant to call {@link #containsNoneIn} instead. */
   @Override
   @Deprecated
-  public void isNotIn(Iterable<?> iterable) {
+  // TODO(b/133145187): Restore to Iterable<?> after removing the type parameters from Subject.
+  public void isNotIn(Iterable iterable) {
     if (Iterables.contains(iterable, actual)) {
       failWithActual("expected not to be any of", iterable);
     }

--- a/core/src/main/java/com/google/common/truth/IterableSubject.java
+++ b/core/src/main/java/com/google/common/truth/IterableSubject.java
@@ -662,13 +662,15 @@ public class IterableSubject extends Subject {
 
   private static ElementFactGrouping pickGrouping(
       Iterable<Entry<?>> first, Iterable<Entry<?>> second) {
-    if (anyHasMultiple(first, second) && anyContainsCommaOrNewline(first, second)) {
+    boolean firstHasMultiple = hasMultiple(first);
+    boolean secondHasMultiple = hasMultiple(second);
+    if ((firstHasMultiple || secondHasMultiple) && anyContainsCommaOrNewline(first, second)) {
       return FACT_PER_ELEMENT;
     }
-    if (hasMultiple(first) && containsEmptyOrLong(first)) {
+    if (firstHasMultiple && containsEmptyOrLong(first)) {
       return FACT_PER_ELEMENT;
     }
-    if (hasMultiple(second) && containsEmptyOrLong(second)) {
+    if (secondHasMultiple && containsEmptyOrLong(second)) {
       return FACT_PER_ELEMENT;
     }
     return ALL_IN_ONE_FACT;
@@ -678,15 +680,6 @@ public class IterableSubject extends Subject {
     for (Entry<?> entry : concat(lists)) {
       String s = String.valueOf(entry.getElement());
       if (s.contains("\n") || s.contains(",")) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private static boolean anyHasMultiple(Iterable<Entry<?>>... lists) {
-    for (Iterable<Entry<?>> list : lists) {
-      if (hasMultiple(list)) {
         return true;
       }
     }

--- a/core/src/main/java/com/google/common/truth/IterableSubject.java
+++ b/core/src/main/java/com/google/common/truth/IterableSubject.java
@@ -693,8 +693,15 @@ public class IterableSubject extends Subject {
     return false;
   }
 
-  private static boolean hasMultiple(Iterable<Entry<?>> list) {
-    return totalCount(list) > 1;
+  private static boolean hasMultiple(Iterable<Entry<?>> entries) {
+    int totalCount = 0;
+    for (Multiset.Entry<?> entry : entries) {
+      totalCount += entry.getCount();
+      if (totalCount > 1) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static boolean containsEmptyOrLong(Iterable<Entry<?>> entries) {
@@ -707,14 +714,6 @@ public class IterableSubject extends Subject {
       totalLength += s.length();
     }
     return totalLength > 200;
-  }
-
-  private static int totalCount(Iterable<Entry<?>> entries) {
-    int totalCount = 0;
-    for (Multiset.Entry<?> entry : entries) {
-      totalCount += entry.getCount();
-    }
-    return totalCount;
   }
 
   /**

--- a/core/src/main/java/com/google/common/truth/LongSubject.java
+++ b/core/src/main/java/com/google/common/truth/LongSubject.java
@@ -24,7 +24,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Christian Gruber (cgruber@israfil.net)
  * @author Kurt Alfred Kluever
  */
-public class LongSubject extends ComparableSubject<LongSubject, Long> {
+public class LongSubject extends ComparableSubject<Long> {
   // TODO(kak): Make this package-protected?
   /**
    * Constructor for use by subclasses. If you want to create an instance of this class itself, call

--- a/core/src/main/java/com/google/common/truth/MapSubject.java
+++ b/core/src/main/java/com/google/common/truth/MapSubject.java
@@ -50,7 +50,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Christian Gruber
  * @author Kurt Alfred Kluever
  */
-public class MapSubject extends Subject<MapSubject, Map<?, ?>> {
+public class MapSubject extends Subject {
   private final Map<?, ?> actual;
 
   /**

--- a/core/src/main/java/com/google/common/truth/MultimapSubject.java
+++ b/core/src/main/java/com/google/common/truth/MultimapSubject.java
@@ -56,7 +56,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Daniel Ploch
  * @author Kurt Alfred Kluever
  */
-public class MultimapSubject extends Subject<MultimapSubject, Multimap<?, ?>> {
+public class MultimapSubject extends Subject {
 
   /** Ordered implementation that does nothing because an earlier check already caused a failure. */
   private static final Ordered ALREADY_FAILED =

--- a/core/src/main/java/com/google/common/truth/ObjectArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/ObjectArraySubject.java
@@ -23,7 +23,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Christian Gruber
  */
-public final class ObjectArraySubject<T> extends AbstractArraySubject<ObjectArraySubject<T>, T[]> {
+public final class ObjectArraySubject<T> extends AbstractArraySubject {
   private final T[] actual;
 
   ObjectArraySubject(

--- a/core/src/main/java/com/google/common/truth/PrimitiveBooleanArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveBooleanArraySubject.java
@@ -23,8 +23,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Christian Gruber (cgruber@israfil.net)
  */
-public final class PrimitiveBooleanArraySubject
-    extends AbstractArraySubject<PrimitiveBooleanArraySubject, boolean[]> {
+public final class PrimitiveBooleanArraySubject extends AbstractArraySubject {
   private final boolean[] actual;
 
   PrimitiveBooleanArraySubject(

--- a/core/src/main/java/com/google/common/truth/PrimitiveByteArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveByteArraySubject.java
@@ -23,8 +23,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Kurt Alfred Kluever
  */
-public final class PrimitiveByteArraySubject
-    extends AbstractArraySubject<PrimitiveByteArraySubject, byte[]> {
+public final class PrimitiveByteArraySubject extends AbstractArraySubject {
   private final byte[] actual;
 
   PrimitiveByteArraySubject(

--- a/core/src/main/java/com/google/common/truth/PrimitiveCharArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveCharArraySubject.java
@@ -23,8 +23,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Christian Gruber (cgruber@israfil.net)
  */
-public final class PrimitiveCharArraySubject
-    extends AbstractArraySubject<PrimitiveCharArraySubject, char[]> {
+public final class PrimitiveCharArraySubject extends AbstractArraySubject {
   private final char[] actual;
 
   PrimitiveCharArraySubject(

--- a/core/src/main/java/com/google/common/truth/PrimitiveDoubleArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveDoubleArraySubject.java
@@ -30,8 +30,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Christian Gruber (cgruber@israfil.net)
  */
-public final class PrimitiveDoubleArraySubject
-    extends AbstractArraySubject<PrimitiveDoubleArraySubject, double[]> {
+public final class PrimitiveDoubleArraySubject extends AbstractArraySubject {
   private final double[] actual;
 
   PrimitiveDoubleArraySubject(

--- a/core/src/main/java/com/google/common/truth/PrimitiveFloatArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveFloatArraySubject.java
@@ -30,8 +30,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Christian Gruber (cgruber@israfil.net)
  */
-public final class PrimitiveFloatArraySubject
-    extends AbstractArraySubject<PrimitiveFloatArraySubject, float[]> {
+public final class PrimitiveFloatArraySubject extends AbstractArraySubject {
   private final float[] actual;
 
   PrimitiveFloatArraySubject(

--- a/core/src/main/java/com/google/common/truth/PrimitiveIntArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveIntArraySubject.java
@@ -23,8 +23,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Christian Gruber (cgruber@israfil.net)
  */
-public final class PrimitiveIntArraySubject
-    extends AbstractArraySubject<PrimitiveIntArraySubject, int[]> {
+public final class PrimitiveIntArraySubject extends AbstractArraySubject {
   private final int[] actual;
 
   PrimitiveIntArraySubject(

--- a/core/src/main/java/com/google/common/truth/PrimitiveLongArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveLongArraySubject.java
@@ -23,8 +23,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Christian Gruber (cgruber@israfil.net)
  */
-public final class PrimitiveLongArraySubject
-    extends AbstractArraySubject<PrimitiveLongArraySubject, long[]> {
+public final class PrimitiveLongArraySubject extends AbstractArraySubject {
   private final long[] actual;
 
   PrimitiveLongArraySubject(

--- a/core/src/main/java/com/google/common/truth/PrimitiveShortArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveShortArraySubject.java
@@ -23,8 +23,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Christian Gruber (cgruber@israfil.net)
  */
-public final class PrimitiveShortArraySubject
-    extends AbstractArraySubject<PrimitiveShortArraySubject, short[]> {
+public final class PrimitiveShortArraySubject extends AbstractArraySubject {
   private final short[] actual;
 
   PrimitiveShortArraySubject(

--- a/core/src/main/java/com/google/common/truth/SimpleSubjectBuilder.java
+++ b/core/src/main/java/com/google/common/truth/SimpleSubjectBuilder.java
@@ -26,12 +26,12 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * under test and returns a {@link Subject}.
  *
  * <p>For more information about the methods in this class, see <a
- * href="https://google.github.io/truth/faq#full-chain">this FAQ entry</a>.
+ * href="https://truth.dev/faq#full-chain">this FAQ entry</a>.
  *
  * <h3>For people extending Truth</h3>
  *
  * <p>You won't extend this type. When you write a custom subject, see <a
- * href="https://google.github.io/truth/extension">our doc on extensions</a>.
+ * href="https://truth.dev/extension">our doc on extensions</a>.
  */
 public final class SimpleSubjectBuilder<SubjectT extends Subject, ActualT> {
   private final FailureMetadata metadata;

--- a/core/src/main/java/com/google/common/truth/StandardSubjectBuilder.java
+++ b/core/src/main/java/com/google/common/truth/StandardSubjectBuilder.java
@@ -43,12 +43,12 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * </ul>
  *
  * <p>For more information about the methods in this class, see <a
- * href="https://google.github.io/truth/faq#full-chain">this FAQ entry</a>.
+ * href="https://truth.dev/faq#full-chain">this FAQ entry</a>.
  *
  * <h3>For people extending Truth</h3>
  *
  * <p>You won't extend this type. When you write a custom subject, see <a
- * href="https://google.github.io/truth/extension">our doc on extensions</a>.
+ * href="https://truth.dev/extension">our doc on extensions</a>.
  */
 public class StandardSubjectBuilder {
   /**

--- a/core/src/main/java/com/google/common/truth/StandardSubjectBuilder.java
+++ b/core/src/main/java/com/google/common/truth/StandardSubjectBuilder.java
@@ -67,7 +67,7 @@ public class StandardSubjectBuilder {
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})
-  public final <ComparableT extends Comparable<?>> ComparableSubject<?, ComparableT> that(
+  public final <ComparableT extends Comparable<?>> ComparableSubject<ComparableT> that(
       @NullableDecl ComparableT actual) {
     return new ComparableSubject(metadata(), actual) {};
   }

--- a/core/src/main/java/com/google/common/truth/StandardSubjectBuilder.java
+++ b/core/src/main/java/com/google/common/truth/StandardSubjectBuilder.java
@@ -76,8 +76,8 @@ public class StandardSubjectBuilder {
     return new BigDecimalSubject(metadata(), actual);
   }
 
-  public final Subject<DefaultSubject, Object> that(@NullableDecl Object actual) {
-    return new DefaultSubject(metadata(), actual);
+  public final Subject that(@NullableDecl Object actual) {
+    return new Subject(metadata(), actual);
   }
 
   @GwtIncompatible("ClassSubject.java")

--- a/core/src/main/java/com/google/common/truth/StringSubject.java
+++ b/core/src/main/java/com/google/common/truth/StringSubject.java
@@ -32,7 +32,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Christian Gruber (cgruber@israfil.net)
  */
 // TODO(kak): Make this final
-public class StringSubject extends ComparableSubject<StringSubject, String> {
+public class StringSubject extends ComparableSubject<String> {
   // TODO(kak): Make this package-private?
   /**
    * Constructor for use by subclasses. If you want to create an instance of this class itself, call

--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -43,7 +43,6 @@ import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import com.google.common.primitives.Shorts;
 import com.google.common.truth.FailureMetadata.OldAndNewValuesAreSimilar;
-import com.google.errorprone.annotations.CompatibleWith;
 import com.google.errorprone.annotations.ForOverride;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
@@ -65,23 +64,10 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * <p>For information about writing a custom {@link Subject}, see <a
  * href="https://truth.dev/extension">our doc on extensions</a>.
  *
- * @param <DeprecatedSelfTypeUseRawTypesInsteadOfParameterizedSubjectT> <b>deprecated -</b> the
- *     self-type, allowing {@code this}-returning methods to avoid needing subclassing. <i>Both type
- *     parameters will be removed, as the methods that need them are being removed. You can prepare
- *     for this change by editing your class to refer to raw {@code Subject} today.</i>
- * @param <DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT> <b>deprecated -</b> the
- *     type of the object being tested by this {@code Subject}. <i>Both type parameters will be
- *     removed, as the methods that need them are being removed. You can prepare for this change by
- *     editing your class to refer to raw {@code Subject} today.</i>
  * @author David Saff
  * @author Christian Gruber
  */
-public class Subject<
-    DeprecatedSelfTypeUseRawTypesInsteadOfParameterizedSubjectT extends
-        Subject<
-                DeprecatedSelfTypeUseRawTypesInsteadOfParameterizedSubjectT,
-                DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT>,
-    DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT> {
+public class Subject {
   /**
    * In a fluent assertion chain, the argument to the common overload of {@link
    * StandardSubjectBuilder#about(Subject.Factory) about}, the method that specifies what kind of
@@ -107,7 +93,7 @@ public class Subject<
       };
 
   private final FailureMetadata metadata;
-  private final DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT actual;
+  private final Object actual;
   private String customName = null;
   @NullableDecl private final String typeDescriptionOverride;
 
@@ -115,9 +101,7 @@ public class Subject<
    * Constructor for use by subclasses. If you want to create an instance of this class itself, call
    * {@link Subject#check}{@code .that(actual)}.
    */
-  protected Subject(
-      FailureMetadata metadata,
-      @NullableDecl DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT actual) {
+  protected Subject(FailureMetadata metadata, @NullableDecl Object actual) {
     this(metadata, actual, /*typeDescriptionOverride=*/ null);
   }
 
@@ -134,7 +118,7 @@ public class Subject<
    */
   Subject(
       FailureMetadata metadata,
-      @NullableDecl DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT actual,
+      @NullableDecl Object actual,
       @NullableDecl String typeDescriptionOverride) {
     this.metadata = metadata.updateForSubject(this);
     this.actual = actual;
@@ -267,9 +251,7 @@ public class Subject<
   }
 
   /** Fails if the subject is not the same instance as the given object. */
-  public final void isSameInstanceAs(
-      @NullableDecl @CompatibleWith("DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT")
-          Object expected) {
+  public final void isSameInstanceAs(@NullableDecl Object expected) {
     if (actual != expected) {
       failEqualityCheck(
           SAME_INSTANCE,
@@ -285,9 +267,7 @@ public class Subject<
   }
 
   /** Fails if the subject is the same instance as the given object. */
-  public final void isNotSameInstanceAs(
-      @NullableDecl @CompatibleWith("DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT")
-          Object unexpected) {
+  public final void isNotSameInstanceAs(@NullableDecl Object unexpected) {
     if (actual == unexpected) {
       /*
        * We use actualCustomStringRepresentation() because it might be overridden to be better than
@@ -354,11 +334,7 @@ public class Subject<
 
   /** Fails unless the subject is equal to any of the given elements. */
   public void isAnyOf(
-      @NullableDecl @CompatibleWith("DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT")
-          Object first,
-      @NullableDecl @CompatibleWith("DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT")
-          Object second,
-      @NullableDecl Object... rest) {
+      @NullableDecl Object first, @NullableDecl Object second, @NullableDecl Object... rest) {
     isIn(accumulate(first, second, rest));
   }
 
@@ -371,16 +347,12 @@ public class Subject<
 
   /** Fails if the subject is equal to any of the given elements. */
   public void isNoneOf(
-      @NullableDecl @CompatibleWith("DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT")
-          Object first,
-      @NullableDecl @CompatibleWith("DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT")
-          Object second,
-      @NullableDecl Object... rest) {
+      @NullableDecl Object first, @NullableDecl Object second, @NullableDecl Object... rest) {
     isNotIn(accumulate(first, second, rest));
   }
 
   /** Returns the actual value under test. */
-  final DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT actual() {
+  final Object actual() {
     return actual;
   }
 

--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -58,12 +58,12 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * <p>To create a {@code Subject} instance, most users will call an {@link Truth#assertThat
  * assertThat} method. For information about other ways to create an instance, see <a
- * href="https://google.github.io/truth/faq#full-chain">this FAQ entry</a>.
+ * href="https://truth.dev/faq#full-chain">this FAQ entry</a>.
  *
  * <h3>For people extending Truth</h3>
  *
  * <p>For information about writing a custom {@link Subject}, see <a
- * href="https://google.github.io/truth/extension">our doc on extensions</a>.
+ * href="https://truth.dev/extension">our doc on extensions</a>.
  *
  * @param <S> <b>deprecated -</b> the self-type, allowing {@code this}-returning methods to avoid
  *     needing subclassing. <i>Both type parameters will be removed, as the methods that need them
@@ -82,11 +82,11 @@ public class Subject<S extends Subject<S, T>, T> {
    * {@link Subject} to create.
    *
    * <p>For more information about the fluent chain, see <a
-   * href="https://google.github.io/truth/faq#full-chain">this FAQ entry</a>.
+   * href="https://truth.dev/faq#full-chain">this FAQ entry</a>.
    *
    * <h3>For people extending Truth</h3>
    *
-   * <p>When you write a custom subject, see <a href="https://google.github.io/truth/extension">our doc on
+   * <p>When you write a custom subject, see <a href="https://truth.dev/extension">our doc on
    * extensions</a>. It explains where {@code Subject.Factory} fits into the process.
    */
   public interface Factory<SubjectT extends Subject, ActualT> {

--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -65,17 +65,23 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * <p>For information about writing a custom {@link Subject}, see <a
  * href="https://truth.dev/extension">our doc on extensions</a>.
  *
- * @param <S> <b>deprecated -</b> the self-type, allowing {@code this}-returning methods to avoid
- *     needing subclassing. <i>Both type parameters will be removed, as the methods that need them
- *     are being removed. You can prepare for this change by editing your class to refer to raw
- *     {@code Subject} today.</i>
- * @param <T> <b>deprecated -</b> the type of the object being tested by this {@code Subject}.
- *     <i>Both type parameters will be removed, as the methods that need them are being removed. You
- *     can prepare for this change by editing your class to refer to raw {@code Subject} today.</i>
+ * @param <DeprecatedSelfTypeUseRawTypesInsteadOfParameterizedSubjectT> <b>deprecated -</b> the
+ *     self-type, allowing {@code this}-returning methods to avoid needing subclassing. <i>Both type
+ *     parameters will be removed, as the methods that need them are being removed. You can prepare
+ *     for this change by editing your class to refer to raw {@code Subject} today.</i>
+ * @param <DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT> <b>deprecated -</b> the
+ *     type of the object being tested by this {@code Subject}. <i>Both type parameters will be
+ *     removed, as the methods that need them are being removed. You can prepare for this change by
+ *     editing your class to refer to raw {@code Subject} today.</i>
  * @author David Saff
  * @author Christian Gruber
  */
-public class Subject<S extends Subject<S, T>, T> {
+public class Subject<
+    DeprecatedSelfTypeUseRawTypesInsteadOfParameterizedSubjectT extends
+        Subject<
+                DeprecatedSelfTypeUseRawTypesInsteadOfParameterizedSubjectT,
+                DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT>,
+    DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT> {
   /**
    * In a fluent assertion chain, the argument to the common overload of {@link
    * StandardSubjectBuilder#about(Subject.Factory) about}, the method that specifies what kind of
@@ -101,7 +107,7 @@ public class Subject<S extends Subject<S, T>, T> {
       };
 
   private final FailureMetadata metadata;
-  private final T actual;
+  private final DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT actual;
   private String customName = null;
   @NullableDecl private final String typeDescriptionOverride;
 
@@ -109,7 +115,9 @@ public class Subject<S extends Subject<S, T>, T> {
    * Constructor for use by subclasses. If you want to create an instance of this class itself, call
    * {@link Subject#check}{@code .that(actual)}.
    */
-  protected Subject(FailureMetadata metadata, @NullableDecl T actual) {
+  protected Subject(
+      FailureMetadata metadata,
+      @NullableDecl DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT actual) {
     this(metadata, actual, /*typeDescriptionOverride=*/ null);
   }
 
@@ -126,7 +134,7 @@ public class Subject<S extends Subject<S, T>, T> {
    */
   Subject(
       FailureMetadata metadata,
-      @NullableDecl T actual,
+      @NullableDecl DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT actual,
       @NullableDecl String typeDescriptionOverride) {
     this.metadata = metadata.updateForSubject(this);
     this.actual = actual;
@@ -259,7 +267,9 @@ public class Subject<S extends Subject<S, T>, T> {
   }
 
   /** Fails if the subject is not the same instance as the given object. */
-  public final void isSameInstanceAs(@NullableDecl @CompatibleWith("T") Object expected) {
+  public final void isSameInstanceAs(
+      @NullableDecl @CompatibleWith("DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT")
+          Object expected) {
     if (actual != expected) {
       failEqualityCheck(
           SAME_INSTANCE,
@@ -275,7 +285,9 @@ public class Subject<S extends Subject<S, T>, T> {
   }
 
   /** Fails if the subject is the same instance as the given object. */
-  public final void isNotSameInstanceAs(@NullableDecl @CompatibleWith("T") Object unexpected) {
+  public final void isNotSameInstanceAs(
+      @NullableDecl @CompatibleWith("DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT")
+          Object unexpected) {
     if (actual == unexpected) {
       /*
        * We use actualCustomStringRepresentation() because it might be overridden to be better than
@@ -342,8 +354,10 @@ public class Subject<S extends Subject<S, T>, T> {
 
   /** Fails unless the subject is equal to any of the given elements. */
   public void isAnyOf(
-      @NullableDecl @CompatibleWith("T") Object first,
-      @NullableDecl @CompatibleWith("T") Object second,
+      @NullableDecl @CompatibleWith("DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT")
+          Object first,
+      @NullableDecl @CompatibleWith("DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT")
+          Object second,
       @NullableDecl Object... rest) {
     isIn(accumulate(first, second, rest));
   }
@@ -357,14 +371,16 @@ public class Subject<S extends Subject<S, T>, T> {
 
   /** Fails if the subject is equal to any of the given elements. */
   public void isNoneOf(
-      @NullableDecl @CompatibleWith("T") Object first,
-      @NullableDecl @CompatibleWith("T") Object second,
+      @NullableDecl @CompatibleWith("DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT")
+          Object first,
+      @NullableDecl @CompatibleWith("DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT")
+          Object second,
       @NullableDecl Object... rest) {
     isNotIn(accumulate(first, second, rest));
   }
 
   /** Returns the actual value under test. */
-  final T actual() {
+  final DeprecatedActualTypeUseRawTypesInsteadOfParameterizedSubjectT actual() {
     return actual;
   }
 

--- a/core/src/main/java/com/google/common/truth/SubjectUtils.java
+++ b/core/src/main/java/com/google/common/truth/SubjectUtils.java
@@ -39,7 +39,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Utility methods used in {@code Subject<T>} implementors.
+ * Utility methods used in {@code Subject} implementors.
  *
  * @author Christian Gruber
  * @author Jens Nyman

--- a/core/src/main/java/com/google/common/truth/TableSubject.java
+++ b/core/src/main/java/com/google/common/truth/TableSubject.java
@@ -29,7 +29,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Kurt Alfred Kluever
  */
-public final class TableSubject extends Subject<TableSubject, Table<?, ?, ?>> {
+public final class TableSubject extends Subject {
   private final Table<?, ?, ?> actual;
 
   TableSubject(FailureMetadata metadata, @NullableDecl Table<?, ?, ?> table) {

--- a/core/src/main/java/com/google/common/truth/ThrowableSubject.java
+++ b/core/src/main/java/com/google/common/truth/ThrowableSubject.java
@@ -22,7 +22,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Kurt Alfred Kluever
  */
-public class ThrowableSubject extends Subject<ThrowableSubject, Throwable> {
+public class ThrowableSubject extends Subject {
   private final Throwable actual;
 
   /**

--- a/core/src/main/java/com/google/common/truth/Truth.java
+++ b/core/src/main/java/com/google/common/truth/Truth.java
@@ -59,7 +59,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * </ul>
  *
  * <p>For more information about the methods in this class, see <a
- * href="https://google.github.io/truth/faq#full-chain">this FAQ entry</a>.
+ * href="https://truth.dev/faq#full-chain">this FAQ entry</a>.
  *
  * <h3>For people extending Truth</h3>
  *

--- a/core/src/main/java/com/google/common/truth/Truth.java
+++ b/core/src/main/java/com/google/common/truth/Truth.java
@@ -144,7 +144,7 @@ public final class Truth {
     return assert_().that(actual);
   }
 
-  public static Subject<DefaultSubject, Object> assertThat(@NullableDecl Object actual) {
+  public static Subject assertThat(@NullableDecl Object actual) {
     return assert_().that(actual);
   }
 

--- a/core/src/main/java/com/google/common/truth/Truth.java
+++ b/core/src/main/java/com/google/common/truth/Truth.java
@@ -136,8 +136,7 @@ public final class Truth {
     return assert_().about(factory);
   }
 
-  public static <T extends Comparable<?>> ComparableSubject<?, T> assertThat(
-      @NullableDecl T actual) {
+  public static <T extends Comparable<?>> ComparableSubject<T> assertThat(@NullableDecl T actual) {
     return assert_().that(actual);
   }
 

--- a/core/src/main/java/com/google/common/truth/package-info.java
+++ b/core/src/main/java/com/google/common/truth/package-info.java
@@ -15,11 +15,14 @@
  */
 
 /**
- * Truth is an open source, fluent testing framework for Java that is designed to make your test
- * assertions and failure messages more readable.
+ * <a href="https://truth.dev">Truth</a> is a library for performing assertions in tests:
  *
- * <p>This package is a part of the open-source <a href="http://github.com/google/truth">Truth</a>
- * library.
+ * <pre>{@code
+ * assertThat(notificationText).contains("testuser@google.com");
+ * }</pre>
+ *
+ * <p>Truth is owned and maintained by the <a href="http://github.com/google/guava">Guava</a> team.
+ * It is used in the majority of the tests in Google’s own codebase.
  */
 @CheckReturnValue
 package com.google.common.truth;

--- a/core/src/test/java/com/google/common/truth/ChainingTest.java
+++ b/core/src/test/java/com/google/common/truth/ChainingTest.java
@@ -223,7 +223,7 @@ public final class ChainingTest extends BaseSubjectTestCase {
    * tests like MultimapSubjectTest.
    */
 
-  private static final class MyObjectSubject extends Subject<MyObjectSubject, Object> {
+  private static final class MyObjectSubject extends Subject {
     static final Factory<MyObjectSubject, Object> FACTORY =
         new Factory<MyObjectSubject, Object>() {
           @Override

--- a/core/src/test/java/com/google/common/truth/ComparableSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/ComparableSubjectTest.java
@@ -240,7 +240,7 @@ public class ComparableSubjectTest extends BaseSubjectTestCase {
     }
   }
 
-  private <T extends Comparable<? super T>> ComparableSubject<?, T> expectFailureWhenTestingThat(
+  private <T extends Comparable<? super T>> ComparableSubject<T> expectFailureWhenTestingThat(
       T actual) {
     return expectFailure.whenTesting().that(actual);
   }

--- a/core/src/test/java/com/google/common/truth/ExpectFailureTest.java
+++ b/core/src/test/java/com/google/common/truth/ExpectFailureTest.java
@@ -140,7 +140,7 @@ public class ExpectFailureTest {
     };
   }
 
-  private static class BadSubject extends Subject<BadSubject, Integer> {
+  private static class BadSubject extends Subject {
     private final Integer actual;
 
     BadSubject(FailureMetadata failureMetadat, Integer actual) {

--- a/core/src/test/java/com/google/common/truth/IntegerSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/IntegerSubjectTest.java
@@ -204,16 +204,16 @@ public class IntegerSubjectTest extends BaseSubjectTestCase {
     assertFailureValue("but was; string representation of actual value", "*");
   }
 
-  private static final Subject.Factory<DefaultSubject, Object> DEFAULT_SUBJECT_FACTORY =
-      new Subject.Factory<DefaultSubject, Object>() {
+  private static final Subject.Factory<Subject, Object> DEFAULT_SUBJECT_FACTORY =
+      new Subject.Factory<Subject, Object>() {
         @Override
-        public DefaultSubject createSubject(FailureMetadata metadata, Object that) {
-          return new DefaultSubject(metadata, that);
+        public Subject createSubject(FailureMetadata metadata, Object that) {
+          return new Subject(metadata, that);
         }
       };
 
   private static void expectFailure(
-      ExpectFailure.SimpleSubjectBuilderCallback<DefaultSubject, Object> callback) {
+      ExpectFailure.SimpleSubjectBuilderCallback<Subject, Object> callback) {
     AssertionError unused = ExpectFailure.expectFailureAbout(DEFAULT_SUBJECT_FACTORY, callback);
   }
 
@@ -236,17 +236,17 @@ public class IntegerSubjectTest extends BaseSubjectTestCase {
     ImmutableSet<Object> fortyTwosNoChar = ImmutableSet.<Object>of(byte42, short42, int42, long42);
     for (final Object actual : fortyTwosNoChar) {
       for (final Object expected : fortyTwosNoChar) {
-        ExpectFailure.SimpleSubjectBuilderCallback<DefaultSubject, Object> actualFirst =
-            new ExpectFailure.SimpleSubjectBuilderCallback<DefaultSubject, Object>() {
+        ExpectFailure.SimpleSubjectBuilderCallback<Subject, Object> actualFirst =
+            new ExpectFailure.SimpleSubjectBuilderCallback<Subject, Object>() {
               @Override
-              public void invokeAssertion(SimpleSubjectBuilder<DefaultSubject, Object> expect) {
+              public void invokeAssertion(SimpleSubjectBuilder<Subject, Object> expect) {
                 expect.that(actual).isNotEqualTo(expected);
               }
             };
-        ExpectFailure.SimpleSubjectBuilderCallback<DefaultSubject, Object> expectedFirst =
-            new ExpectFailure.SimpleSubjectBuilderCallback<DefaultSubject, Object>() {
+        ExpectFailure.SimpleSubjectBuilderCallback<Subject, Object> expectedFirst =
+            new ExpectFailure.SimpleSubjectBuilderCallback<Subject, Object>() {
               @Override
-              public void invokeAssertion(SimpleSubjectBuilder<DefaultSubject, Object> expect) {
+              public void invokeAssertion(SimpleSubjectBuilder<Subject, Object> expect) {
                 expect.that(expected).isNotEqualTo(actual);
               }
             };

--- a/core/src/test/java/com/google/common/truth/SubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/SubjectTest.java
@@ -97,7 +97,7 @@ public class SubjectTest extends BaseSubjectTestCase {
           && method.getName().equals("assertThat")
           && method.getParameterTypes().length == 1) {
         Object actual = null;
-        Subject<?, ?> subject = (Subject<?, ?>) method.invoke(Truth.class, actual);
+        Subject subject = (Subject) method.invoke(Truth.class, actual);
 
         subject.isNull();
         try {
@@ -783,8 +783,7 @@ public class SubjectTest extends BaseSubjectTestCase {
     }
   }
 
-  private static final class ForbidsEqualityChecksSubject
-      extends Subject<ForbidsEqualityChecksSubject, Object> {
+  private static final class ForbidsEqualityChecksSubject extends Subject {
     ForbidsEqualityChecksSubject(FailureMetadata metadata, @NullableDecl Object actual) {
       super(metadata, actual);
     }

--- a/core/src/test/java/com/google/common/truth/extension/EmployeeSubject.java
+++ b/core/src/test/java/com/google/common/truth/extension/EmployeeSubject.java
@@ -27,7 +27,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Kurt Alfred Kluever (kak@google.com)
  */
-public final class EmployeeSubject extends Subject<EmployeeSubject, Employee> {
+public final class EmployeeSubject extends Subject {
 
   // User-defined entry point
   public static EmployeeSubject assertThat(@NullableDecl Employee employee) {

--- a/core/src/test/java/com/google/common/truth/gwt/Inventory.java
+++ b/core/src/test/java/com/google/common/truth/gwt/Inventory.java
@@ -19,7 +19,6 @@ import com.google.common.truth.BigDecimalSubject;
 import com.google.common.truth.BooleanSubject;
 import com.google.common.truth.ClassSubject;
 import com.google.common.truth.ComparableSubject;
-import com.google.common.truth.DefaultSubject;
 import com.google.common.truth.DoubleSubject;
 import com.google.common.truth.FailureStrategy;
 import com.google.common.truth.FloatSubject;
@@ -55,7 +54,6 @@ public class Inventory {
   BooleanSubject booleanSubject;
   ClassSubject classSubject;
   ComparableSubject comparableSubject;
-  DefaultSubject defaultSubject;
   DoubleSubject doubleSubject;
   FailureStrategy failureStrategy;
   FloatSubject floatSubject;

--- a/extensions/java8/src/main/java/com/google/common/truth/IntStreamSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/IntStreamSubject.java
@@ -40,7 +40,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Kurt Alfred Kluever
  */
-public final class IntStreamSubject extends Subject<IntStreamSubject, IntStream> {
+public final class IntStreamSubject extends Subject {
 
   private final List<?> actualList;
 

--- a/extensions/java8/src/main/java/com/google/common/truth/LongStreamSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/LongStreamSubject.java
@@ -40,7 +40,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Kurt Alfred Kluever
  */
-public final class LongStreamSubject extends Subject<LongStreamSubject, LongStream> {
+public final class LongStreamSubject extends Subject {
 
   private final List<?> actualList;
 

--- a/extensions/java8/src/main/java/com/google/common/truth/OptionalDoubleSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/OptionalDoubleSubject.java
@@ -26,7 +26,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Ben Douglass
  */
-public final class OptionalDoubleSubject extends Subject<OptionalDoubleSubject, OptionalDouble> {
+public final class OptionalDoubleSubject extends Subject {
 
   private final OptionalDouble actual;
 

--- a/extensions/java8/src/main/java/com/google/common/truth/OptionalIntSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/OptionalIntSubject.java
@@ -26,7 +26,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Ben Douglass
  */
-public final class OptionalIntSubject extends Subject<OptionalIntSubject, OptionalInt> {
+public final class OptionalIntSubject extends Subject {
   private final OptionalInt actual;
 
   OptionalIntSubject(

--- a/extensions/java8/src/main/java/com/google/common/truth/OptionalLongSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/OptionalLongSubject.java
@@ -26,7 +26,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Ben Douglass
  */
-public final class OptionalLongSubject extends Subject<OptionalLongSubject, OptionalLong> {
+public final class OptionalLongSubject extends Subject {
   private final OptionalLong actual;
 
   OptionalLongSubject(

--- a/extensions/java8/src/main/java/com/google/common/truth/OptionalSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/OptionalSubject.java
@@ -26,7 +26,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @author Christian Gruber
  */
-public final class OptionalSubject extends Subject<OptionalSubject, Optional<?>> {
+public final class OptionalSubject extends Subject {
   private final Optional<?> actual;
 
   OptionalSubject(

--- a/extensions/java8/src/main/java/com/google/common/truth/PathSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/PathSubject.java
@@ -20,7 +20,7 @@ import java.nio.file.Path;
 
 /** Assertions for {@link Path} instances. */
 @GwtIncompatible
-public final class PathSubject extends Subject<PathSubject, Path> {
+public final class PathSubject extends Subject {
   private PathSubject(FailureMetadata failureMetadata, Path actual) {
     super(failureMetadata, actual);
   }

--- a/extensions/java8/src/main/java/com/google/common/truth/StreamSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/StreamSubject.java
@@ -31,15 +31,15 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * provide more readable failure messages. You should not use this class if you intend to leave the
  * stream un-consumed or if the stream is <i>very</i> large or infinite.
  *
- * <p>If you intend to make multiple assertions on the same stream of data you should instead
- * first collect the contents of the stream into a collection, and then assert directly on that.
+ * <p>If you intend to make multiple assertions on the same stream of data you should instead first
+ * collect the contents of the stream into a collection, and then assert directly on that.
  *
  * <p>For very large or infinite streams you may want to first {@linkplain Stream#limit limit} the
  * stream before asserting on it.
  *
  * @author Kurt Alfred Kluever
  */
-public final class StreamSubject extends Subject<StreamSubject, Stream<?>> {
+public final class StreamSubject extends Subject {
 
   private final List<?> actualList;
 

--- a/extensions/liteproto/src/main/java/com/google/common/truth/extensions/proto/LiteProtoSubject.java
+++ b/extensions/liteproto/src/main/java/com/google/common/truth/extensions/proto/LiteProtoSubject.java
@@ -24,7 +24,6 @@ import com.google.common.base.Objects;
 import com.google.common.truth.FailureMetadata;
 import com.google.common.truth.IntegerSubject;
 import com.google.common.truth.Subject;
-import com.google.common.truth.Truth;
 import com.google.errorprone.annotations.CheckReturnValue;
 import com.google.protobuf.MessageLite;
 import java.util.regex.Pattern;
@@ -36,36 +35,16 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * <p>LiteProtoSubject supports versions 2 and 3 of Protocol Buffers. Due to the lack of runtime
  * descriptors, its functionality is limited compared to ProtoSubject, in particular in performing
  * detailed comparisons between messages.
- *
- * @param <S> <b>deprecated -</b> the self-type, allowing {@code this}-returning methods to avoid
- *     needing subclassing. <i>Both type parameters will be removed, as the methods that need them
- *     are being removed. You can prepare for this change by editing your class to refer to raw
- *     {@code LiteProtoSubject} today.</i>
- * @param <M> <b>deprecated -</b> the type of the message being tested by this {@code Subject}.
- *     <i>Both type parameters will be removed, as the methods that need them are being removed. You
- *     can prepare for this change by editing your class to refer to raw {@code LiteProtoSubject}
- *     today.</i>
  */
 @CheckReturnValue
-public class LiteProtoSubject<S extends LiteProtoSubject<S, M>, M extends MessageLite>
-    extends Subject<S, M> {
+public class LiteProtoSubject extends Subject {
 
   /**
-   * Typed extension of {@link Subject.Factory}.
-   *
-   * <p>The existence of this class is necessary in order to satisfy the generic constraints of
-   * {@link Truth#assertAbout(Subject.Factory)}, whilst also hiding the Untyped classes which are
-   * not meant to be exposed.
+   * Returns a {@code Subject.Factory} for {@link MessageLite} subjects which you can use to assert
+   * things about Lite Protobuf properties.
    */
-  public abstract static class Factory<S extends LiteProtoSubject<S, M>, M extends MessageLite>
-      implements Subject.Factory<S, M> {}
-
-  /**
-   * Returns a SubjectFactory for {@link MessageLite} subjects which you can use to assert things
-   * about Lite Protobuf properties.
-   */
-  static Factory<?, MessageLite> liteProtos() {
-    return MessageLiteSubjectFactory.INSTANCE;
+  static Factory<LiteProtoSubject, MessageLite> liteProtos() {
+    return LiteProtoSubjectFactory.INSTANCE;
   }
 
   /*
@@ -83,9 +62,10 @@ public class LiteProtoSubject<S extends LiteProtoSubject<S, M>, M extends Messag
    * TODO(b/127819891): Use a better API for this if one is addded.
    */
   private final FailureMetadata metadata;
-  private final M actual;
+  private final MessageLite actual;
 
-  protected LiteProtoSubject(FailureMetadata failureMetadata, @NullableDecl M messageLite) {
+  protected LiteProtoSubject(
+      FailureMetadata failureMetadata, @NullableDecl MessageLite messageLite) {
     super(failureMetadata, messageLite);
     this.metadata = failureMetadata;
     this.actual = messageLite;
@@ -250,21 +230,14 @@ public class LiteProtoSubject<S extends LiteProtoSubject<S, M>, M extends Messag
     return check("getSerializedSize()").that(actual.getSerializedSize());
   }
 
-  static final class MessageLiteSubject extends LiteProtoSubject<MessageLiteSubject, MessageLite> {
-
-    MessageLiteSubject(FailureMetadata failureMetadata, @NullableDecl MessageLite messageLite) {
-      super(failureMetadata, messageLite);
-    }
-  }
-
-  private static final class MessageLiteSubjectFactory
-      extends Factory<MessageLiteSubject, MessageLite> {
-    private static final MessageLiteSubjectFactory INSTANCE = new MessageLiteSubjectFactory();
+  private static final class LiteProtoSubjectFactory
+      implements Factory<LiteProtoSubject, MessageLite> {
+    private static final LiteProtoSubjectFactory INSTANCE = new LiteProtoSubjectFactory();
 
     @Override
-    public MessageLiteSubject createSubject(
+    public LiteProtoSubject createSubject(
         FailureMetadata failureMetadata, @NullableDecl MessageLite messageLite) {
-      return new MessageLiteSubject(failureMetadata, messageLite);
+      return new LiteProtoSubject(failureMetadata, messageLite);
     }
   }
 }

--- a/extensions/liteproto/src/main/java/com/google/common/truth/extensions/proto/LiteProtoTruth.java
+++ b/extensions/liteproto/src/main/java/com/google/common/truth/extensions/proto/LiteProtoTruth.java
@@ -18,8 +18,9 @@ package com.google.common.truth.extensions.proto;
 
 import static com.google.common.truth.Truth.assertAbout;
 
-import com.google.protobuf.MessageLite;
+import com.google.common.truth.Subject;
 import com.google.errorprone.annotations.CheckReturnValue;
+import com.google.protobuf.MessageLite;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
@@ -36,11 +37,11 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  */
 @CheckReturnValue
 public final class LiteProtoTruth {
-  public static LiteProtoSubject<?, MessageLite> assertThat(@NullableDecl MessageLite messageLite) {
+  public static LiteProtoSubject assertThat(@NullableDecl MessageLite messageLite) {
     return assertAbout(liteProtos()).that(messageLite);
   }
 
-  public static LiteProtoSubject.Factory<?, MessageLite> liteProtos() {
+  public static Subject.Factory<LiteProtoSubject, MessageLite> liteProtos() {
     return LiteProtoSubject.liteProtos();
   }
 

--- a/extensions/liteproto/src/test/java/com/google/common/truth/extensions/proto/LiteProtoSubjectTest.java
+++ b/extensions/liteproto/src/test/java/com/google/common/truth/extensions/proto/LiteProtoSubjectTest.java
@@ -131,11 +131,11 @@ public class LiteProtoSubjectTest {
     this.config = config;
   }
 
-  private LiteProtoSubject<?, MessageLite> expectThat(@NullableDecl MessageLite m) {
+  private LiteProtoSubject expectThat(@NullableDecl MessageLite m) {
     return expect.about(LiteProtoTruth.liteProtos()).that(m);
   }
 
-  private Subject<?, ?> expectThat(@NullableDecl Object o) {
+  private Subject expectThat(@NullableDecl Object o) {
     return expect.that(o);
   }
 
@@ -276,16 +276,16 @@ public class LiteProtoSubjectTest {
       assertThat(config.nonEmptyMessage()).serializedSize().isGreaterThan(size);
       fail("Should have failed.");
     } catch (AssertionError e) {
-      assertThat(e).factValue("value of").isEqualTo("messageLite.getSerializedSize()");
-      assertThat(e).factValue("messageLite was").containsMatch("optional_int:\\s*3");
+      assertThat(e).factValue("value of").isEqualTo("liteProto.getSerializedSize()");
+      assertThat(e).factValue("liteProto was").containsMatch("optional_int:\\s*3");
     }
 
     try {
       assertThat(config.defaultInstance()).serializedSize().isGreaterThan(0);
       fail("Should have failed.");
     } catch (AssertionError e) {
-      assertThat(e).factValue("value of").isEqualTo("messageLite.getSerializedSize()");
-      assertThat(e).factValue("messageLite was").contains("[empty proto]");
+      assertThat(e).factValue("value of").isEqualTo("liteProto.getSerializedSize()");
+      assertThat(e).factValue("liteProto was").contains("[empty proto]");
     }
   }
 

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosSubject.java
@@ -42,9 +42,8 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * ProtoTruth.assertThat(actual).ignoringRepeatedFieldOrder().containsExactlyEntriesIn(expected)}.
  *
  * <p>Floating-point fields are compared using exact equality, which is <a
- * href="http://google.github.io/truth/floating_point">probably not what you want</a> if the values
- * are the results of some arithmetic. Support for approximate equality may be added in a later
- * version.
+ * href="https://truth.dev/floating_point">probably not what you want</a> if the values are the
+ * results of some arithmetic. Support for approximate equality may be added in a later version.
  *
  * <p>Equality tests, and other methods, may yield slightly different behavior for versions 2 and 3
  * of Protocol Buffers. If testing protos of multiple versions, make sure you understand the

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubject.java
@@ -42,9 +42,8 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * ProtoTruth.assertThat(actual).ignoringRepeatedFieldOrder().containsExactly(expected)}.
  *
  * <p>Floating-point fields are compared using exact equality, which is <a
- * href="http://google.github.io/truth/floating_point">probably not what you want</a> if the values
- * are the results of some arithmetic. Support for approximate equality may be added in a later
- * version.
+ * href="https://truth.dev/floating_point">probably not what you want</a> if the values are the
+ * results of some arithmetic. Support for approximate equality may be added in a later version.
  *
  * <p>Equality tests, and other methods, may yield slightly different behavior for versions 2 and 3
  * of Protocol Buffers. If testing protos of multiple versions, make sure you understand the

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubject.java
@@ -50,55 +50,25 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * of Protocol Buffers. If testing protos of multiple versions, make sure you understand the
  * behaviors of default and unknown fields so you don't under or over test.
  *
- * @param <S> <b>deprecated -</b> the self-type, allowing {@code this}-returning methods to avoid
- *     needing subclassing. <i>This type parameter will be removed, as the method that needs it is
- *     being removed. You can prepare for this change by editing your class to refer to raw {@code
- *     MapWithProtoValuesSubject} today and then, after the removal, editing it to refer to {@code
- *     MapWithProtoValuesSubject<M>} (with a single type parameter).</i>
- * @param <K> <b>deprecated -</b> the type of the keys in the map. <i>This type parameter will be
- *     removed, as it has never been used. You can prepare for this change by editing your class to
- *     refer to raw {@code MapWithProtoValuesSubject} today and then, after the removal, editing it
- *     to refer to {@code MapWithProtoValuesSubject<M>} (with a single type parameter).</i>
  * @param <M> the type of the message values in the map
- * @param <C> <b>deprecated -</b> the type of the {@code Map} being tested by this {@code Subject}.
- *     <i>This type parameter will be removed, as the method that needs it is being removed. You can
- *     prepare for this change by editing your class to refer to raw {@code
- *     MapWithProtoValuesSubject} today and then, after the removal, editing it to refer to {@code
- *     MapWithProtoValuesSubject<M>} (with a single type parameter).</i>
  */
-public class MapWithProtoValuesSubject<
-        S extends MapWithProtoValuesSubject<S, K, M, C>, K, M extends Message, C extends Map<K, M>>
-    extends MapSubject {
+public class MapWithProtoValuesSubject<M extends Message> extends MapSubject {
 
   /*
    * Storing a FailureMetadata instance in a Subject subclass is generally a bad practice. For an
    * explanation of why it works out OK here, see LiteProtoSubject.
    */
   private final FailureMetadata metadata;
-  private final C actual;
+  private final Map<?, M> actual;
   private final FluentEqualityConfig config;
 
-  /** Default implementation of {@link MapWithProtoValuesSubject}. */
-  public static final class MapWithMessageValuesSubject<K, M extends Message>
-      extends MapWithProtoValuesSubject<MapWithMessageValuesSubject<K, M>, K, M, Map<K, M>> {
-    // See IterableOfProtosSubject.IterableOfMessagesSubject for why this class is exposed.
-
-    MapWithMessageValuesSubject(FailureMetadata failureMetadata, @NullableDecl Map<K, M> map) {
-      super(failureMetadata, map);
-    }
-
-    private MapWithMessageValuesSubject(
-        FailureMetadata failureMetadata, FluentEqualityConfig config, @NullableDecl Map<K, M> map) {
-      super(failureMetadata, config, map);
-    }
-  }
-
-  protected MapWithProtoValuesSubject(FailureMetadata failureMetadata, @NullableDecl C map) {
+  protected MapWithProtoValuesSubject(
+      FailureMetadata failureMetadata, @NullableDecl Map<?, M> map) {
     this(failureMetadata, FluentEqualityConfig.defaultInstance(), map);
   }
 
   MapWithProtoValuesSubject(
-      FailureMetadata failureMetadata, FluentEqualityConfig config, @NullableDecl C map) {
+      FailureMetadata failureMetadata, FluentEqualityConfig config, @NullableDecl Map<?, M> map) {
     super(failureMetadata, map);
     this.metadata = failureMetadata;
     this.actual = map;
@@ -110,9 +80,8 @@ public class MapWithProtoValuesSubject<
   //////////////////////////////////////////////////////////////////////////////////////////////////
 
   MapWithProtoValuesFluentAssertion<M> usingConfig(FluentEqualityConfig newConfig) {
-    MapWithMessageValuesSubject<K, M> newSubject =
-        new MapWithMessageValuesSubject<>(metadata, newConfig, actual);
-    return new MapWithProtoValuesFluentAssertionImpl<>(newSubject);
+    return new MapWithProtoValuesFluentAssertionImpl<>(
+        new MapWithProtoValuesSubject<>(metadata, newConfig, actual));
   }
 
   /**
@@ -647,9 +616,9 @@ public class MapWithProtoValuesSubject<
   // specified. So, we implement a dumb, private delegator to return instead.
   private static final class MapWithProtoValuesFluentAssertionImpl<M extends Message>
       implements MapWithProtoValuesFluentAssertion<M> {
-    private final MapWithProtoValuesSubject<?, ?, M, ?> subject;
+    private final MapWithProtoValuesSubject<M> subject;
 
-    MapWithProtoValuesFluentAssertionImpl(MapWithProtoValuesSubject<?, ?, M, ?> subject) {
+    MapWithProtoValuesFluentAssertionImpl(MapWithProtoValuesSubject<M> subject) {
       this.subject = subject;
     }
 

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubject.java
@@ -45,9 +45,8 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * ProtoTruth.assertThat(actual).ignoringRepeatedFieldOrder().containsExactlyEntriesIn(expected)}.
  *
  * <p>Floating-point fields are compared using exact equality, which is <a
- * href="http://google.github.io/truth/floating_point">probably not what you want</a> if the values
- * are the results of some arithmetic. Support for approximate equality may be added in a later
- * version.
+ * href="https://truth.dev/floating_point">probably not what you want</a> if the values are the
+ * results of some arithmetic. Support for approximate equality may be added in a later version.
  *
  * <p>Equality tests, and other methods, may yield slightly different behavior for versions 2 and 3
  * of Protocol Buffers. If testing protos of multiple versions, make sure you understand the

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubject.java
@@ -53,64 +53,27 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * of Protocol Buffers. If testing protos of multiple versions, make sure you understand the
  * behaviors of default and unknown fields so you don't under or over test.
  *
- * @param <S> <b>deprecated -</b> the self-type, allowing {@code this}-returning methods to avoid
- *     needing subclassing. <i>This type parameter will be removed, as the method that needs it is
- *     being removed. You can prepare for this change by editing your class to refer to raw {@code
- *     MultimapWithProtoValuesSubject} today and then, after the removal, editing it to refer to
- *     {@code MultimapWithProtoValuesSubject<M>} (with a single type parameter).</i>
- * @param <K> <b>deprecated -</b> the type of the keys in the map. <i>This type parameter will be
- *     removed, as it has never been used. You can prepare for this change by editing your class to
- *     refer to raw {@code MultimapWithProtoValuesSubject} today and then, after the removal,
- *     editing it to refer to {@code MultimapWithProtoValuesSubject<M>} (with a single type
- *     parameter).</i>
- * @param <M> the type of the message values in the map
- * @param <C> <b>deprecated -</b> the type of the {@code Multimap} being tested by this {@code
- *     Subject}. <i>This type parameter will be removed, as the method that needs it is being
- *     removed. You can prepare for this change by editing your class to refer to raw {@code
- *     MultimapWithProtoValuesSubject} today and then, after the removal, editing it to refer to
- *     {@code MultimapWithProtoValuesSubject<M>} (with a single type parameter).</i>
+ * @param <M> the type of the message values in the multimap
  */
-public class MultimapWithProtoValuesSubject<
-        S extends MultimapWithProtoValuesSubject<S, K, M, C>,
-        K,
-        M extends Message,
-        C extends Multimap<K, M>>
-    extends MultimapSubject {
+public class MultimapWithProtoValuesSubject<M extends Message> extends MultimapSubject {
 
   /*
    * Storing a FailureMetadata instance in a Subject subclass is generally a bad practice. For an
    * explanation of why it works out OK here, see LiteProtoSubject.
    */
   private final FailureMetadata metadata;
-  private final C actual;
+  private final Multimap<?, M> actual;
   private final FluentEqualityConfig config;
 
-  /** Default implementation of {@link MultimapWithProtoValuesSubject}. */
-  public static class MultimapWithMessageValuesSubject<K, M extends Message>
-      extends MultimapWithProtoValuesSubject<
-          MultimapWithMessageValuesSubject<K, M>, K, M, Multimap<K, M>> {
-    // See IterableOfProtosSubject.IterableOfMessagesSubject for why this class is exposed.
-
-    MultimapWithMessageValuesSubject(
-        FailureMetadata failureMetadata, @NullableDecl Multimap<K, M> multimap) {
-      super(failureMetadata, multimap);
-    }
-
-    private MultimapWithMessageValuesSubject(
-        FailureMetadata failureMetadata,
-        FluentEqualityConfig config,
-        @NullableDecl Multimap<K, M> multimap) {
-      super(failureMetadata, config, multimap);
-    }
-  }
-
   protected MultimapWithProtoValuesSubject(
-      FailureMetadata failureMetadata, @NullableDecl C multimap) {
+      FailureMetadata failureMetadata, @NullableDecl Multimap<?, M> multimap) {
     this(failureMetadata, FluentEqualityConfig.defaultInstance(), multimap);
   }
 
   MultimapWithProtoValuesSubject(
-      FailureMetadata failureMetadata, FluentEqualityConfig config, @NullableDecl C multimap) {
+      FailureMetadata failureMetadata,
+      FluentEqualityConfig config,
+      @NullableDecl Multimap<?, M> multimap) {
     super(failureMetadata, multimap);
     this.metadata = failureMetadata;
     this.actual = multimap;
@@ -124,7 +87,7 @@ public class MultimapWithProtoValuesSubject<
    * <p>This method performs no checks on its own and cannot cause test failures. Subsequent
    * assertions must be chained onto this method call to test properties of the {@link Multimap}.
    */
-  public IterableOfProtosSubject<?, M, Iterable<M>> valuesForKey(@NullableDecl Object key) {
+  public IterableOfProtosSubject<M> valuesForKey(@NullableDecl Object key) {
     return check("valuesForKey(%s)", key)
         .about(protos())
         .that(((Multimap<Object, M>) actual).get(key));
@@ -135,9 +98,8 @@ public class MultimapWithProtoValuesSubject<
   //////////////////////////////////////////////////////////////////////////////////////////////////
 
   MultimapWithProtoValuesFluentAssertion<M> usingConfig(FluentEqualityConfig newConfig) {
-    MultimapWithMessageValuesSubject<K, M> newSubject =
-        new MultimapWithMessageValuesSubject<>(metadata, newConfig, actual);
-    return new MultimapWithProtoValuesFluentAssertionImpl<>(newSubject);
+    return new MultimapWithProtoValuesFluentAssertionImpl<>(
+        new MultimapWithProtoValuesSubject<>(metadata, newConfig, actual));
   }
 
   /**
@@ -676,9 +638,9 @@ public class MultimapWithProtoValuesSubject<
   // specified. So, we implement a dumb, private delegator to return instead.
   private static final class MultimapWithProtoValuesFluentAssertionImpl<M extends Message>
       implements MultimapWithProtoValuesFluentAssertion<M> {
-    private final MultimapWithProtoValuesSubject<?, ?, M, ?> subject;
+    private final MultimapWithProtoValuesSubject<M> subject;
 
-    MultimapWithProtoValuesFluentAssertionImpl(MultimapWithProtoValuesSubject<?, ?, M, ?> subject) {
+    MultimapWithProtoValuesFluentAssertionImpl(MultimapWithProtoValuesSubject<M> subject) {
       this.subject = subject;
     }
 

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoSubject.java
@@ -39,9 +39,8 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * ProtoTruth.assertThat(actual).ignoringRepeatedFieldOrder().isEqualTo(expected)}.
  *
  * <p>Floating-point fields are compared using exact equality, which is <a
- * href="http://google.github.io/truth/floating_point">probably not what you want</a> if the values
- * are the results of some arithmetic. Support for approximate equality may be added in a later
- * version.
+ * href="https://truth.dev/floating_point">probably not what you want</a> if the values are the
+ * results of some arithmetic. Support for approximate equality may be added in a later version.
  *
  * <p>Equality tests, and other methods, may yield slightly different behavior for versions 2 and 3
  * of Protocol Buffers. If testing protos of multiple versions, make sure you understand the

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoSubject.java
@@ -46,43 +46,31 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * <p>Equality tests, and other methods, may yield slightly different behavior for versions 2 and 3
  * of Protocol Buffers. If testing protos of multiple versions, make sure you understand the
  * behaviors of default and unknown fields so you don't under or over test.
- *
- * @param <S> <b>deprecated -</b> the self-type, allowing {@code this}-returning methods to avoid
- *     needing subclassing. <i>Both type parameters will be removed, as the methods that need them
- *     are being removed. You can prepare for this change by editing your class to refer to raw
- *     {@code ProtoSubject} today.</i>
- * @param <M> <b>deprecated -</b> the type of the message being tested by this {@code Subject}.
- *     <i>Both type parameters will be removed, as the methods that need them are being removed. You
- *     can prepare for this change by editing your class to refer to raw {@code ProtoSubject}
- *     today.</i>
  */
-public class ProtoSubject<S extends ProtoSubject<S, M>, M extends Message>
-    extends LiteProtoSubject<S, M> implements ProtoFluentAssertion {
+public class ProtoSubject extends LiteProtoSubject implements ProtoFluentAssertion {
 
   /*
    * Storing a FailureMetadata instance in a Subject subclass is generally a bad practice. For an
    * explanation of why it works out OK here, see LiteProtoSubject.
    */
   private final FailureMetadata metadata;
-  private final M actual;
-  // TODO(user): Type this if we solve the typing assertAbout() problem for
-  // IterableOfProtosSubject and there is use for such typing.
+  private final Message actual;
   private final FluentEqualityConfig config;
 
-  protected ProtoSubject(FailureMetadata failureMetadata, @NullableDecl M message) {
+  protected ProtoSubject(FailureMetadata failureMetadata, @NullableDecl Message message) {
     this(failureMetadata, FluentEqualityConfig.defaultInstance(), message);
   }
 
   ProtoSubject(
-      FailureMetadata failureMetadata, FluentEqualityConfig config, @NullableDecl M message) {
+      FailureMetadata failureMetadata, FluentEqualityConfig config, @NullableDecl Message message) {
     super(failureMetadata, message);
     this.metadata = failureMetadata;
     this.actual = message;
     this.config = config;
   }
 
-  ProtoSubject<?, Message> usingConfig(FluentEqualityConfig newConfig) {
-    return new MessageSubject(metadata, newConfig, actual);
+  ProtoSubject usingConfig(FluentEqualityConfig newConfig) {
+    return new ProtoSubject(metadata, newConfig, actual);
   }
 
   @Override
@@ -367,18 +355,5 @@ public class ProtoSubject<S extends ProtoSubject<S, M>, M extends Message>
     return config
         .withExpectedMessages(Arrays.asList(expected))
         .toMessageDifferencer(actual.getDescriptorForType());
-  }
-
-  static final class MessageSubject extends ProtoSubject<MessageSubject, Message> {
-    MessageSubject(FailureMetadata failureMetadata, @NullableDecl Message message) {
-      super(failureMetadata, message);
-    }
-
-    private MessageSubject(
-        FailureMetadata failureMetadata,
-        FluentEqualityConfig config,
-        @NullableDecl Message message) {
-      super(failureMetadata, config, message);
-    }
   }
 }

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoSubjectBuilder.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoSubjectBuilder.java
@@ -58,18 +58,16 @@ public final class ProtoSubjectBuilder extends CustomSubjectBuilder {
     return new ProtoSubject(metadata(), message);
   }
 
-  public <M extends Message> IterableOfProtosSubject<?, M, Iterable<M>> that(
-      @NullableDecl Iterable<M> messages) {
-    return new IterableOfProtosSubject.IterableOfMessagesSubject<M>(metadata(), messages);
+  public <M extends Message> IterableOfProtosSubject<M> that(@NullableDecl Iterable<M> messages) {
+    return new IterableOfProtosSubject<M>(metadata(), messages);
   }
 
-  public <K, M extends Message> MapWithProtoValuesSubject<?, K, M, Map<K, M>> that(
-      @NullableDecl Map<K, M> map) {
-    return new MapWithProtoValuesSubject.MapWithMessageValuesSubject<>(metadata(), map);
+  public <M extends Message> MapWithProtoValuesSubject<M> that(@NullableDecl Map<?, M> map) {
+    return new MapWithProtoValuesSubject<>(metadata(), map);
   }
 
-  public <K, M extends Message> MultimapWithProtoValuesSubject<?, K, M, Multimap<K, M>> that(
-      @NullableDecl Multimap<K, M> map) {
-    return new MultimapWithProtoValuesSubject.MultimapWithMessageValuesSubject<>(metadata(), map);
+  public <M extends Message> MultimapWithProtoValuesSubject<M> that(
+      @NullableDecl Multimap<?, M> map) {
+    return new MultimapWithProtoValuesSubject<>(metadata(), map);
   }
 }

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoSubjectBuilder.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoSubjectBuilder.java
@@ -50,12 +50,12 @@ public final class ProtoSubjectBuilder extends CustomSubjectBuilder {
     super(failureMetadata);
   }
 
-  public LiteProtoSubject<?, MessageLite> that(@NullableDecl MessageLite messageLite) {
-    return new LiteProtoSubject.MessageLiteSubject(metadata(), messageLite);
+  public LiteProtoSubject that(@NullableDecl MessageLite messageLite) {
+    return new LiteProtoSubject(metadata(), messageLite);
   }
 
-  public ProtoSubject<?, Message> that(@NullableDecl Message message) {
-    return new ProtoSubject.MessageSubject(metadata(), message);
+  public ProtoSubject that(@NullableDecl Message message) {
+    return new ProtoSubject(metadata(), message);
   }
 
   public <M extends Message> IterableOfProtosSubject<?, M, Iterable<M>> that(

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoTruth.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoTruth.java
@@ -68,7 +68,7 @@ public final class ProtoTruth {
   // methods without conflict. If this method instead accepted Iterable<? extends Message>, this
   // would result in method ambiguity errors.
   // See http://stackoverflow.com/a/8467804 for a more thorough explanation.
-  public static <M extends Message> IterableOfProtosSubject<?, M, Iterable<M>> assertThat(
+  public static <M extends Message> IterableOfProtosSubject<M> assertThat(
       @NullableDecl Iterable<M> messages) {
     return assertAbout(protos()).that(messages);
   }
@@ -79,8 +79,8 @@ public final class ProtoTruth {
    * <p>This allows for the equality configurations on {@link ProtoSubject} to be applied to all
    * comparison tests available on {@link MapSubject.UsingCorrespondence}.
    */
-  public static <K, M extends Message> MapWithProtoValuesSubject<?, K, M, Map<K, M>> assertThat(
-      @NullableDecl Map<K, M> map) {
+  public static <M extends Message> MapWithProtoValuesSubject<M> assertThat(
+      @NullableDecl Map<?, M> map) {
     return assertAbout(protos()).that(map);
   }
 
@@ -90,9 +90,8 @@ public final class ProtoTruth {
    * <p>This allows for the equality configurations on {@link ProtoSubject} to be applied to all
    * comparison tests available on {@link MultimapSubject.UsingCorrespondence}.
    */
-  public static <K, M extends Message>
-      MultimapWithProtoValuesSubject<?, K, M, Multimap<K, M>> assertThat(
-          @NullableDecl Multimap<K, M> multimap) {
+  public static <M extends Message> MultimapWithProtoValuesSubject<M> assertThat(
+      @NullableDecl Multimap<?, M> multimap) {
     return assertAbout(protos()).that(multimap);
   }
 

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoTruth.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoTruth.java
@@ -48,12 +48,12 @@ public final class ProtoTruth {
   }
 
   /** Assert on a single {@link MessageLite} instance. */
-  public static LiteProtoSubject<?, MessageLite> assertThat(@NullableDecl MessageLite messageLite) {
+  public static LiteProtoSubject assertThat(@NullableDecl MessageLite messageLite) {
     return assertAbout(protos()).that(messageLite);
   }
 
   /** Assert on a single {@link Message} instance. */
-  public static ProtoSubject<?, Message> assertThat(@NullableDecl Message message) {
+  public static ProtoSubject assertThat(@NullableDecl Message message) {
     return assertAbout(protos()).that(message);
   }
 

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTestBase.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTestBase.java
@@ -156,7 +156,7 @@ public class ProtoSubjectTestBase {
     return expect.about(truthFailures()).that(multiExpectFailure.getFailure());
   }
 
-  protected final ProtoSubject<?, Message> expectThat(@NullableDecl Message message) {
+  protected final ProtoSubject expectThat(@NullableDecl Message message) {
     return expect.about(ProtoTruth.protos()).that(message);
   }
 
@@ -175,8 +175,7 @@ public class ProtoSubjectTestBase {
     return expect.about(ProtoTruth.protos()).that(multimap);
   }
 
-  protected final ProtoSubject<?, Message> expectThatWithMessage(
-      String msg, @NullableDecl Message message) {
+  protected final ProtoSubject expectThatWithMessage(String msg, @NullableDecl Message message) {
     return expect.withMessage(msg).about(ProtoTruth.protos()).that(message);
   }
 

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTestBase.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTestBase.java
@@ -160,17 +160,15 @@ public class ProtoSubjectTestBase {
     return expect.about(ProtoTruth.protos()).that(message);
   }
 
-  protected final <M extends Message> IterableOfProtosSubject<?, M, ?> expectThat(
-      Iterable<M> messages) {
+  protected final <M extends Message> IterableOfProtosSubject<M> expectThat(Iterable<M> messages) {
     return expect.about(ProtoTruth.protos()).that(messages);
   }
 
-  protected final <M extends Message> MapWithProtoValuesSubject<?, ?, M, ?> expectThat(
-      Map<?, M> map) {
+  protected final <M extends Message> MapWithProtoValuesSubject<M> expectThat(Map<?, M> map) {
     return expect.about(ProtoTruth.protos()).that(map);
   }
 
-  protected final <M extends Message> MultimapWithProtoValuesSubject<?, ?, M, ?> expectThat(
+  protected final <M extends Message> MultimapWithProtoValuesSubject<M> expectThat(
       Multimap<?, M> multimap) {
     return expect.about(ProtoTruth.protos()).that(multimap);
   }

--- a/extensions/re2j/src/main/java/com/google/common/truth/extensions/re2j/Re2jSubjects.java
+++ b/extensions/re2j/src/main/java/com/google/common/truth/extensions/re2j/Re2jSubjects.java
@@ -47,7 +47,7 @@ public final class Re2jSubjects {
    *
    * @see #re2jString
    */
-  public static final class Re2jStringSubject extends Subject<Re2jStringSubject, String> {
+  public static final class Re2jStringSubject extends Subject {
     private static final Subject.Factory<Re2jStringSubject, String> FACTORY =
         new Subject.Factory<Re2jStringSubject, String>() {
           @Override

--- a/pom.xml
+++ b/pom.xml
@@ -217,20 +217,6 @@
     <system>Jenkins</system>
     <url>https://travis-ci.org/google/truth</url>
   </ciManagement>
-  <mailingLists>
-    <mailingList>
-      <name>Announcements List</name>
-      <post>truth-announce@googlecode.com</post>
-    </mailingList>
-    <mailingList>
-      <name>User List</name>
-      <post>truth-users@googlecode.com</post>
-    </mailingList>
-    <mailingList>
-      <name>Developer List</name>
-      <post>truth-dev@googlecode.com</post>
-    </mailingList>
-  </mailingLists>
   <scm>
     <connection>scm:git:git@github.com:google/truth.git</connection>
     <url>scm:git:git@github.com:google/truth.git</url>

--- a/pom.xml
+++ b/pom.xml
@@ -266,8 +266,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>animal-sniffer-maven-plugin</artifactId>
-          <!-- Note that 1.17 doesn't work with Java 8: https://github.com/mojohaus/animal-sniffer/issues/53 -->
-          <version>1.16</version>
+          <version>1.18</version>
           <configuration>
             <signature>
               <groupId>org.codehaus.mojo.signature</groupId>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove type parameters from ProtoSubject and LiteProtoSubject and their users.

Also, change most Subject classes in Truth itself (including ProtoSubject and LiteProtoSubject) to extend raw Subject. The type parameters will be removed from Subject.

This CL doesn't cover subjects that extend from ComparableSubject, since we are removing only *some* of its type parameters (and I'm planning to make that change atomically). Ditto for IterableOfProtosSubject, MapWithProtoValuesSubject, and MultimapWithProtoValuesSubject. I probably could have at least changed ComparableSubject, etc. to extend raw Subject in this CL, but I didn't think about it until now. Oh, well.

This CL also doesn't cover DefaultSubject, which is blocked on the import of an external pull request and on a Kotlin change.

[]

[]

adfb2a8846dcdf26ddd4c71e061f1738409e3ec1

-------

<p> Atomically remove type parameters from ComparableSubject, IterableOfProtosSubject, MapWithProtoValuesSubject, and MultimapWithProtoValuesSubject.

[]

[]

8d33a73979b8b06f800613ef61961064b96272df

-------

<p> Upgrade animal sniffer to version 1.18.

Fixes #566

Startblock:
  [] is submitted

112d497442c8ffe49162bb89ad9bc09599ad62b0

-------

<p> Return as soon as we find multiple elements.

969b81c30429d936d72d860d426a883888be8360

-------

<p> Store results of `hasMultiple` in local variables to avoid duplicate computation.

acc61e599c655991f88781f027c86a712ca3e35b

-------

<p> Loudly "deprecate" type parameters.

947a8dce4e75f881b922788a9fe93da35d0fc091

-------

<p> Remove type parameters from Subject.

Also, return plain Subject instead of DefaultSubject, and make DefaultSubject extend raw Subject. But keep DefaultSubject around (and extensible) until after the next release, since that makes it easier for Kotlin code to migrate.

[]

[]

RELNOTES=Removed the type parameters from `Subject`. If you subclass this type (or declare it as a method return type, etc.), you will have to update those usages at the same time you update Truth. Or you can remove the type parameters from your usages (temporarily introducing rawtypes/unchecked warnings, which you may wish to suppress) and then update Truth (at which point the warnings will go away and you can remove any suppressions).

e0c64a60ce15360a96aacffea9646d68569a472b

-------

<p> Copy Truth description to package-info, putting link to site in the first sentence so that it shows up above the giant tables of classes.

Remove some mailing lists that mostly don't exist (and that, for the ones that do exist, we don't use them).

99e622876e8ea66abfad7f2bfe4c0c8533f6726a

-------

<p> Point links to truth.dev.

14413b5dce1c3555d65f563e503157683df21d6f