### PR TITLE
Fix Gradle integration

### DIFF
--- a/index.md
+++ b/index.md
@@ -133,11 +133,11 @@ Truth and [Hamcrest] differ significantly. We prefer Truth because:
 ### Gradle:
 
 ```groovy
-buildscript {
-  repositories.mavenLocal()
+repositories {
+  mavenCentral()
 }
 dependencies {
-  testCompile "com.google.truth:truth:{{ site.version }}"
+  testImplementation "com.google.truth:truth:{{ site.version }}"
 }
 ```
 


### PR DESCRIPTION
The `buildscript` block is actually not needed.
Also the mavenLocal repository makes no sense because not everyone have `truth` in their local maven, right 😉?!

Since Gradle 3.6 there is anew configuration type `implementation`.
We should use this instead of `compile`.
