### PR TITLE
Add a reflective field equality based subject and correspondence.

### DIFF
--- a/extensions/fields/README.md
+++ b/extensions/fields/README.md
@@ -1,0 +1,178 @@
+# Reflective Field Comparisons for Truth
+
+###### Brought to you by Square, Inc.
+
+## Overview
+
+Sometimes there are types without proper equality semantics, or odd cases where introspecting a
+variable not available via an API is necessary. It's often an anti-patern, but can be a useful
+hedge in edge cases, during migrations, etc.
+
+The **truth-fields-extension** allows you to use a custom `Subject` and `Correspondence` 
+instances to do field-by-field comparisons (in regular and list situations respectively).
+
+> Note: Examples here assume static importing of the subject factory, or correspondence.
+
+For example, comparing a single (complex) instance with another: 
+
+```java
+public class MyTest {
+    // assume Foo, Bar, and Blah types
+    @Test public void compareBlahs() {
+        assertAbout(fields())
+            .that(Blah(Bar(Foo(B("A", "B")), "q")))
+            .comparingAllFields()
+            .recursively(/* respectDeclaredEquals = */ false /* default = true */)
+            .isNotEqualTo(Blah(Bar(Foo(B("NotA", "B")), "a")));
+    }
+}
+```
+
+
+```java
+public class MyTest {
+    // assume Foo
+    @Test public void correspondence_with_all_fields_success() {
+        List<Foo> actual = asList(
+            new Foo("foo", "bar"),
+            new Foo("baz", "blah"),
+            new Foo("qu", "arr"));
+        List<Foo> expected = asList(
+            new Foo("baz", "blah"),
+            new Foo("foo", "bar"), // intentionally out of order
+            new Foo("qu", "arr"));
+
+        assertThat(actual)
+            .comparingElementsUsing(flatFieldByField()) // can also do deep comparisons
+            .containsExactlyElementsIn(expected);
+    }
+}
+```
+
+## How to use it
+
+### Build setup
+
+Requires at least Truth at the same version number.
+
+#### Maven:
+
+```xml
+<dependency>
+  <groupId>com.google.truth.extensions</groupId>
+  <artifactId>truth-fields-extension</artifactId>
+  <version>1.0</version>
+  <scope>test</scope>
+</dependency>
+```
+
+#### Gradle:
+
+```groovy
+repositories {
+  mavenCentral()
+}
+dependencies {
+  testImplementation "com.google.truth.extensions:truth-fields-extension:1.0"
+}
+```
+
+Then use it just like you would use Truth, but in place of `assertThat(...)` use `assertAbout(...)`
+using one of the `Correspondence` instances (see below).  
+
+### Kotlin vs. Java : You Decide
+
+The subject and correspondence is written in Kotlin, and so can be invoked using
+named parameters, and using normal Kotlin conveniences. Examples given here are
+written in Java since the tests are mostly written in Kotlin. Where applicable,
+the Kotlin has been annotated for ease of Java-based consumption, but this should
+not affect Kotlin usage.
+
+### Configuring the Subject
+
+When simply comparing two objects, use the field comparing subject like so:
+
+```java
+assertAbout(fields())
+    .that(actual)
+    .comparingAllFields()
+    .isEqualTo(expected);
+```
+
+#### Selecting fields
+
+The field subject can be configured to compare different sets of fields, and this must be specified.
+The simplest is to compare all fields (except fields on Object in Java or Any
+in Kotlin). It can also be configured to compare only a whitelisted set of fields, or to exclude
+certain fields:
+
+
+```java
+// compares all fields, except fields named "foo" and "bar"
+assertAbout(fields())
+    .that(actual)
+    .comparingAllFields()
+    .except("foo", "bar")
+    .isEqualTo(expected);
+
+// compares fields named "bar" and "baz" but excludes "bar" (and "foo" which wasn't used anyway)
+assertAbout(fields())
+    .that(actual)
+    .comparingFields("bar", "baz")
+    .except("foo", "bar")
+    .isEqualTo(expected);
+```
+
+Exclusions override inclusions, and typical set semantics are used to work out the field list.
+Comparing on fields that don't exist in the type compared will result in an
+`IllegalArgumentException`.  Excluding non-existent fields will have no effect.
+
+### Comparing collections of objects by field type.
+
+The `truth-fields-extension` also provides a `Correspondence` for field-by-field evaluation,
+which can be used for collections comparisons like so:
+
+```java
+        List<Foo> actual =
+            asList(new Foo("foo", "bar"), new Foo("baz", "blah"), new Foo("qu", "arr"));
+        List<Foo> expected =
+            asList(new Foo("foo", "bar"), new Foo("baz", "blah"), new Foo("qu", "arr"));
+
+        assertThat(actual)
+            .comparingElementsUsing(flatFieldByField())
+            .containsExactlyElementsIn(expected);
+        // or
+        assertThat(actual)
+            .comparingElementsUsing(deepFieldByField(/* respect declared equals*/ true)))
+            .containsExactlyElementsIn(expected);
+```
+
+### Cyclic object references
+
+Objects with fields that participate in a reference cycle may be compared, though there
+are a few subtleties. 
+
+Firstly, positive assertions will trigger only if the same types are being passed to
+the assertion. That is comparing `Foo` with `Foo` will work as expected, but comparing
+`Foo` with `Bar`, even if Foo and Bar are in a cycle containing the same field values.
+
+Secondly, while the comparison framework can handle cycles, it will throw a stack-overflow
+error messages if the `toString()` representations are not built to account for the cycle.
+This would, however, be an issue with any assertion system that uses the objects' `toString()`
+in its error messages.
+
+## License
+
+```text
+License Copyright 2019 Square, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License
+is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+or implied. See the License for the specific language governing permissions and limitations under
+the License.
+```

--- a/extensions/fields/pom.xml
+++ b/extensions/fields/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.google.truth.extensions</groupId>
+    <artifactId>truth-extensions-parent</artifactId>
+    <version>HEAD-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>truth-fields-extension</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <version>${kotlin.version}</version>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <phase>compile</phase>
+            <goals><goal>compile</goal></goals>
+          </execution>
+          <execution>
+            <id>test-compile</id>
+            <phase>test-compile</phase>
+            <goals><goal>test-compile</goal></goals>
+          </execution>
+        </executions>
+        <configuration>
+          <jvmTarget>1.6</jvmTarget>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <!-- Replacing default-compile as it is treated specially by maven -->
+          <execution>
+            <id>default-compile</id>
+            <phase>none</phase>
+          </execution>
+          <!-- Replacing default-testCompile as it is treated specially by maven -->
+          <execution>
+            <id>default-testCompile</id>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>java-compile</id>
+            <phase>compile</phase>
+            <goals><goal>compile</goal></goals>
+          </execution>
+          <execution>
+            <id>java-test-compile</id>
+            <phase>test-compile</phase>
+            <goals><goal>testCompile</goal></goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/extensions/fields/src/main/java/com/google/common/truth/extensions/fields/ReflectiveFieldComparisons.kt
+++ b/extensions/fields/src/main/java/com/google/common/truth/extensions/fields/ReflectiveFieldComparisons.kt
@@ -1,0 +1,190 @@
+/*
+ * License Copyright 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.common.truth.extensions.fields
+
+import java.lang.IllegalArgumentException
+import java.lang.reflect.Field
+import java.util.ArrayDeque
+
+/**
+ * Does a field-by-field comparison of two objects, invoking workhorse lambdas on specific
+ * mismatches.  This can result in different outcomes - e.g. comparator-style -1, 0, 1 output, or
+ * a matching predicate, or an accumulation of mismatches as Truth errors.
+ */
+internal data class FieldComparer<R>(
+    val scanner: FieldScanner,
+    val configuration: Configuration = Configuration.DEFAULT,
+    private val mismatch: (name: String, actual: Any?, expected: Any?) -> Iterable<R>,
+    private val typeMismatch: (name: String, actual: Any?, expected: Any?) -> Iterable<R>
+) {
+
+    data class Configuration(val deep: Boolean, val respectEquals: Boolean) {
+        init {
+            check(deep || !respectEquals) {
+                "When deep is false respectEquals cannot be true."
+            }
+        }
+
+        companion object {
+            val DEFAULT = Configuration(deep = false, respectEquals = false)
+        }
+    }
+
+    private fun compareLeaf(path: ComparisonPath, actual: Any?, expected: Any?): Iterable<R> =
+        if (actual != expected) mismatch(path.fieldName(), actual, expected) else emptyList()
+
+    /**
+     * Performs a field-by-field comparison between [act] and [exp] invoking the lambdas
+     * [mismatch] and [typeMismatch] on unequal fields or types.
+     *
+     * > Note: Does not cross over collections or maps (uses their .equals method).  Also ignores
+     * > other [equals] methods unless to honor them. (see [Configuration])
+     */
+    fun compare(act: Any?, exp: Any?): Iterable<R> =
+    // Sadly, the === and null-or checks must be duplicated here, where there is no field, as well
+    // as in compare(path, act, exp, configuration) since in this method we have no field, whereas
+        // in compare(path, act, exp, configuration) a path exists.
+        when {
+            act === exp -> emptyList() // Short circuit reference (or null) equality
+            act == null || exp == null -> mismatch("", act, exp) // no field here.
+            else -> compareBranch(ComparisonPath(Pair(act, exp)), act, exp, configuration)
+        }
+
+    private fun compareBranch(
+        path: ComparisonPath,
+        act: Any?,
+        exp: Any?,
+        configuration: Configuration
+    ): Iterable<R> {
+        // Shorter names chosen here, to allow more consistent visualization in the decision table
+        return when {
+            act === exp -> emptyList() // Short circuit reference (or null) equality
+            act == null || exp == null -> compareLeaf(path, act, exp)
+            act unlike exp -> typeMismatch(path.fieldName(), act, exp)
+            else -> when (act) {
+                is String,
+                is Number,
+                is Boolean,
+                is Char,
+                is Enum<*> -> compareLeaf(path, act, exp)
+                is Array<*> -> compareLeaf(path, act.asList(), (exp as Array<*>).asList())
+                is BooleanArray -> compareLeaf(path, act.asList(), (exp as BooleanArray).asList())
+                is CharArray -> compareLeaf(path, act.asList(), (exp as CharArray).asList())
+                is DoubleArray -> compareLeaf(path, act.asList(), (exp as DoubleArray).asList())
+                is FloatArray -> compareLeaf(path, act.asList(), (exp as FloatArray).asList())
+                is IntArray -> compareLeaf(path, act.asList(), (exp as IntArray).asList())
+                is LongArray -> compareLeaf(path, act.asList(), (exp as LongArray).asList())
+                is ShortArray -> compareLeaf(path, act.asList(), (exp as ShortArray).asList())
+                is Collection<*> -> compareLeaf(path, act, exp as Collection<*>)
+                else -> {
+                    if (configuration.respectEquals && act.javaClass.hasDeclaredEquals()) {
+                        return compareLeaf(path, act, exp)
+                    }
+
+                    val fields = scanner.on(act.javaClass)
+                    fields.flatMap {
+                        val compareData =
+                            CompareData(field = it, actual = it.get(act), expected = it.get(exp))
+                        if (path.seen(compareData)) emptyList()
+                        else {
+                            path.inContext(compareData) { data ->
+                                if (!configuration.deep) compareLeaf(
+                                    path,
+                                    data.actual,
+                                    data.expected
+                                )
+                                else compareBranch(path, data.actual, data.expected, configuration)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private class CompareData(val field: Field, val actual: Any?, val expected: Any?) {
+    override fun toString() = "CompareData(field=${field.name}, actual=$actual, expected=$expected"
+    override fun equals(other: Any?) =
+        other is CompareData && field == other.field && actual === other.actual &&
+                expected === other.expected
+}
+
+private class ComparisonPath(
+    val root: Pair<Any, Any>,
+    private val stack: ArrayDeque<CompareData> = ArrayDeque()
+) {
+    fun <R> inContext(e: CompareData, work: (e: CompareData) -> R): R {
+        stack.push(e)
+        return work(e).also { stack.pop() }
+    }
+
+    override fun toString() =
+        "CyclePath(root=${root.first.javaClass.simpleName}, stack=${stack.map { it.field.name }}"
+
+    fun fieldName() =
+        "${rootType().simpleName}.${stack.reversed().joinToString(".") { it.field.name }}"
+
+    fun seen(compareData: CompareData) =
+        !stack.isEmpty() &&
+                root.first === compareData.actual &&
+                root.first === compareData.expected ||
+                stack.contains(compareData)
+
+    fun rootType(): Class<*> =
+        if (stack.isEmpty()) root.first.javaClass else stack.peekLast().field.declaringClass
+}
+
+/** Scans a class for all declared fields, based optionally on a whitelist and exclusion list */
+internal data class FieldScanner internal constructor(
+    val whitelisted: Set<String> = setOf(),
+    val exclusions: Set<String> = setOf()
+) {
+    /**
+     * Scans [clazz] for declared fields, optionally filtering with a whitelist and exclusion list,
+     * throwing an [IllegalArgumentException] when a non-existent field is specified in the
+     * inclusion list.
+     */
+    fun on(clazz: Class<Any>?)
+        = declaredFieldsFromHierarchyOf(clazz)
+            .toList()
+            .also { fields ->
+                if (whitelisted.isNotEmpty()) {
+                    val extras = whitelisted.subtract(fields.map { it.name })
+                    if (extras.isNotEmpty()) {
+                        throw IllegalArgumentException(
+                            "Comparing type: ${clazz?.name} using non-existent fields: $extras")
+                    }
+                }
+            }
+            .onEach { it.isAccessible = true }
+            .filter { if (whitelisted.isEmpty()) true else whitelisted.contains(it.name) }
+            .filter { if (exclusions.isEmpty()) true else !exclusions.contains(it.name) }
+
+    /** Returns the full sequence of declared fields from the type hierarchy of [clazz] */
+    private fun declaredFieldsFromHierarchyOf(clazz: Class<*>?): Sequence<Field> {
+        return if (clazz == null) sequenceOf()
+        else sequenceOf(*clazz.declaredFields) + declaredFieldsFromHierarchyOf(clazz.superclass)
+    }
+}
+
+internal fun Class<*>.hasDeclaredEquals(): Boolean {
+    if (this == Any::class.java) return false
+    val hasEqualsMethodError = this.declaredMethods.any { method ->
+        method.name == "equals" && method.parameterTypes.let {
+            it.size == 1 && it[0] == Any::class.java
+        }
+    }
+    return hasEqualsMethodError || superclass.hasDeclaredEquals()
+}

--- a/extensions/fields/src/main/java/com/google/common/truth/extensions/fields/ReflectiveFieldCorrespondence.kt
+++ b/extensions/fields/src/main/java/com/google/common/truth/extensions/fields/ReflectiveFieldCorrespondence.kt
@@ -1,0 +1,91 @@
+/*
+ * License Copyright 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.common.truth.extensions.fields
+
+import com.google.common.truth.Correspondence
+import com.google.common.truth.extensions.fields.FieldComparer.Configuration
+
+/**
+ * A [Correspondence] for use in Truth subjects, which compares based on a field-by-field comparison
+ * strategy, defined in [FieldComparer]
+ */
+object ReflectiveFieldCorrespondence {
+
+    /**
+     * Makes a correspondence which deeply (recursively) scans field equality across a graph.
+     *
+     * By default, if the type has an explicitly declared .equals() method (other than
+     * Any's/Object's default implementation) then short-circuit on that. Otherwise, do further
+     * field comparison. This facility can be configured by the [respectDeclaredEquals] parameter.
+     */
+    @JvmOverloads
+    @JvmStatic
+    fun deepFieldByField(respectDeclaredEquals: Boolean = true): Correspondence<Any, Any> =
+        reflectiveFieldCorrespondence(
+            FieldComparer(
+                FieldScanner(),
+                Configuration(true, respectDeclaredEquals),
+                ::mismatch,
+                ::mismatch
+            )
+        )
+
+    /**
+     * Makes a correspondence which compares field-by-field (shallow comparison for each field),
+     * where the fields may be unfiltered, or filtered via a whitelist or an exclusion list.
+     * Exclusions (if any) are subtracted from the whitelist (if present), or from the full set of
+     * available fields.
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun flatFieldByField(whitelisted: Set<String> = setOf(), exclude: Set<String> = setOf()) =
+        reflectiveFieldCorrespondence(
+            FieldComparer(
+                FieldScanner(whitelisted, exclude), Configuration.DEFAULT, ::mismatch, ::mismatch
+            )
+        )
+
+    private fun reflectiveFieldCorrespondence(
+        comparer: FieldComparer<Boolean>
+    ): Correspondence<Any, Any> {
+        return Correspondence.from({ actual, expected ->
+            // This compare returns a list of mismatches, so if there are any, it didn't match,
+            // so we need to invert.
+            !comparer.compare(actual, expected).any { it }
+        }, description(comparer))
+    }
+
+    private fun description(comparer: FieldComparer<Boolean>) = when {
+        comparer.configuration.deep -> "has fields which (deeply) match those of"
+        else -> "has ${fieldsAffected(comparer)} which match those of"
+    }
+
+    private fun fieldsAffected(comparer: FieldComparer<Boolean>): String {
+        val (whitelisted, exclusions) = comparer.scanner
+        return when {
+            whitelisted.isEmpty() && exclusions.isEmpty() -> "fields"
+            whitelisted.isEmpty() && exclusions.isNotEmpty() -> "fields (excluding $exclusions)"
+            whitelisted.isNotEmpty() && exclusions.isEmpty() -> "fields $whitelisted"
+            else -> "fields ${whitelisted - exclusions}"
+        }
+    }
+}
+
+/** Simply returns true on a mismatch, to allow the presence of mismatches to be noted */
+@Suppress("UNUSED_PARAMETER")
+private fun mismatch(
+    name: String,
+    actual: Any?,
+    expected: Any?
+): Iterable<Boolean> = listOf(true)

--- a/extensions/fields/src/main/java/com/google/common/truth/extensions/fields/ReflectiveFieldSubject.kt
+++ b/extensions/fields/src/main/java/com/google/common/truth/extensions/fields/ReflectiveFieldSubject.kt
@@ -1,0 +1,212 @@
+/*
+ * License Copyright 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.common.truth.extensions.fields
+
+import com.google.common.truth.Fact
+import com.google.common.truth.Fact.fact
+import com.google.common.truth.Fact.simpleFact
+import com.google.common.truth.FailureMetadata
+import com.google.common.truth.Subject
+import com.google.common.truth.Truth
+import com.google.common.truth.extensions.fields.FieldComparer.Configuration
+import java.lang.reflect.Field
+import kotlin.DeprecationLevel.ERROR
+
+/**
+ * A set of propositions for the [Truth] framework to test things about a class based on its fields,
+ * using a reflective to specify or exclude fields under consideration.
+ */
+class ReflectiveFieldSubject private constructor(
+    failureMetadata: FailureMetadata,
+    private val actual: Any?
+) : Subject(failureMetadata, actual) {
+    companion object {
+        @JvmStatic
+        fun fields(): Factory<ReflectiveFieldSubject, Any?> = Factory(::ReflectiveFieldSubject)
+    }
+
+    @Deprecated(
+        message = "Do not use isEqualTo() directly on this subject",
+        replaceWith = ReplaceWith("comparingAllFields().isEqualTo(expected)"),
+        level = ERROR
+    )
+    override fun isEqualTo(expected: Any?): Unit =
+        throw UnsupportedOperationException("Should use field-comparing methods before isEqualTo()")
+
+    @Deprecated(
+        message = "Do not use isEqualTo() directly on this subject",
+        replaceWith = ReplaceWith("comparingAllFields().isNotEqualTo(unexpected)"),
+        level = ERROR
+    )
+    override fun isNotEqualTo(unexpected: Any?): Unit =
+        throw UnsupportedOperationException(
+            "Should use field-comparing methods before isNotEqualTo()"
+        )
+
+    fun comparingFields(vararg fields: String): FieldFilteringTerm =
+        FieldComparingTerm(FieldScanner(setOf(*fields)), Configuration.DEFAULT)
+
+    fun comparingAllFields(): AllFieldsTerm =
+        FieldComparingTerm(FieldScanner(), Configuration.DEFAULT)
+
+    /**
+     * The terminal term in the fluent call chain, containing the actual test methods, configured
+     * by earlier calls in the chain.
+     */
+    interface TerminalTerm {
+        fun isEqualTo(expected: Any?)
+        fun isNotEqualTo(unexpected: Any?)
+    }
+
+    /**
+     * A fluent chain term which can present in the case of "all fields" or "some fields" cases,
+     * which optionally configures field exclusion, to reduce the set of fields under consideration.
+     */
+    interface FieldFilteringTerm : TerminalTerm {
+        /** Configures the equality test to exclude the supplied fields from consideration. */
+        fun except(vararg exclusions: String): TerminalTerm
+    }
+
+    /**
+     * A fluent chain term which is present when all fields (as opposed to a whitelisted set) are
+     * under consideration for field-by-field equality.  It offers further configuration of the
+     * equality consideration by either excluding fields by name, or configuring a recursive
+     * (deepFieldByField) equality.
+     */
+    interface AllFieldsTerm : FieldFilteringTerm, TerminalTerm {
+        /**
+         * Configures the equality test to exclude the supplied fields from consideration.
+         *
+         * If [respectDeclaredEquals] is true and the class contains its own `equals()` method
+         * (meaning an `equals()` method other than the one from Any), then the method uses the
+         * `equals()` for comparing the object instead of the fields individually.
+         */
+        fun recursively(respectDeclaredEquals: Boolean): TerminalTerm
+
+        /**
+         * Configures the equality test to exclude the supplied fields from consideration.
+         *
+         * If the class contains its own `equals()` method (meaning an `equals()` method other than
+         * the one from Any), then the method uses the `equals()` for comparing the object instead
+         * of the fields individually.
+         */
+        // Note, in Kotlin only you should use a default parameter, but this doesn't work well with
+        // Java. Neither @JmvOverloads nor @JvmName are working in interfaces.
+        fun recursively() = recursively(true)
+    }
+
+    private inner class FieldComparingTerm private constructor(
+        private val comparer: FieldComparer<Fact>
+    ) : AllFieldsTerm, FieldFilteringTerm, TerminalTerm {
+        constructor(scanner: FieldScanner, configuration: Configuration) :
+                this(FieldComparer(scanner, configuration, ::mismatchFact, ::typeMismatchFact))
+
+        override fun except(vararg exclusions: String): FieldComparingTerm =
+            FieldComparingTerm(
+                comparer = comparer.copy(
+                    scanner = comparer.scanner.copy(exclusions = setOf(*exclusions))
+                )
+            )
+
+        override fun recursively(respectDeclaredEquals: Boolean): FieldComparingTerm =
+            FieldComparingTerm(
+                comparer.copy(
+                    configuration = Configuration(
+                        deep = true,
+                        respectEquals = respectDeclaredEquals
+                    )
+                )
+            )
+
+        override fun isEqualTo(expected: Any?) {
+            when {
+                actual === expected -> {
+                }
+                actual == null || expected == null -> check("isEqualTo()").that(actual).isEqualTo(
+                    expected
+                )
+                actual unlike expected -> check("isEqualTo()").that(actual).isEqualTo(expected)
+                else -> {
+                    val facts = comparer.compare(actual, expected).toList()
+                    if (facts.isNotEmpty()) {
+                        if (comparer.configuration.deep) {
+                            failWithoutActual(
+                                simpleFact("Some fields failed to match:"),
+                                *facts.toTypedArray()
+                            )
+                        } else {
+                            failWithoutActual(
+                                fact(
+                                    "Compared using fields",
+                                    comparer.scanner.on(actual.javaClass).map(Field::getName)
+                                ),
+                                *(listOf(fact("resulted in mismatches", "")) + facts).toTypedArray()
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        override fun isNotEqualTo(unexpected: Any?) {
+            when {
+                actual === unexpected -> failWithoutActual(fact("expected not to be", unexpected))
+                // Short circuit when one is null and the other isn't.
+                actual == null || unexpected == null -> return
+                else -> {
+                    val facts = comparer.compare(actual, unexpected).toList()
+                    if (facts.isEmpty()) {
+                        if (comparer.configuration.deep) failWithActual(
+                            fact(
+                                "expected not to be",
+                                unexpected
+                            )
+                        )
+                        else {
+                            failWithActual(
+                                fact(
+                                    "Compared using fields",
+                                    comparer.scanner.on(actual.javaClass).map(Field::getName)
+                                ),
+                                fact("expected not to be", unexpected)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun mismatchFact(field: String, actual: Any?, expected: Any?) =
+    if (actual is Collection<*> && expected is Collection<*> && actual.size == expected.size) {
+        fact(
+            "$field ", "expected: <$expected> (class: ${expected::class.java}) " +
+                    "but was: <$actual> (class: ${actual::class.java})"
+        ).iterable()
+    } else {
+        fact("$field ", "expected: <$expected> but was: <$actual>").iterable()
+    }
+
+private fun typeMismatchFact(field: String, actual: Any?, expected: Any?) =
+    if (actual is Collection<*> && expected is Collection<*> && actual.size == expected.size) {
+        fact(
+            "$field ", "expected: <$expected> (class: ${expected::class.java}) " +
+                    "but was: <$actual> (class: ${actual::class.java})"
+        ).iterable()
+    } else {
+        fact("$field ", "expected: <$expected> but was: <$actual>").iterable()
+    }
+
+private fun Fact?.iterable(): Iterable<Fact> = if (this == null) emptyList() else listOf(this)

--- a/extensions/fields/src/main/java/com/google/common/truth/extensions/fields/ReflectiveFieldUtils.kt
+++ b/extensions/fields/src/main/java/com/google/common/truth/extensions/fields/ReflectiveFieldUtils.kt
@@ -1,0 +1,21 @@
+/*
+ * License Copyright 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.common.truth.extensions.fields
+
+/**
+ * Checks whether two objects have either identical concrete types, or are Collections, which have
+ * comparable type semantics.
+ */
+internal infix fun Any.unlike(that: Any) =
+    this::class != that::class && this !is Collection<*> && that !is Collection<*>

--- a/extensions/fields/src/test/java/com/google/common/truth/extensions/fields/ReflectiveFieldComparisonsTest.kt
+++ b/extensions/fields/src/test/java/com/google/common/truth/extensions/fields/ReflectiveFieldComparisonsTest.kt
@@ -1,0 +1,39 @@
+/*
+ * License Copyright 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.common.truth.extensions.fields
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class ReflectiveFieldComparisonsTest {
+
+    private open class Foo
+    private open class Bar : Foo() {
+        override fun equals(other: Any?) = true
+    }
+
+    private class Baz : Bar()
+    private class Quf : Foo()
+
+    @Test
+    fun hasDeclaredEquals() {
+        assertThat(Foo::class.java.hasDeclaredEquals()).isFalse()
+        assertThat(Bar::class.java.hasDeclaredEquals()).isTrue()
+        assertThat(Baz::class.java.hasDeclaredEquals()).isTrue()
+        assertThat(Quf::class.java.hasDeclaredEquals()).isFalse()
+    }
+}

--- a/extensions/fields/src/test/java/com/google/common/truth/extensions/fields/ReflectiveFieldCorrespondenceTest.kt
+++ b/extensions/fields/src/test/java/com/google/common/truth/extensions/fields/ReflectiveFieldCorrespondenceTest.kt
@@ -1,0 +1,274 @@
+/*
+ * License Copyright 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.common.truth.extensions.fields
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.extensions.fields.ReflectiveFieldCorrespondence.deepFieldByField
+import com.google.common.truth.extensions.fields.ReflectiveFieldCorrespondence.flatFieldByField
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import kotlin.test.assertFailsWith
+
+@RunWith(JUnit4::class)
+class ReflectiveFieldCorrespondenceTest {
+
+    /**
+     * A supertype for test classes that will contain fields reflectively scanned, but which may
+     * have odd equals (to force certain test cases).  This supertype gives each a string
+     * representation and a default (dumb, but correct) hashCode() implementation.
+     */
+    internal abstract class TestClass {
+        override fun hashCode() =
+            0 // For testing, this is never used as a key in a hashtable in production.
+
+        protected val stringRep
+            get() = "${javaClass.simpleName}@${super.toString().split("@")[1]}"
+    }
+
+    // Can't use a data class to test this as .equals will hijack the field-by field. In general
+    // kotlin data classes don't need this sort of assertion.
+    private class Foo(val a: String, val b: String) : TestClass() {
+        override fun toString() = "TestData@$stringRep(a=$a, b=$b)"
+    }
+
+    @Test
+    fun verify_test_class_fails_with_regular_iterablesubject() {
+        val actual =
+            listOf(Foo("foo", "bar"), Foo("baz", "blah"), Foo("qu", "arr"))
+        val expected =
+            listOf(Foo("foo", "bar"), Foo("baz", "blah"), Foo("qu", "arr"))
+
+        val error = assertFailsWith<VerificationError> {
+            VERIFY.that(actual).containsExactlyElementsIn(expected)
+        }
+        assertThat(error).hasMessageThat().contains("missing (3)")
+        assertThat(error).hasMessageThat().contains("unexpected (3)")
+    }
+
+    @Test
+    fun correspondence_with_all_fields_success() {
+        val actual =
+            listOf(Foo("foo", "bar"), Foo("baz", "blah"), Foo("qu", "arr"))
+        val expected =
+            listOf(Foo("foo", "bar"), Foo("baz", "blah"), Foo("qu", "arr"))
+
+        VERIFY.that(actual).comparingElementsUsing(flatFieldByField())
+            .containsExactlyElementsIn(expected)
+    }
+
+    @Test
+    fun correspondence_with_all_fields_failure() {
+        val actual =
+            listOf(Foo("foo", "bar"), Foo("baz", "blah"), Foo("qu", "arr"))
+        val expected =
+            listOf(Foo("bar", "bar"), Foo("blah", "blah"), Foo("qu", "arr"))
+
+        val error = assertFailsWith<VerificationError> {
+            VERIFY.that(actual).comparingElementsUsing(flatFieldByField())
+                .containsExactlyElementsIn(expected)
+        }
+        assertThat(error).hasMessageThat()
+            .contains("contains exactly one element that has fields which match those of")
+        assertThat(error).hasMessageThat()
+            .contains("It is missing an element that has fields which match those of")
+    }
+
+    @Test
+    fun correspondence_with_whitelisted_fields_success() {
+        val actual =
+            listOf(Foo("foo", "bar"), Foo("baz", "blah"), Foo("qu", "arr"))
+        val expected =
+            listOf(Foo("foo", "foo"), Foo("baz", "blah"), Foo("qu", "arr"))
+        val fieldByField = flatFieldByField(whitelisted = setOf("a"))
+
+        VERIFY.that(actual).comparingElementsUsing(fieldByField).containsExactlyElementsIn(expected)
+    }
+
+    @Test
+    fun correspondence_with_whitelisted_fields_failure() {
+        val actual =
+            listOf(Foo("foo", "bar"), Foo("baz", "blah"), Foo("qu", "arr"))
+        val expected =
+            listOf(Foo("bar", "bar"), Foo("blah", "blah"), Foo("qu", "arr"))
+        val fieldByField = flatFieldByField(whitelisted = setOf("a"))
+
+        val error = assertFailsWith<VerificationError> {
+            VERIFY.that(actual).comparingElementsUsing(fieldByField)
+                .containsExactlyElementsIn(expected)
+        }
+        assertThat(error).hasMessageThat()
+            .contains("contains exactly one element that has fields [a] which match those of")
+        assertThat(error).hasMessageThat()
+            .contains("It is missing an element that has fields [a] which match those of")
+    }
+
+    @Test
+    fun correspondence_with_excluded_fields_success() {
+        val actual =
+            listOf(Foo("foo", "bar"), Foo("baz", "blah"), Foo("qu", "arr"))
+        val expected =
+            listOf(Foo("bar", "bar"), Foo("baz", "blah"), Foo("qu", "arr"))
+        val fieldByField = flatFieldByField(exclude = setOf("a"))
+
+        VERIFY.that(actual).comparingElementsUsing(fieldByField).containsExactlyElementsIn(expected)
+    }
+
+    @Test
+    fun correspondence_with_excluded_fields_failure() {
+        val actual =
+            listOf(Foo("foo", "foo"), Foo("baz", "blah"), Foo("qu", "arr"))
+        val expected =
+            listOf(Foo("foo", "bar"), Foo("baz", "blah"), Foo("qu", "arr"))
+        val fieldByField = flatFieldByField(exclude = setOf("a"))
+
+        val error = assertFailsWith<VerificationError> {
+            VERIFY.that(actual).comparingElementsUsing(fieldByField)
+                .containsExactlyElementsIn(expected)
+        }
+        assertThat(error).hasMessageThat()
+            .contains("contains exactly one element that has fields")
+        assertThat(error).hasMessageThat()
+            .contains("(excluding [a]) which match those of")
+        assertThat(error).hasMessageThat()
+            .contains("It is missing an element that has fields (excluding [a]) which match those")
+    }
+
+    @Test
+    fun correspondence_with_whitelisted_and_excluded_fields_success() {
+        val actual =
+            listOf(Foo("foo", "bar"), Foo("baz", "blah"), Foo("qu", "arr"))
+        val expected =
+            listOf(Foo("bar", "bar"), Foo("baz", "blah"), Foo("qu", "arr"))
+        val fieldByField = flatFieldByField(whitelisted = setOf("a", "b"), exclude = setOf("a"))
+
+        VERIFY.that(actual).comparingElementsUsing(fieldByField).containsExactlyElementsIn(expected)
+    }
+
+    @Test
+    fun correspondence_with_whitelisted_and_excluded_fields_failure() {
+        val actual =
+            listOf(Foo("foo", "foo"), Foo("baz", "blah"), Foo("qu", "arr"))
+        val expected =
+            listOf(Foo("foo", "bar"), Foo("baz", "blah"), Foo("qu", "arr"))
+        val fieldByField = flatFieldByField(whitelisted = setOf("a", "b"), exclude = setOf("a"))
+
+        val error = assertFailsWith<VerificationError> {
+            VERIFY.that(actual).comparingElementsUsing(fieldByField)
+                .containsExactlyElementsIn(expected)
+        }
+        assertThat(error).hasMessageThat()
+            .contains("contains exactly one element that has fields [b] which match those of")
+        assertThat(error).hasMessageThat()
+            .contains("It is missing an element that has fields [b] which match those of")
+    }
+
+    private class A(val data: String) : TestClass() {
+        override fun toString() = "$stringRep(data=$data)"
+    }
+
+    private class B(val data: String, val a: A) : TestClass() {
+        override fun toString() = "$stringRep(data=$data, a=$a)"
+    }
+
+    @Test
+    fun verify_nested_test_classes_fails_with_regular_iterablesubject() {
+        val actual = listOf(
+            B("foo", A("bar")),
+            B("baz", A("blah")),
+            B("qu", A("arr"))
+        )
+        val expected = listOf(
+            B("foo", A("bar")),
+            B("baz", A("blah")),
+            B("qu", A("arr"))
+        )
+
+        val error = assertFailsWith<VerificationError> {
+            VERIFY.that(actual).containsExactlyElementsIn(expected)
+        }
+        assertThat(error).hasMessageThat().contains("missing (3)")
+        assertThat(error).hasMessageThat().contains("unexpected (3)")
+    }
+
+    @Test
+    fun correspondence_with_recursively_matched_fields_success() {
+        val actual = listOf(
+            B("foo", A("bar")),
+            B("baz", A("blah")),
+            B("qu", A("arr"))
+        )
+        val expected = listOf(
+            B("foo", A("bar")),
+            B("baz", A("blah")),
+            B("qu", A("arr"))
+        )
+
+        VERIFY.that(actual).comparingElementsUsing(deepFieldByField())
+            .containsExactlyElementsIn(expected)
+    }
+
+    @Test
+    fun correspondence_with_recursively_matched_fields_failure() {
+        val actual = listOf(
+            B("foo", A("bar")),
+            B("baz", A("blah")),
+            B("qu", A("arr"))
+        )
+        val expected = listOf(
+            B("foo", A("foo")),
+            B("baz", A("blah")),
+            B("qu", A("arr"))
+        )
+
+        val error = assertFailsWith<VerificationError> {
+            VERIFY.that(actual).comparingElementsUsing(deepFieldByField())
+                .containsExactlyElementsIn(expected)
+        }
+        assertThat(error).hasMessageThat()
+            .contains("contains exactly one element that has fields which (deeply) match those of")
+        assertThat(error).hasMessageThat()
+            .contains("It is missing an element that has fields which (deeply) match those of")
+    }
+
+    private class C(val data: String, val ignored: String) : TestClass() {
+        override fun toString() = "$stringRep(data=$data, ignored=$ignored)"
+        override fun equals(other: Any?) = other is C && data == other.data
+    }
+
+    private class D(val data: String, val c: C) : TestClass() {
+        override fun toString() = "$stringRep(data=$data, c=$c)"
+    }
+
+    @Test
+    fun correspondence_with_recursively_matched_fields_respecting_equals() {
+        val actual = listOf(
+            D("foo", C("bar", "foo")),
+            D("baz", C("blah", "baz"))
+        )
+        val expected = listOf(
+            D("foo", C("bar", "bar")),
+            D("baz", C("blah", "baz"))
+        )
+
+        VERIFY.that(actual)
+            .comparingElementsUsing(deepFieldByField(true))
+            .containsExactlyElementsIn(expected)
+        assertFailsWith<VerificationError> {
+            VERIFY.that(actual)
+                .comparingElementsUsing(deepFieldByField(false))
+                .containsExactlyElementsIn(expected)
+        }
+    }
+}

--- a/extensions/fields/src/test/java/com/google/common/truth/extensions/fields/ReflectiveFieldJavaUsageTest.java
+++ b/extensions/fields/src/test/java/com/google/common/truth/extensions/fields/ReflectiveFieldJavaUsageTest.java
@@ -1,0 +1,71 @@
+/*
+ * License Copyright 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.common.truth.extensions.fields;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.List;
+
+import static com.google.common.truth.extensions.fields.ReflectiveFieldCorrespondence.flatFieldByField;
+import static com.google.common.truth.extensions.fields.TruthSubjectTesting.VERIFY;
+import static java.util.Arrays.asList;
+
+/**
+ * A subset of the other tests, rewritten in Java, both to prove out the java interop, and to show
+ * usage in Java.
+ */
+@RunWith(JUnit4.class)
+public class ReflectiveFieldJavaUsageTest {
+    // Can't use an auto-value to test this as .equals will hijack the field-by field. In general
+    // auto-value classes don't need this sort of assertion.
+    private class Foo {
+        private final String a;
+        private final String b;
+
+        Foo(String a, String b) {
+            this.a = a;
+            this.b = b;
+        }
+
+        @Override
+        public int hashCode() {
+            return 0;
+        }
+
+        @Override
+        public String toString() {
+            String stringRep = super.toString().split("@")[1];
+            return "TestData@" + stringRep + "(a=" + a + ", b=" + b + ")";
+        }
+    }
+
+    @Test
+    public void correspondence_with_all_fields_success() {
+        List<Foo> actual = asList(
+            new Foo("foo", "bar"),
+            new Foo("baz", "blah"),
+            new Foo("qu", "arr"));
+        List<Foo> expected = asList(
+            new Foo("baz", "blah"),
+            new Foo("foo", "bar"), // intentionally out of order
+            new Foo("qu", "arr"));
+
+        VERIFY.that(actual)
+            .comparingElementsUsing(flatFieldByField())
+            .containsExactlyElementsIn(expected);
+    }
+
+}

--- a/extensions/fields/src/test/java/com/google/common/truth/extensions/fields/ReflectiveFieldSubjectTest.kt
+++ b/extensions/fields/src/test/java/com/google/common/truth/extensions/fields/ReflectiveFieldSubjectTest.kt
@@ -1,0 +1,487 @@
+/*
+ * License Copyright 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.common.truth.extensions.fields
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.extensions.fields.ReflectiveFieldSubject.Companion.fields
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.util.LinkedList
+import kotlin.test.assertFailsWith
+
+@RunWith(JUnit4::class)
+class ReflectiveFieldSubjectTest {
+
+    data class TestData(val a: String?, val b: String?)
+
+    @Test
+    fun comparingAllFields_null_actual_isEqualTo_null_expected_success() {
+        VERIFY.about(fields()).that(null).comparingAllFields().isEqualTo(null)
+    }
+
+    @Test
+    fun comparingAllFields_null_actual_isEqualTo_notnull_expected_failure() {
+        val error = assertFailsWith<VerificationError> {
+            VERIFY.about(fields())
+                .that(null)
+                .comparingAllFields()
+                .isEqualTo(TestData("a", "a"))
+        }
+        assertThat(error).hasMessageThat().contains("expected           : TestData(a=a, b=a)")
+        assertThat(error).hasMessageThat().contains("but was            : null")
+    }
+
+    @Test
+    fun comparingAllFields_notnull_actual_isEqualTo_null_expected_failure() {
+        val error = assertFailsWith<VerificationError> {
+            VERIFY.about(fields())
+                .that(TestData("a", "a"))
+                .comparingAllFields()
+                .isEqualTo(null)
+        }
+        assertThat(error).hasMessageThat().contains("expected           : null")
+        assertThat(error).hasMessageThat().contains("but was            : TestData(a=a, b=a)")
+    }
+
+    @Test
+    fun comparingAllFields_where_fields_are_null_actual_isEqualTo_null_expected_success() {
+        VERIFY.about(fields()).that(TestData(null, "b"))
+            .comparingAllFields()
+            .isEqualTo(TestData(null, "b"))
+    }
+
+    @Test
+    fun comparingAllFields_where_fields_are_null_actual_isEqualTo_notnull_expected_failure() {
+        val error = assertFailsWith<VerificationError> {
+            VERIFY.about(fields())
+                .that(TestData(null, "b"))
+                .comparingAllFields()
+                .isEqualTo(TestData("a", "a"))
+        }
+        assertThat(error).hasMessageThat().contains("Compared using fields : [a, b]")
+        assertThat(error).hasMessageThat()
+            .contains("TestData.a            : expected: <a> but was: <null>")
+    }
+
+    @Test
+    fun comparingAllFields_where_fields_are_notnull_actual_isEqualTo_null_expected_failure() {
+        val error = assertFailsWith<VerificationError> {
+            VERIFY.about(fields())
+                .that(TestData("a", "a"))
+                .comparingAllFields()
+                .isEqualTo(TestData(null, "a"))
+        }
+        assertThat(error).hasMessageThat().contains("Compared using fields : [a, b]")
+        assertThat(error).hasMessageThat()
+            .contains("TestData.a            : expected: <null> but was: <a>")
+    }
+
+    @Test
+    fun comparingAllFields_isEqualTo_success() {
+        VERIFY.about(fields())
+            .that(TestData("a", "b"))
+            .comparingAllFields()
+            .isEqualTo(TestData("a", "b"))
+    }
+
+    @Test
+    fun comparingAllFields_isEqualTo_failure() {
+        val error = assertFailsWith<VerificationError> {
+            VERIFY.about(fields())
+                .that(TestData("a", "b"))
+                .comparingAllFields()
+                .isEqualTo(TestData("a", "a"))
+        }
+        assertThat(error).hasMessageThat().contains("Compared using fields : [a, b]")
+        assertThat(error).hasMessageThat()
+            .contains("TestData.b            : expected: <a> but was: <b>")
+    }
+
+    @Test
+    fun comparingFields_isEqualTo_success() {
+        VERIFY.about(fields())
+            .that(TestData("a", "b"))
+            .comparingFields("a")
+            .isEqualTo(TestData("a", "a"))
+    }
+
+    @Test
+    fun comparingFields_isEqualTo_failure() {
+        val error = assertFailsWith<VerificationError> {
+            VERIFY.about(fields())
+                .that(TestData("a", "b"))
+                .comparingFields("b")
+                .isEqualTo(TestData("a", "a"))
+        }
+        assertThat(error).hasMessageThat().contains("Compared using fields : [b]")
+        assertThat(error).hasMessageThat()
+            .contains("TestData.b            : expected: <a> but was: <b>")
+    }
+
+    @Test
+    fun comparingFields_non_existant_field_failure() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            VERIFY.about(fields())
+                .that(TestData("a", "b"))
+                .comparingFields("nonexistent_field")
+                .isEqualTo(TestData("a", "a"))
+        }
+        assertThat(error).hasMessageThat().contains("Comparing type")
+        assertThat(error).hasMessageThat().contains("\$TestData using non-existent fields")
+        assertThat(error).hasMessageThat().contains("[nonexistent_field]")
+   }
+
+    @Test
+    fun comparingAllFieldsExcept_isEqualTo_success() {
+        VERIFY.about(fields())
+            .that(TestData("a", "b"))
+            .comparingAllFields()
+            .except("b")
+            .isEqualTo(TestData("a", "a"))
+    }
+
+    @Test
+    fun comparingAllFieldsExcept_isEqualTo_failure() {
+        val error = assertFailsWith<VerificationError> {
+            VERIFY.about(fields())
+                .that(TestData("a", "b"))
+                .comparingAllFields()
+                .except("a")
+                .isEqualTo(TestData("a", "a"))
+        }
+        assertThat(error).hasMessageThat().contains("Compared using fields : [b]")
+        assertThat(error).hasMessageThat()
+            .contains("TestData.b            : expected: <a> but was: <b>")
+    }
+
+    @Test
+    fun comparingAllFields_isNotEqualTo_success() {
+        VERIFY.about(fields())
+            .that(TestData("a", "b"))
+            .comparingAllFields()
+            .isNotEqualTo(TestData("a", "a"))
+    }
+
+    @Test
+    fun comparingAllFields_isNotEqualTo_failure() {
+        val error = assertFailsWith<VerificationError> {
+            VERIFY.about(fields())
+                .that(TestData("a", "b"))
+                .comparingAllFields()
+                .isNotEqualTo(TestData("a", "b"))
+        }
+        assertThat(error).hasMessageThat().contains("Compared using fields: [a, b]")
+        assertThat(error).hasMessageThat().contains("expected not to be   : TestData(a=a, b=b)")
+        assertThat(error).hasMessageThat().contains("but was              : TestData(a=a, b=b)")
+    }
+
+    @Test
+    fun comparingFields_isNotEqualTo_success() {
+        VERIFY.about(fields())
+            .that(TestData("a", "b"))
+            .comparingFields("b")
+            .isNotEqualTo(TestData("a", "a"))
+    }
+
+    @Test
+    fun comparingFields_isNotEqualTo_failure() {
+        val error = assertFailsWith<VerificationError> {
+            VERIFY.about(fields())
+                .that(TestData("a", "b"))
+                .comparingFields("b")
+                .isNotEqualTo(TestData("a", "b"))
+        }
+        assertThat(error).hasMessageThat().contains("Compared using fields: [b]")
+        assertThat(error).hasMessageThat().contains("expected not to be   : TestData(a=a, b=b)")
+        assertThat(error).hasMessageThat().contains("but was              : TestData(a=a, b=b)")
+    }
+
+    @Test
+    fun comparingFieldsExcept_isNotEqualTo_success() {
+        VERIFY.about(fields())
+            .that(TestData("a", "b"))
+            .comparingAllFields()
+            .except("a")
+            .isNotEqualTo(TestData("a", "a"))
+    }
+
+    @Test
+    fun comparingFieldsExcept_isNotEqualTo_failure() {
+        val error = assertFailsWith<VerificationError> {
+            VERIFY.about(fields())
+                .that(TestData("a", "b"))
+                .comparingAllFields()
+                .except("b")
+                .isNotEqualTo(TestData("a", "a"))
+        }
+        assertThat(error).hasMessageThat().contains("Compared using fields: [a]")
+        assertThat(error).hasMessageThat().contains("expected not to be   : TestData(a=a, b=a)")
+        assertThat(error).hasMessageThat().contains("but was              : TestData(a=a, b=b)")
+    }
+
+    abstract class A(protected val a: String)
+    class B(a: String, val b: String) : A(a) {
+        override fun toString() = "B(a=$a, b=$b)"
+        override fun equals(other: Any?) =
+            a::class == b::class && a == (other as B).a && b == other.b
+
+        override fun hashCode() =
+            0 // For testing, this is never used as a key in a hashtable in production.
+    }
+
+    @Test
+    fun comparingAllFields_isEqualTo_inherited_types_success() {
+        VERIFY.about(fields())
+            .that(B("a", "b"))
+            .comparingAllFields()
+            .isEqualTo(B("a", "b"))
+    }
+
+    @Test
+    fun comparingAllFields_isEqualTo_inherited_types_failure() {
+        val error = assertFailsWith<VerificationError> {
+            VERIFY.about(fields())
+                .that(B("a", "b"))
+                .comparingAllFields()
+                .isEqualTo(B("q", "a"))
+        }
+
+        assertThat(error).hasMessageThat().contains("Compared using fields : [b, a]")
+        assertThat(error).hasMessageThat()
+            .contains("B.b                   : expected: <a> but was: <b>")
+        assertThat(error).hasMessageThat()
+            .contains("A.a                   : expected: <q> but was: <a>")
+    }
+
+    data class Foo(val b: B)
+    data class Bar(val foo: Foo, val q: String)
+    data class Blah(val bar: Bar)
+
+    @Test
+    fun comparingAllFields_recursively_isEqualTo_success() {
+        VERIFY.about(fields())
+            .that(Blah(Bar(Foo(B("some_A", "some_B")), "q")))
+            .comparingAllFields()
+            .recursively()
+            .isEqualTo(Blah(Bar(Foo(B("some_A", "some_B")), "q")))
+    }
+
+    @Test
+    fun comparingAllFields_recursively_isEqualTo_failure() {
+        val error = assertFailsWith<VerificationError> {
+            VERIFY.about(fields())
+                .that(Blah(Bar(Foo(B("A", "B")), "q")))
+                .comparingAllFields()
+                .recursively(respectDeclaredEquals = false)
+                .isEqualTo(Blah(Bar(Foo(B("NotA", "B")), "a")))
+        }
+        assertThat(error).hasMessageThat()
+            .contains("Blah.bar.foo.b.a : expected: <NotA> but was: <A>")
+        assertThat(error).hasMessageThat().contains("Blah.bar.q       : expected: <a> but was: <q>")
+    }
+
+    class Cycle(var a: TestA? = null, val data: String) {
+        override fun equals(that: Any?) = that is Cycle && data == that.data && a === that.a
+        override fun hashCode() = 1000003 xor data.hashCode()
+        override fun toString() = "Cycle(data=$data, a=TestA@${a.hashCode()}"
+    }
+
+    data class TestA(val b: TestB)
+    data class TestB(val c: Cycle)
+
+    @Test
+    fun comparingAllFields_recursively_WithCycles_simple() {
+        val actual = TestA(TestB(Cycle(data = "foo")))
+        val expected = TestA(TestB(Cycle(data = "foo")))
+
+        // make the cycles
+        actual.b.c.a = actual
+        expected.b.c.a = expected
+
+        VERIFY.about(fields())
+            .that(actual)
+            .comparingAllFields()
+            .recursively(respectDeclaredEquals = false)
+            .isEqualTo(expected)
+    }
+
+    @Test
+    fun comparingAllFields_recursively_WithCycles_cross_cycle() {
+        val actual = TestA(TestB(Cycle(data = "foo")))
+        val expected = TestA(TestB(Cycle(data = "foo")))
+
+        // Make a cross-cycle
+        actual.b.c.a = expected
+        expected.b.c.a = actual
+
+        // This technically succeeds, because the cross cycle makes both identical, just starting
+        // at different parts in the cycle.  But since they're the same type, and they loop around,
+        // they're the same, field-by-field.
+        VERIFY.about(fields())
+            .that(actual)
+            .comparingAllFields()
+            .recursively(respectDeclaredEquals = false)
+            .isEqualTo(expected)
+    }
+
+    @Test
+    fun comparingAllFields_recursively_WithCycles_cross_cycle_different_start() {
+        val actual = TestA(TestB(Cycle(data = "foo")))
+        val expected = TestB(Cycle(data = "foo"))
+        val expectedA = TestA(expected)
+
+        // Make a cross-cycle
+        actual.b.c.a = expectedA
+        expected.c.a = actual
+
+        // This fails, despite being the same object as the above, because of the different types
+        // under consideration.  The internal cycle has implications on hashcode/equals/tostring,
+        // thought, so these are manually tweaked to avoid infinite cycles, as Truth relies on
+        // having valid (non-infinitely recursing) implementations of these.
+        val error = assertFailsWith<VerificationError> {
+            VERIFY.about(fields())
+                .that(actual)
+                .comparingAllFields()
+                .recursively()
+                .isEqualTo(expected)
+        }
+        // Trimmed off the hashcode from the error message.
+        assertThat(error).hasMessageThat()
+            .contains("expected           : TestB(c=Cycle(data=foo, a=TestA@")
+        assertThat(error).hasMessageThat()
+            .contains("but was            : TestA(b=TestB(c=Cycle(data=foo, a=TestA@")
+    }
+
+    sealed class State {
+        abstract val abstractField: String
+        data class StateA(val state: Int, override val abstractField: String) : State()
+        data class StateB(val state: Int, override val abstractField: String) : State()
+    }
+
+    /*
+     * For now, we don't support inter-type comparisons by field, which unfortunately rules out
+     * certain use of abstract properties (because the field in A is not the same as the field in
+     * B).
+     *
+     * This could be fixed for kotlin properties with kotlin reflection using properties as a first
+     * class item, or it could be fixed by getting the get<property>() accessor and preferring that.
+     * For now, however, it's out of scope. This will catch type inconsistencies.
+     */
+    @Test
+    fun comparingAllFields_isEqualTo_abstract_properties_error() {
+        val error = assertFailsWith<VerificationError> {
+            VERIFY.about(fields())
+                .that(State.StateA(1, "bar"))
+                .comparingAllFields()
+                .isEqualTo(State.StateB(1, "foo"))
+        }
+        assertThat(error).hasMessageThat()
+            .contains("expected           : StateB(state=1, abstractField=foo)")
+        assertThat(error).hasMessageThat()
+            .contains("but was            : StateA(state=1, abstractField=bar)")
+    }
+
+    data class Stateful(val state: State)
+
+    @Test
+    fun comparingAllFields_isEqualTo_abstract_properties_error_deep() {
+        val error = assertFailsWith<VerificationError> {
+            VERIFY.about(fields())
+                .that(Stateful(State.StateA(1, "bar")))
+                .comparingAllFields()
+                .isEqualTo(Stateful(State.StateB(1, "foo")))
+        }
+        assertThat(error).hasMessageThat().contains("Compared using fields : [state]")
+        assertThat(error).hasMessageThat()
+            .contains(
+                "Stateful.state        : expected: <StateB(state=1, abstractField=foo)> " +
+                        "but was: <StateA(state=1, abstractField=bar)>"
+            )
+    }
+
+    @Test
+    fun comparingAllFields_recursively_isEqualTo_collection() {
+        class Holder(@Suppress("unused") val collection: Collection<String>)
+
+        val holder = Holder(LinkedList())
+
+        // Different list types are equal.
+        VERIFY.about(fields())
+            .that(Holder(ArrayList()))
+            .comparingAllFields()
+            .recursively()
+            .isEqualTo(holder)
+
+        // List with one element is unequal.
+        assertFailsWith<VerificationError> {
+            VERIFY.about(fields())
+                .that(Holder(LinkedList<String>().apply { add("1 element") }))
+                .comparingAllFields()
+                .recursively()
+                .isEqualTo(holder)
+        }.let { assertThat(it).hasMessageThat() }.also {
+            it.contains("Some fields failed to match:")
+            it.contains("expected: <[]> but was: <[1 element]>")
+        }
+
+        // Set is unequal.
+        assertFailsWith<VerificationError> {
+            VERIFY.about(fields())
+                .that(Holder(emptySet()))
+                .comparingAllFields()
+                .recursively()
+                .isEqualTo(holder)
+        }.let { assertThat(it).hasMessageThat() }.also {
+            it.contains("Some fields failed to match:")
+            it.contains(
+                "expected: <[]> (class: class java.util.LinkedList) but was: <[]> " +
+                        "(class: class kotlin.collections.EmptySet)"
+            )
+        }
+    }
+
+    @Suppress("unused")
+    @Test
+    fun comparingAllFields_recursively_respects_declared_equals_method() {
+        data class InnerWithEquals(val string: String) {
+            override fun equals(other: Any?): Boolean = true
+            override fun hashCode(): Int = 0
+        }
+
+        class HolderWithEquals(val inner: InnerWithEquals)
+
+        class InnerWithoutEquals(val string: String)
+        class HolderWithoutEquals(val inner: InnerWithoutEquals)
+
+        // Uses the custom equals() method and is always equal
+        VERIFY.about(fields())
+            .that(HolderWithEquals(InnerWithEquals("hello")))
+            .comparingAllFields()
+            .recursively()
+            .isEqualTo(HolderWithEquals(InnerWithEquals("world")))
+
+        // List with one element is unequal.
+        assertFailsWith<VerificationError> {
+            VERIFY.about(fields())
+                .that(HolderWithoutEquals(InnerWithoutEquals("hello")))
+                .comparingAllFields()
+                .recursively()
+                .isEqualTo(HolderWithoutEquals(InnerWithoutEquals("world")))
+        }.let { assertThat(it).hasMessageThat() }
+            .also {
+                it.contains("expected: <world> but was: <hello>")
+            }
+    }
+}

--- a/extensions/fields/src/test/java/com/google/common/truth/extensions/fields/TruthSubjectTesting.kt
+++ b/extensions/fields/src/test/java/com/google/common/truth/extensions/fields/TruthSubjectTesting.kt
@@ -1,0 +1,42 @@
+/*
+ * License Copyright 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+@file:JvmName("TruthSubjectTesting")
+
+package com.google.common.truth.extensions.fields
+
+import com.google.common.truth.FailureStrategy
+import com.google.common.truth.StandardSubjectBuilder
+import java.lang.RuntimeException
+
+/**
+ * A separate class of error, separate from AssertionError while testing Truth subject
+ * implementations so as to not create incorrect test expectations.  VerificationException isn't a
+ * known or thrown exception type, so it won't be confused for a false failure.
+ *
+ * WARNING: This should only ever be used to test Truth Subject implementations. General users of
+ * Truth should not use this mechanism.
+ */
+class VerificationError(cause: Throwable) : RuntimeException(cause)
+
+private val THROW_VERIFICATION_ERROR: FailureStrategy =
+    FailureStrategy { failure -> throw VerificationError(failure) }
+
+/**
+ * When testing [com.google.common.truth.Subject] implementations, use [VERIFY].that() instead of
+ * assertThat() to avoid mistaking an expected AssertionError to be a failure of the Subject
+ * implementation, vs. a real test failure.
+ */
+@JvmField
+internal val VERIFY: StandardSubjectBuilder =
+    StandardSubjectBuilder.forCustomFailureStrategy(THROW_VERIFICATION_ERROR)

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -22,5 +22,6 @@
     <module>re2j</module>
     <module>liteproto</module>
     <module>proto</module>
+    <module>fields</module>
   </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <guava.version>27.0.1</guava.version>
     <gwt.version>2.8.2</gwt.version>
     <protobuf.version>3.6.1</protobuf.version>
+    <kotlin.version>1.3.41</kotlin.version>
     <!-- Property for protobuf-lite protocArtifact, which isn't a "normal" Maven dep. -->
     <protobuf-lite.protoc.version>3.1.0</protobuf-lite.protoc.version>
     <!-- Property for protobuf-java protocArtifact, which ought to be the same as protobuf.version but can't be internally at the moment. -->
@@ -125,6 +126,21 @@
             <artifactId>truth-java8-extension</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>${kotlin.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-jdk8</artifactId>
+        <version>${kotlin.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-test</artifactId>
+        <version>${kotlin.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.errorprone</groupId>


### PR DESCRIPTION
This is written in Kotlin and depends on kotlin runtime as a result, however is designed to work cleanly from Java, and its kotlin origins should not be paritcularly noticeable to the test-writing developer.

The tests handle single object testing (via the Subject) and list element comparisons using a Correspondence. Field comparisons can be shallow or deep, and can respect (in the deep case) declared `equals()` methods or ignore them.  It also can handle reference cycles (with caveats).

This is upstreamed from Square, Inc. and licensed under Apache 2.0.

Addresses #560 