### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/Correspondence.java
+++ b/core/src/main/java/com/google/common/truth/Correspondence.java
@@ -749,6 +749,19 @@ public abstract class Correspondence<A, E> {
   @Override
   public abstract String toString();
 
+  /** Returns a {@link Fact} describing how this correspondence compares elements of an iterable. */
+  final Fact describeForIterable() {
+    return fact("testing whether", "actual element " + this + " expected element");
+  }
+
+  /**
+   * Returns a {@link Fact} describing how this correspondence compares values in a map (or
+   * multimap).
+   */
+  final Fact describeForMapValues() {
+    return fact("testing whether", "expected element " + this + " actual element");
+  }
+
   /**
    * @throws UnsupportedOperationException always
    * @deprecated {@link Object#equals(Object)} is not supported. If you meant to compare objects

--- a/core/src/test/java/com/google/common/truth/CorrespondenceTest.java
+++ b/core/src/test/java/com/google/common/truth/CorrespondenceTest.java
@@ -475,11 +475,11 @@ public final class CorrespondenceTest extends BaseSubjectTestCase {
         .that(ImmutableList.of(1.02, 2.04, 3.08))
         .comparingElementsUsing(tolerance(0.05))
         .contains(3.01);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1.02, 2.04, 3.08]> contains at least one element that "
-                + "is a finite number within 0.05 of <3.01>");
+    assertFailureKeys("expected to contain", "testing whether", "but did not", "full contents");
+    assertFailureValue("expected to contain", "3.01");
+    assertFailureValue(
+        "testing whether", "actual element is a finite number within 0.05 of expected element");
+    assertFailureValue("full contents", "[1.02, 2.04, 3.08]");
   }
 
   // Tests of formattingDiffsUsing.

--- a/core/src/test/java/com/google/common/truth/IterableSubjectCorrespondenceTest.java
+++ b/core/src/test/java/com/google/common/truth/IterableSubjectCorrespondenceTest.java
@@ -70,11 +70,10 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
         .that(actual)
         .comparingElementsUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .contains(2345);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[not a number, +123, +456, +789]> contains at least one element that"
-                + " parses to <2345>");
+    assertFailureKeys("expected to contain", "testing whether", "but did not", "full contents");
+    assertFailureValue("expected to contain", "2345");
+    assertFailureValue("testing whether", "actual element parses to expected element");
+    assertFailureValue("full contents", "[not a number, +123, +456, +789]");
   }
 
   @Test
@@ -88,8 +87,10 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
         .contains("DEF");
     // We fail with the more helpful failure message about the missing value, not the NPE.
     assertFailureKeys(
-        "Not true that <[abc, null, ghi]> contains at least one element that "
-            + "equals (ignoring case) <DEF>",
+        "expected to contain",
+        "testing whether",
+        "but did not",
+        "full contents",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
     assertThatFailure()
@@ -111,11 +112,11 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
     assertFailureKeys(
         "one or more exceptions were thrown while comparing elements",
         "first exception",
-        "comparing contents by testing that at least one element equals (ignoring case) "
-            + "the expected value",
         "expected to contain",
-        "but was");
-    assertFailureValue("expected to contain", "GHI");
+        "testing whether",
+        "found match (but failing because of exception)",
+        "full contents");
+    assertFailureValue("found match (but failing because of exception)", "ghi");
     assertThatFailure()
         .factValue("first exception")
         .startsWith("compare(null, GHI) threw java.lang.NullPointerException");
@@ -137,13 +138,46 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
         .comparingElementsUsing(RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10)
         .displayingDiffsPairedBy(RECORD_ID)
         .contains(expected);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "Not true that <[1/100, 2/211, 4/400, 2/189, none/999]> contains at least one element "
-                + "that has the same id as and a score within 10 of <2/200>. It did contain the "
-                + "following elements with the correct key: "
-                + "<[2/211 (diff: score:11), 2/189 (diff: score:-11)]>");
+    assertFailureKeys(
+        "expected to contain",
+        "testing whether",
+        "but did not",
+        "though it did contain elements with correct key (2)",
+        "#1",
+        "diff",
+        "#2",
+        "diff",
+        "---",
+        "full contents");
+    assertFailureValue("#1", "2/211");
+    assertFailureValueIndexed("diff", 0, "score:11");
+    assertFailureValue("#2", "2/189");
+    assertFailureValueIndexed("diff", 1, "score:-11");
+  }
+
+  @Test
+  public void displayingDiffsPairedBy_1arg_contains_noDiff() {
+    Record expected = Record.create(2, 200);
+    ImmutableList<Record> actual =
+        ImmutableList.of(
+            Record.create(1, 100),
+            Record.create(2, 211),
+            Record.create(4, 400),
+            Record.create(2, 189),
+            Record.createWithoutId(999));
+    expectFailure
+        .whenTesting()
+        .that(actual)
+        .comparingElementsUsing(RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10_NO_DIFF)
+        .displayingDiffsPairedBy(RECORD_ID)
+        .contains(expected);
+    assertFailureKeys(
+        "expected to contain",
+        "testing whether",
+        "but did not",
+        "though it did contain elements with correct key (2)",
+        "full contents");
+    assertFailureValue("though it did contain elements with correct key (2)", "[2/211, 2/189]");
   }
 
   @Test
@@ -157,8 +191,10 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
         .displayingDiffsPairedBy(RECORD_ID)
         .contains(expected);
     assertFailureKeys(
-        "Not true that <[1/100, null, 4/400]> contains at least one element that has the same id "
-            + "as and a score within 10 of <0/999>",
+        "expected to contain",
+        "testing whether",
+        "but did not",
+        "full contents",
         "additionally, one or more exceptions were thrown while keying elements for pairing",
         "first exception");
     assertThatFailure()
@@ -177,8 +213,10 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
         .displayingDiffsPairedBy(RECORD_ID)
         .contains(null);
     assertFailureKeys(
-        "Not true that <[1/100, 2/200, 4/400]> contains at least one element that has the same id "
-            + "as and a score within 10 of <null>",
+        "expected to contain",
+        "testing whether",
+        "but did not",
+        "full contents",
         "additionally, one or more exceptions were thrown while keying elements for pairing",
         "first exception");
     assertThatFailure()
@@ -197,9 +235,11 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
         .displayingDiffsPairedBy(NULL_SAFE_RECORD_ID)
         .contains(expected);
     assertFailureKeys(
-        "Not true that <[1/100, null, 4/400]> contains at least one element that has the same id "
-            + "as and a score within 10 of <0/999>. It did contain the following elements with "
-            + "the correct key: <[null]>",
+        "expected to contain",
+        "testing whether",
+        "but did not",
+        "though it did contain elements with correct key (1)",
+        "full contents",
         "additionally, one or more exceptions were thrown while formatting diffs",
         "first exception");
     assertThatFailure()
@@ -224,7 +264,10 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
         .comparingElementsUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .contains(456);
     assertFailureKeys(
-        "Not true that <[valid, 123]> contains at least one element that parses to <456>",
+        "expected to contain",
+        "testing whether",
+        "but did not",
+        "full contents",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
     assertThatFailure()

--- a/core/src/test/java/com/google/common/truth/PrimitiveDoubleArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveDoubleArraySubjectTest.java
@@ -169,14 +169,13 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(array(1.1, INTOLERABLE_2POINT2, 3.3))
         .usingTolerance(DEFAULT_TOLERANCE)
         .contains(2.2);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "value of: array.asList()\nNot true that <[1.1, "
-                + INTOLERABLE_2POINT2
-                + ", 3.3]> contains at least one element that is a finite number within "
-                + DEFAULT_TOLERANCE
-                + " of <2.2>");
+    assertFailureKeys(
+        "value of", "expected to contain", "testing whether", "but did not", "full contents");
+    assertFailureValue("expected to contain", "2.2");
+    assertFailureValue(
+        "testing whether",
+        "actual element is a finite number within " + DEFAULT_TOLERANCE + " of expected element");
+    assertFailureValue("full contents", "[1.1, " + INTOLERABLE_2POINT2 + ", 3.3]");
   }
 
   @Test
@@ -184,14 +183,10 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(array(1.1, POSITIVE_INFINITY, 3.3))
         .usingTolerance(DEFAULT_TOLERANCE)
         .contains(POSITIVE_INFINITY);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "value of: array.asList()\nNot true that <[1.1, Infinity, 3.3]> "
-                + "contains at least one element that is "
-                + "a finite number within "
-                + DEFAULT_TOLERANCE
-                + " of <Infinity>");
+    assertFailureKeys(
+        "value of", "expected to contain", "testing whether", "but did not", "full contents");
+    assertFailureValue("expected to contain", "Infinity");
+    assertFailureValue("full contents", "[1.1, Infinity, 3.3]");
   }
 
   @Test
@@ -199,14 +194,10 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(array(1.1, NaN, 3.3))
         .usingTolerance(DEFAULT_TOLERANCE)
         .contains(NaN);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "value of: array.asList()\nNot true that <[1.1, NaN, 3.3]> "
-                + "contains at least one element that is "
-                + "a finite number within "
-                + DEFAULT_TOLERANCE
-                + " of <NaN>");
+    assertFailureKeys(
+        "value of", "expected to contain", "testing whether", "but did not", "full contents");
+    assertFailureValue("expected to contain", "NaN");
+    assertFailureValue("full contents", "[1.1, NaN, 3.3]");
   }
 
   @Test
@@ -254,10 +245,10 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
         .contains(null);
     assertFailureKeys(
         "value of",
-        "Not true that <[1.1, 2.2, 3.3]> contains at least one element that is a finite number "
-            + "within "
-            + DEFAULT_TOLERANCE
-            + " of <null>",
+        "expected to contain",
+        "testing whether",
+        "but did not",
+        "full contents",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
     assertThatFailure()
@@ -439,12 +430,11 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
   @Test
   public void usingExactEquality_contains_failure() {
     expectFailureWhenTestingThat(array(1.1, OVER_2POINT2, 3.3)).usingExactEquality().contains(2.2);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "value of: array.asList()\nNot true that <[1.1, "
-                + OVER_2POINT2
-                + ", 3.3]> contains at least one element that is exactly equal to <2.2>");
+    assertFailureKeys(
+        "value of", "expected to contain", "testing whether", "but did not", "full contents");
+    assertFailureValue("expected to contain", "2.2");
+    assertFailureValue("testing whether", "actual element is exactly equal to expected element");
+    assertFailureValue("full contents", "[1.1, " + OVER_2POINT2 + ", 3.3]");
   }
 
   @Test
@@ -465,11 +455,13 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(array(1.1, 2.2, 3.3)).usingExactEquality().contains(expected);
     assertFailureKeys(
         "value of",
-        "Not true that <[1.1, 2.2, 3.3]> contains at least one element that is exactly equal to <"
-            + expected
-            + ">",
+        "expected to contain",
+        "testing whether",
+        "but did not",
+        "full contents",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
+    assertFailureValue("expected to contain", Long.toString(expected));
     assertThatFailure()
         .factValue("first exception")
         .startsWith("compare(1.1, " + expected + ") threw java.lang.IllegalArgumentException");
@@ -488,11 +480,13 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(array(1.1, 2.2, 3.3)).usingExactEquality().contains(expected);
     assertFailureKeys(
         "value of",
-        "Not true that <[1.1, 2.2, 3.3]> contains at least one element that is exactly equal to <"
-            + expected
-            + ">",
+        "expected to contain",
+        "testing whether",
+        "but did not",
+        "full contents",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
+    assertFailureValue("expected to contain", "2");
     assertThatFailure()
         .factValue("first exception")
         .startsWith("compare(1.1, " + expected + ") threw java.lang.IllegalArgumentException");
@@ -510,11 +504,13 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(array(1.1, 2.2, 3.3)).usingExactEquality().contains(expected);
     assertFailureKeys(
         "value of",
-        "Not true that <[1.1, 2.2, 3.3]> contains at least one element that is exactly equal to <"
-            + expected
-            + ">",
+        "expected to contain",
+        "testing whether",
+        "but did not",
+        "full contents",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
+    assertFailureValue("expected to contain", expected.toString());
     assertThatFailure()
         .factValue("first exception")
         .startsWith("compare(1.1, " + expected + ") threw java.lang.IllegalArgumentException");
@@ -539,20 +535,15 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
   @Test
   public void usingExactEquality_contains_failureWithNegativeZero() {
     expectFailureWhenTestingThat(array(1.1, -0.0, 3.3)).usingExactEquality().contains(0.0);
+    assertFailureKeys(
+        "value of", "expected to contain", "testing whether", "but did not", "full contents");
     /*
      * TODO(cpovirk): Find a way to print "0.0" rather than 0 in the error, even under GWT. One
      * easy(?) hack would be to make UsingCorrespondence use Platform.doubleToString() when
      * applicable. Or maybe Correspondence implementations should be able to provide custom string
      * conversions, similar to how we plan to let them render their own diffs.
      */
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            "value of: array.asList()\nNot true that <[1.1, -0.0, 3.3]> "
-                + "contains at least one element that is "
-                + "exactly equal to <"
-                + 0.0
-                + ">");
+    assertFailureValue("expected to contain", Double.toString(0.0));
   }
 
   @Test
@@ -560,10 +551,13 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(array(1.1, 2.2, 3.3)).usingExactEquality().contains(null);
     assertFailureKeys(
         "value of",
-        "Not true that <[1.1, 2.2, 3.3]> contains at least one element that is exactly equal to "
-            + "<null>",
+        "expected to contain",
+        "testing whether",
+        "but did not",
+        "full contents",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
+    assertFailureValue("expected to contain", "null");
     assertThatFailure()
         .factValue("first exception")
         .startsWith("compare(1.1, null) threw java.lang.NullPointerException");

--- a/core/src/test/java/com/google/common/truth/PrimitiveFloatArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveFloatArraySubjectTest.java
@@ -27,7 +27,6 @@ import static org.junit.Assert.fail;
 import com.google.common.annotations.GwtIncompatible;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -159,14 +158,15 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(array(1.0f, INTOLERABLE_TWO, 3.0f))
         .usingTolerance(DEFAULT_TOLERANCE)
         .contains(2.0f);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            lenientFormat(
-                "value of: array.asList()\nNot true that <[%s, %s, %s]> "
-                    + "contains at least one element that is a finite "
-                    + "number within %s of <%s>",
-                1.0f, INTOLERABLE_TWO, 3.0f, (double) DEFAULT_TOLERANCE, 2.0f));
+    assertFailureKeys(
+        "value of", "expected to contain", "testing whether", "but did not", "full contents");
+    assertFailureValue("expected to contain", Float.toString(2.0f));
+    assertFailureValue(
+        "testing whether",
+        "actual element is a finite number within "
+            + (double) DEFAULT_TOLERANCE
+            + " of expected element");
+    assertFailureValue("full contents", "[" + 1.0f + ", " + INTOLERABLE_TWO + ", " + 3.0f + "]");
   }
 
   @Test
@@ -174,14 +174,10 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(array(1.0f, POSITIVE_INFINITY, 3.0f))
         .usingTolerance(DEFAULT_TOLERANCE)
         .contains(POSITIVE_INFINITY);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            lenientFormat(
-                "value of: array.asList()\nNot true that <[%s, Infinity, %s]> "
-                    + "contains at least one element that is "
-                    + "a finite number within %s of <Infinity>",
-                1.0f, 3.0f, (double) DEFAULT_TOLERANCE));
+    assertFailureKeys(
+        "value of", "expected to contain", "testing whether", "but did not", "full contents");
+    assertFailureValue("expected to contain", "Infinity");
+    assertFailureValue("full contents", "[" + 1.0f + ", Infinity, " + 3.0f + "]");
   }
 
   @Test
@@ -189,14 +185,10 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(array(1.0f, NaN, 3.0f))
         .usingTolerance(DEFAULT_TOLERANCE)
         .contains(NaN);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            lenientFormat(
-                "value of: array.asList()\nNot true that <[%s, NaN, %s]> "
-                    + "contains at least one element that is "
-                    + "a finite number within %s of <NaN>",
-                1.0f, 3.0f, (double) DEFAULT_TOLERANCE));
+    assertFailureKeys(
+        "value of", "expected to contain", "testing whether", "but did not", "full contents");
+    assertFailureValue("expected to contain", "NaN");
+    assertFailureValue("full contents", "[" + 1.0f + ", NaN, " + 3.0f + "]");
   }
 
   @Test
@@ -246,12 +238,10 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(actual).usingTolerance(DEFAULT_TOLERANCE).contains(null);
     assertFailureKeys(
         "value of",
-        "Not true that <"
-            + Arrays.toString(actual)
-            + "> contains at least one element that is a finite number "
-            + "within "
-            + (double) DEFAULT_TOLERANCE
-            + " of <null>",
+        "expected to contain",
+        "testing whether",
+        "but did not",
+        "full contents",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
     assertThatFailure()
@@ -446,14 +436,11 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(array(1.0f, JUST_OVER_2POINT2, 3.0f))
         .usingExactEquality()
         .contains(2.2f);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            lenientFormat(
-                "value of: array.asList()\nNot true that <[%s, %s, %s]> "
-                    + "contains at least one element "
-                    + "that is exactly equal to <%s>",
-                1.0f, JUST_OVER_2POINT2, 3.0f, 2.2f));
+    assertFailureKeys(
+        "value of", "expected to contain", "testing whether", "but did not", "full contents");
+    assertFailureValue("expected to contain", Float.toString(2.2f));
+    assertFailureValue("testing whether", "actual element is exactly equal to expected element");
+    assertFailureValue("full contents", "[" + 1.0f + ", " + JUST_OVER_2POINT2 + ", " + 3.0f + "]");
   }
 
   @Test
@@ -473,11 +460,10 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(actual).usingExactEquality().contains(expected);
     assertFailureKeys(
         "value of",
-        "Not true that <"
-            + Arrays.toString(actual)
-            + "> contains at least one element that is exactly equal to <"
-            + expected
-            + ">",
+        "expected to contain",
+        "testing whether",
+        "but did not",
+        "full contents",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
     assertThatFailure()
@@ -504,13 +490,13 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(actual).usingExactEquality().contains(expected);
     assertFailureKeys(
         "value of",
-        "Not true that <"
-            + Arrays.toString(actual)
-            + "> contains at least one element that is exactly equal to <"
-            + expected
-            + ">",
+        "expected to contain",
+        "testing whether",
+        "but did not",
+        "full contents",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
+    assertFailureValue("expected to contain", Long.toString(expected));
     assertThatFailure()
         .factValue("first exception")
         .startsWith(
@@ -535,11 +521,10 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(actual).usingExactEquality().contains(expected);
     assertFailureKeys(
         "value of",
-        "Not true that <"
-            + Arrays.toString(actual)
-            + "> contains at least one element that is exactly equal to <"
-            + expected
-            + ">",
+        "expected to contain",
+        "testing whether",
+        "but did not",
+        "full contents",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
     assertThatFailure()
@@ -564,13 +549,13 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(actual).usingExactEquality().contains(expected);
     assertFailureKeys(
         "value of",
-        "Not true that <"
-            + Arrays.toString(actual)
-            + "> contains at least one element that is exactly equal to <"
-            + expected
-            + ">",
+        "expected to contain",
+        "testing whether",
+        "but did not",
+        "full contents",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
+    assertFailureValue("expected to contain", "2");
     assertThatFailure()
         .factValue("first exception")
         .startsWith(
@@ -594,13 +579,13 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(actual).usingExactEquality().contains(expected);
     assertFailureKeys(
         "value of",
-        "Not true that <"
-            + Arrays.toString(actual)
-            + "> contains at least one element that is exactly equal to <"
-            + expected
-            + ">",
+        "expected to contain",
+        "testing whether",
+        "but did not",
+        "full contents",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
+    assertFailureValue("expected to contain", expected.toString());
     assertThatFailure()
         .factValue("first exception")
         .startsWith(
@@ -632,14 +617,9 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
   @Test
   public void usingExactEquality_contains_failureWithNegativeZero() {
     expectFailureWhenTestingThat(array(1.0f, -0.0f, 3.0f)).usingExactEquality().contains(0.0f);
-    assertThat(expectFailure.getFailure())
-        .hasMessageThat()
-        .isEqualTo(
-            lenientFormat(
-                "value of: array.asList()\nNot true that <[%s, -0.0, %s]> "
-                    + "contains at least one element that is "
-                    + "exactly equal to <%s>",
-                1.0f, 3.0f, 0.0f));
+    assertFailureKeys(
+        "value of", "expected to contain", "testing whether", "but did not", "full contents");
+    assertFailureValue("expected to contain", Float.toString(0.0f));
   }
 
   @Test
@@ -648,12 +628,13 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(actual).usingExactEquality().contains(null);
     assertFailureKeys(
         "value of",
-        "Not true that <"
-            + Arrays.toString(actual)
-            + "> contains at least one element that is exactly equal to "
-            + "<null>",
+        "expected to contain",
+        "testing whether",
+        "but did not",
+        "full contents",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
+    assertFailureValue("expected to contain", "null");
     assertThatFailure()
         .factValue("first exception")
         .startsWith("compare(" + actual[0] + ", null) threw java.lang.NullPointerException");

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/IterableOfProtosSubjectTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/IterableOfProtosSubjectTest.java
@@ -239,7 +239,7 @@ public class IterableOfProtosSubjectTest extends ProtoSubjectTestBase {
         .ignoringFields(ignoreFieldNumber)
         .contains(eqRepeatedMessage1);
     expectThatFailure()
-        .hasMessageThat()
+        .factValue("testing whether")
         .contains(
             "is equivalent according to "
                 + "assertThat(proto)"
@@ -411,7 +411,7 @@ public class IterableOfProtosSubjectTest extends ProtoSubjectTestBase {
         .ignoringRepeatedFieldOrder()
         .contains(message2);
     expectThatFailure()
-        .hasMessageThat()
+        .factValue("testing whether")
         .contains(
             "assertThat(proto).withPartialScope(FieldScopes.fromSetFields({o_int: 3\n"
                 + "r_string: \"baz\"\n"
@@ -426,7 +426,7 @@ public class IterableOfProtosSubjectTest extends ProtoSubjectTestBase {
         .ignoringFieldAbsence()
         .contains(message2);
     expectThatFailure()
-        .hasMessageThat()
+        .factValue("testing whether")
         .contains(
             "assertThat(proto)"
                 + ".ignoringRepeatedFieldOrder()"
@@ -445,7 +445,7 @@ public class IterableOfProtosSubjectTest extends ProtoSubjectTestBase {
         .reportingMismatchesOnly()
         .contains(message2);
     expectThatFailure()
-        .hasMessageThat()
+        .factValue("testing whether")
         .contains(
             "assertThat(proto)"
                 + ".ignoringFields("


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update IterableSubject.UsingCorrespondence.contains() to fail using structured facts.

The basic pattern follows IterableSubject.contains().

65e6c751543ea9610aa4d28ebda186a183935c31