### PR TITLE
Moe Sync

### DIFF
--- a/comparison.md
+++ b/comparison.md
@@ -351,9 +351,9 @@ away from using it unless they mean to test reference equality.
 
 Under Truth, `assertThat(listOfStrings).doesNotContain(integer)` passes, even
 though your test is probably buggy. Under AssertJ, it doesn't compile. (Truth's
-looser types are [occasionally useful][`CollectionIncompatibleType`], but they
-may be more trouble than they're worth.) We plan to add static analysis to
-[Error Prone] to catch such bugs.
+looser types are [occasionally useful][pull-575-thread], but they may be more
+[trouble][`CollectionIncompatibleType`] than they're worth.) We plan to add
+static analysis to [Error Prone] to catch such bugs.
 
 ### Conditions
 
@@ -403,5 +403,6 @@ significant.
 [monorepo]: https://cacm.acm.org/magazines/2016/7/204032-why-google-stores-billions-of-lines-of-code-in-a-single-repository/fulltext
 [intellij-diff]: https://stackoverflow.com/q/48565168/28465
 [Error Prone]: https://errorprone.info
+[pull-575-thread]: https://github.com/google/truth/pull/575#discussion_r293444380
 [`CollectionIncompatibleType`]: https://errorprone.info/bugpattern/CollectionIncompatibleType
 

--- a/comparison.md
+++ b/comparison.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Comparison
+title: Truth vs. AssertJ and Hamcrest
 ---
 
 

--- a/comparison.md
+++ b/comparison.md
@@ -350,8 +350,10 @@ chosen a different name for the method (`isNotSameInstanceAs`) to steer people
 away from using it unless they mean to test reference equality.
 
 Under Truth, `assertThat(listOfStrings).doesNotContain(integer)` passes, even
-though your test is probably buggy. Under AssertJ, it doesn't compile. We plan
-to add static analysis to [Error Prone] to catch such bugs.
+though your test is probably buggy. Under AssertJ, it doesn't compile. (Truth's
+looser types are [occasionally useful][`CollectionIncompatibleType`], but they
+may be more trouble than they're worth.) We plan to add static analysis to
+[Error Prone] to catch such bugs.
 
 ### Conditions
 
@@ -401,4 +403,5 @@ significant.
 [monorepo]: https://cacm.acm.org/magazines/2016/7/204032-why-google-stores-billions-of-lines-of-code-in-a-single-repository/fulltext
 [intellij-diff]: https://stackoverflow.com/q/48565168/28465
 [Error Prone]: https://errorprone.info
+[`CollectionIncompatibleType`]: https://errorprone.info/bugpattern/CollectionIncompatibleType
 

--- a/extension.md
+++ b/extension.md
@@ -263,6 +263,9 @@ There are four parts to the example:
         `isCeo()` is testing a boolean property. Boolean properties are good
         candidates for the manual check-and-fail approach.
 
+        For tips on writing failure messages, see
+        [this guide](failure_messages).
+
         One advanced point: Custom `Subject` types sometimes declare "chaining"
         methods that return an instance of another `Subject`. For example,
         instead of providing `hasName(…)`, `EmployeeSubject` might declare a

--- a/extension.md
+++ b/extension.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Extension
+title: Extensions to Truth
 ---
 
 

--- a/failure_messages.md
+++ b/failure_messages.md
@@ -1,18 +1,14 @@
 ---
 layout: default
-title: Failure Messages
+title: Writing failure messages for a Truth Subject
 ---
-
-**Note: As of this writing, Truth does not yet use the new style of failure
-messages described below. This page describes changes we plan to make in the
-future.**
 
 This page contains guidelines for writing Truth failure messages.
 
-## Fields
+## Facts
 
-Truth failure messages are composed of key-value pairs, which we call "fields."
-For example, here's a message with 2 fields:
+Truth failure messages are composed of key-value pairs, which we call "facts."
+For example, here's a message with 2 facts:
 
 ```none
 expected:  0.0
@@ -41,7 +37,7 @@ The general pattern is: Keys are fixed strings, and values are runtime values.
 When a `Subject` implementation reports a failure, it generally passes a fixed
 set of keys.
 
-In the normal case, there will be one field describing the expected value. Its
+In the normal case, there will be one fact describing the expected value. Its
 name is often similar to the name of the assertion method:
 
 ```none
@@ -50,8 +46,8 @@ expected to contain:          // for contains(...)
 expected:                     // for isEqualTo(...)
 ```
 
-That field is usually followed by a "but was" field, as in the examples at the
-top of the page. (Occasionally, there's no need for "but was." For example, take
+That fact is usually followed by a "but was" fact, as in the examples at the top
+of the page. (Occasionally, there's no need for "but was." For example, take
 "expected not to be null." Adding "but was null" would add no information.)
 
 ### Values are runtime values
@@ -61,7 +57,7 @@ Typically, they're the parameters the test passed in. For example:
 -   The value of "expected" is the parameter passed to `isEqualTo(...)`.
 -   The value of "but was" is the parameter passed to `assertThat(...)`.
 
-Sometimes the fields contain more than just the `toString()` representation of a
+Sometimes the facts contain more than just the `toString()` representation of a
 parameter. For example:
 
 ```none
@@ -79,7 +75,7 @@ but was instance of : java.lang.Double
 with value          : 4.5
 ```
 
-But even in unusual cases, the first field usually describes the expected value.
+But even in unusual cases, the first fact usually describes the expected value.
 Its key usually includes "expected," and its value is usually a parameter to the
 assertion method.
 

--- a/faq.md
+++ b/faq.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Questions and Answers
+title: Truth FAQ
 ---
 
 1. auto-gen TOC:

--- a/faq.md
+++ b/faq.md
@@ -11,23 +11,27 @@ title: Questions and Answers
 First, make sure you're depending on
 `com.google.truth.extensions:truth-java8-extension:<your truth version>`
 
-Next, you will need to add *both* of the following static imports to your class:
+Next, you will usually need *both* of the following static imports:
 
 ```java
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 ...
-// This assertion uses the Truth8.assertThat(java.util.Optional) overload.
+// This assertion uses Truth8.assertThat(Optional).
 Optional<String> javaUtilOptional = someStream.map(...).filter(...).findFirst();
 assertThat(javaUtilOptional).hasValue("duke");
 
-// This assertion uses the Truth.assertThat(com.google.common.base.Optional) overload.
-Optional<String> guavaOptional = user.getMiddleName();
-assertThat(guavaOptional).hasValue("alfred");
+// Other assertions will use the various Truth.assertThat(...) overloads.
 ```
 
-See [below](#full-chain) for more examples of asserting on external subjects,
-including how to use alternate assertion entry points such as `expect`.
+To use the Java 8 types with `assertWithMessage`, `expect`, or other entry
+points, use `about`:
+
+```java
+assertWithMessage(...).about(optionals()).that(javaUtilOptional).hasValue("duke");
+```
+
+For more information, read about [the full fluent chain](#full-chain).
 
 ## Why do I get a "`cannot find symbol .hasValue("foo");`" error for a type that should have `hasValue`? {#missing-import}
 

--- a/index.md
+++ b/index.md
@@ -140,6 +140,12 @@ dependencies {
 To use the Java 8 extensions, also include
 `com.google.truth.extensions:truth-java8-extension:{{ site.version }}`.
 
+One warning: Truth depends on the "Android" version of [Guava], a subset of the
+"JRE" version. If your project uses the JRE version, be aware that your build
+system might select the Android version instead. If so, you may see "missing
+symbol" errors. The easiest fix is usually to add a direct dependency on the
+newest JRE version of Guava.
+
 
 ## 2. Add static imports for Truth’s entry points:
 

--- a/known_types.md
+++ b/known_types.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Known Types
+title: Truth: Known Types
 ---
 
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Mention assertWithMessage explicitly when discussing Java 8 types.

Closes https://github.com/google/truth/issues/469

2cf279e1643414b5189947663c72cfeeda0b39bc

-------

<p> Explain why Truth's IterableSubject has looser types, for better or for worse.

https://github.com/google/truth/pull/575#discussion_r293043218

69dc71b2719849373a580dcb8a38f21be0772fde

-------

<p> Link to an example of where looser input parameters are useful.

e2c2e530a04dae37851009f75e7681a71a9eb12f

-------

<p> Mention AssertJ and Hamcrest (and Truth) in the title.

dcb8cde38d0fe2730a1a0c114e20604ac3334dcb

-------

<p> Mention Truth in page titles.

a91f28e1a1596760381a2a3687b2d1e61d78b3e1

-------

<p> Document that Truth may override your JRE version of Guava with an Android version.

9dba706d7e7a96ddbfabe9434bb0c23805195798

-------

<p> Endorse the page on writing failure messages.

6f05b30977f592887116ef99a03e422bb9a6dcee