### PR TITLE
Mark the dependencies on auto-value-annotations as provided.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -46,6 +46,7 @@
     <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>

--- a/extensions/liteproto/pom.xml
+++ b/extensions/liteproto/pom.xml
@@ -31,6 +31,7 @@
     <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>

--- a/extensions/proto/pom.xml
+++ b/extensions/proto/pom.xml
@@ -35,6 +35,7 @@
     <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>


### PR DESCRIPTION
Mark the dependencies on auto-value-annotations as provided so they …don't leak the dependency at a particular version to downstream dependants.  Turns out its an annotations-only dep, so it can be absent at runtime, and it's only needed to signal during hte build of truth itself.

Fixes #590