### PR TITLE
Fix Javadoc link to vararg method

### DIFF
--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -98,7 +98,7 @@ public class Subject {
 
   /**
    * Constructor for use by subclasses. If you want to create an instance of this class itself, call
-   * {@link Subject#check(String, Object..) check(...)}{@code .that(actual)}.
+   * {@link Subject#check(String, Object...) check(...)}{@code .that(actual)}.
    */
   protected Subject(FailureMetadata metadata, @NullableDecl Object actual) {
     this(metadata, actual, /*typeDescriptionOverride=*/ null);


### PR DESCRIPTION
It seems to be the only such instance in this file, but I haven't check the rest of the project.