### PR TITLE
Moe Sync

### DIFF
--- a/known_types.md
+++ b/known_types.md
@@ -52,7 +52,6 @@ Truth has built in support for the following types:
     *   [`Multimap`]
     *   [`Multiset`]
     *   [`Table`]
-    *   [`AtomicLongMap`]
 
 Truth is [extensible](extension.md), so if you don't see a type you need to make
 assertions on in this list, you can
@@ -71,7 +70,6 @@ assertions on in this list, you can
 [LongArray]: https://truth.dev/api/latest/com/google/common/truth/PrimitiveLongArraySubject
 [ObjectArray]: https://truth.dev/api/latest/com/google/common/truth/ObjectArraySubject
 [ShortArray]: https://truth.dev/api/latest/com/google/common/truth/PrimitiveShortArraySubject
-[`AtomicLongMap`]: https://truth.dev/api/latest/com/google/common/truth/AtomicLongMapSubject
 [`BigDecimal`]: https://truth.dev/api/latest/com/google/common/truth/BigDecimalSubject
 [`Boolean`]: https://truth.dev/api/latest/com/google/common/truth/BooleanSubject
 [`Class`]: https://truth.dev/api/latest/com/google/common/truth/ClassSubject


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Deprecate AtomicLongMapSubject

Fixes https://github.com/google/truth/issues/451
Fixes https://github.com/google/truth/issues/579

RELNOTES=Deprecated `AtomicLongMapSubject`. In most cases, you can [assert on the `asMap()` view instead](https://github.com/google/truth/issues/579).

20ddb956269f4f729b2ab2f85c56320caac154e7