### PR TITLE
Moe Sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: java
 
 jdk:
-  - &jdk_for_publishing oraclejdk8
+  - &jdk_for_publishing oraclejdk11
 
 install:
   - mvn -B -U -P!standard-with-extra-repos dependency:go-offline test clean --quiet --fail-never -DskipTests=true
@@ -32,7 +32,7 @@ branches:
 addons:
   apt:
     packages:
-      - oracle-java8-installer
+      - oracle-java11-installer
 
 cache:
   directories:

--- a/core/src/main/java/com/google/common/truth/Fact.java
+++ b/core/src/main/java/com/google/common/truth/Fact.java
@@ -30,6 +30,9 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * <p>Most Truth users will never interact with this type. It appears in the Truth API only as a
  * parameter to methods like {@link Subject#failWithActual(Fact, Fact...)}, which are used only by
  * custom {@code Subject} implementations.
+ *
+ * <p>If you are writing a custom {@code Subject}, see <a
+ * href="https://truth.dev/failure_messages">our tips on writing failure messages</a>.
  */
 public final class Fact implements Serializable {
   /**

--- a/core/src/main/java/com/google/common/truth/IterableSubject.java
+++ b/core/src/main/java/com/google/common/truth/IterableSubject.java
@@ -827,8 +827,7 @@ public class IterableSubject extends Subject {
   /** @deprecated You probably meant to call {@link #containsNoneIn} instead. */
   @Override
   @Deprecated
-  // TODO(b/133145187): Restore to Iterable<?> after removing the type parameters from Subject.
-  public void isNotIn(Iterable iterable) {
+  public void isNotIn(Iterable<?> iterable) {
     if (Iterables.contains(iterable, actual)) {
       failWithActual("expected not to be any of", iterable);
     }

--- a/core/src/main/java/com/google/common/truth/LazyMessage.java
+++ b/core/src/main/java/com/google/common/truth/LazyMessage.java
@@ -29,7 +29,7 @@ final class LazyMessage {
   private final String format;
   private final Object[] args;
 
-  LazyMessage(@NullableDecl String format, @NullableDecl Object... args) {
+  LazyMessage(String format, @NullableDecl Object... args) {
     this.format = format;
     this.args = args;
     int placeholders = countPlaceholders(format);
@@ -42,10 +42,7 @@ final class LazyMessage {
   }
 
   @VisibleForTesting
-  static int countPlaceholders(@NullableDecl String template) {
-    if (template == null) {
-      return 0;
-    }
+  static int countPlaceholders(String template) {
     int index = 0;
     int count = 0;
     while (true) {

--- a/core/src/main/java/com/google/common/truth/StandardSubjectBuilder.java
+++ b/core/src/main/java/com/google/common/truth/StandardSubjectBuilder.java
@@ -199,7 +199,7 @@ public class StandardSubjectBuilder {
    *     equal the number of given arguments
    */
   public final StandardSubjectBuilder withMessage(
-      @NullableDecl String format, Object /* @NullableDeclType */... args) {
+      String format, Object /* @NullableDeclType */... args) {
     return new StandardSubjectBuilder(metadata().withMessage(format, args));
   }
 

--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -18,7 +18,6 @@ package com.google.common.truth;
 import static com.google.common.base.CaseFormat.LOWER_CAMEL;
 import static com.google.common.base.CaseFormat.UPPER_CAMEL;
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.lenientFormat;
 import static com.google.common.truth.Fact.fact;
 import static com.google.common.truth.Fact.simpleFact;
@@ -661,7 +660,6 @@ public class Subject {
 
   private StandardSubjectBuilder doCheck(
       OldAndNewValuesAreSimilar valuesAreSimilar, String format, Object[] args) {
-    checkNotNull(format); // Probably LazyMessage itself should be this strict, but it isn't yet.
     final LazyMessage message = new LazyMessage(format, args);
     Function<String, String> descriptionUpdate =
         new Function<String, String>() {

--- a/core/src/test/java/com/google/common/truth/CustomFailureMessageTest.java
+++ b/core/src/test/java/com/google/common/truth/CustomFailureMessageTest.java
@@ -42,7 +42,6 @@ public class CustomFailureMessageTest extends BaseSubjectTestCase {
 
   @Test
   public void countPlaceholders() {
-    assertThat(LazyMessage.countPlaceholders(null)).isEqualTo(0);
     assertThat(LazyMessage.countPlaceholders("")).isEqualTo(0);
     assertThat(LazyMessage.countPlaceholders("%s")).isEqualTo(1);
     assertThat(LazyMessage.countPlaceholders("%s%s")).isEqualTo(2);

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubject.java
@@ -43,9 +43,9 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * <p>By default, floating-point fields are compared using exact equality, which is <a
  * href="https://truth.dev/floating_point">probably not what you want</a> if the values are the
- * results of some arithmetic. To check for approximate equality, use {@link #usingDoubleTolerance},
- * {@link #usingFloatTolerance}, and {@linkplain #usingDoubleToleranceForFields(double, int, int...)
- * their per-field equivalents}.
+ * results of some arithmetic. To check for approximate equality, use {@link
+ * #usingDoubleToleranceForValues}, {@link #usingFloatToleranceForValues}, and {@linkplain
+ * #usingDoubleToleranceForFieldsForValues(double, int, int...) their per-field equivalents}.
  *
  * <p>Equality tests, and other methods, may yield slightly different behavior for versions 2 and 3
  * of Protocol Buffers. If testing protos of multiple versions, make sure you understand the

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubject.java
@@ -46,9 +46,9 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * <p>By default, floating-point fields are compared using exact equality, which is <a
  * href="https://truth.dev/floating_point">probably not what you want</a> if the values are the
- * results of some arithmetic. To check for approximate equality, use {@link #usingDoubleTolerance},
- * {@link #usingFloatTolerance}, and {@linkplain #usingDoubleToleranceForFields(double, int, int...)
- * their per-field equivalents}.
+ * results of some arithmetic. To check for approximate equality, use {@link
+ * #usingDoubleToleranceForValues}, {@link #usingFloatToleranceForValues}, and {@linkplain
+ * #usingDoubleToleranceForFieldsForValues(double, int, int...) their per-field equivalents}.
  *
  * <p>Equality tests, and other methods, may yield slightly different behavior for versions 2 and 3
  * of Protocol Buffers. If testing protos of multiple versions, make sure you understand the

--- a/util/generate-latest-docs.sh
+++ b/util/generate-latest-docs.sh
@@ -39,6 +39,7 @@ if [[ -n "${RELEASE_VERSION:-}" ||
 
   mvn javadoc:aggregate
   perl -ni -e 'print unless /Tolerant.*Comparison/ || /SubjectBuilderCallback/ || /UsingCorrespondence/ || /AsIterable/ || /Correspondence[.][A-Z]/ || /FluentAssertion/ || /PathSubject/ || /Re2jSubjects/ || /Ordered/' target/site/apidocs/allclasses-frame.html
+  find target/site/apidocs -name '*.html' | xargs perl -077pi -e 's#<li class="blockList"><a name="nested.classes.inherited.from.class.com.google.common.truth.\w*Subject">.*?</li>##msg; if (m#<!-- ======== NESTED CLASS SUMMARY ======== -->(.*?)(?=<!-- =)#ms) { if ($1 !~ m#nested.classes.inherited.from|memberSummary#) { s#<!-- ======== NESTED CLASS SUMMARY ======== -->.*?(?=<!-- =)##msg; } }'
   target_dir="$(pwd)/target"
   cd ${target_dir}
   rm -rf gh-pages


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix broken links.

051b75ed029f848ccc2455738f92ea7c89a600a0

-------

<p> Hide "Nested classes/interfaces inherited from class com.google.common.truth.Subject" (and other subjects, meaning Iterable, Map, and Multimap).

And, if that's the only table under "Nested Class Summary," hide that entirely.

Chances that I got this wrong and blew away a whole section of useful Javadoc somewhere: 15%.

Before: https://truth.dev/api/0.45/com/google/common/truth/MultisetSubject.html
After: https://truth.dev/api/latest/com/google/common/truth/MultisetSubject.html

a330fb4ca9bbb91c6de4cc720db9a76900518853

-------

<p> Remove raw type now that I've removed the type parameters from Subject.

19bd6692c897744d1cfae005268e9abc2c2c03b8

-------

<p> Update to JDK11.

This is an attempt to fix the error:
  Expected feature release number in range of 9 to 13, but got: 8
  The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .
https://travis-ci.org/google/truth/builds/544847563

Possibly we could just request an old version of Ubuntu:
  dist: trusty
https://travis-ci.org/google/truth/builds/544847563

But we'll have to update eventually, so let's try now.

If this works, I can replicate it to our other projects.

9146f3e0f289e377e4a8b3f38205015208c6c878

-------

<p> Link to our tips on writing failure messages.

e06c1197fbbd861fba8b440ddfbc4c524d2d1208

-------

<p> Reject null messages, at least in combination with format args.

Fixes https://github.com/google/truth/issues/225

d9e7db0bc07613e1ed890cdf86878ccd68bc367f