### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/IterableSubject.java
+++ b/core/src/main/java/com/google/common/truth/IterableSubject.java
@@ -1063,8 +1063,7 @@ public class IterableSubject extends Subject {
           facts(
                   fact("expected to contain", expected),
                   correspondence.describeForIterable(),
-                  simpleFact("but did not"),
-                  subject.fullContents())
+                  subject.butWas())
               .and(exceptions.describeAsAdditionalInfo()));
     }
 

--- a/core/src/test/java/com/google/common/truth/CorrespondenceTest.java
+++ b/core/src/test/java/com/google/common/truth/CorrespondenceTest.java
@@ -475,11 +475,11 @@ public final class CorrespondenceTest extends BaseSubjectTestCase {
         .that(ImmutableList.of(1.02, 2.04, 3.08))
         .comparingElementsUsing(tolerance(0.05))
         .contains(3.01);
-    assertFailureKeys("expected to contain", "testing whether", "but did not", "full contents");
+    assertFailureKeys("expected to contain", "testing whether", "but was");
     assertFailureValue("expected to contain", "3.01");
     assertFailureValue(
         "testing whether", "actual element is a finite number within 0.05 of expected element");
-    assertFailureValue("full contents", "[1.02, 2.04, 3.08]");
+    assertFailureValue("but was", "[1.02, 2.04, 3.08]");
   }
 
   // Tests of formattingDiffsUsing.

--- a/core/src/test/java/com/google/common/truth/IterableSubjectCorrespondenceTest.java
+++ b/core/src/test/java/com/google/common/truth/IterableSubjectCorrespondenceTest.java
@@ -70,10 +70,10 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
         .that(actual)
         .comparingElementsUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .contains(2345);
-    assertFailureKeys("expected to contain", "testing whether", "but did not", "full contents");
+    assertFailureKeys("expected to contain", "testing whether", "but was");
     assertFailureValue("expected to contain", "2345");
     assertFailureValue("testing whether", "actual element parses to expected element");
-    assertFailureValue("full contents", "[not a number, +123, +456, +789]");
+    assertFailureValue("but was", "[not a number, +123, +456, +789]");
   }
 
   @Test
@@ -89,8 +89,7 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
     assertFailureKeys(
         "expected to contain",
         "testing whether",
-        "but did not",
-        "full contents",
+        "but was",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
     assertThatFailure()
@@ -193,8 +192,7 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
     assertFailureKeys(
         "expected to contain",
         "testing whether",
-        "but did not",
-        "full contents",
+        "but was",
         "additionally, one or more exceptions were thrown while keying elements for pairing",
         "first exception");
     assertThatFailure()
@@ -215,8 +213,7 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
     assertFailureKeys(
         "expected to contain",
         "testing whether",
-        "but did not",
-        "full contents",
+        "but was",
         "additionally, one or more exceptions were thrown while keying elements for pairing",
         "first exception");
     assertThatFailure()
@@ -266,8 +263,7 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
     assertFailureKeys(
         "expected to contain",
         "testing whether",
-        "but did not",
-        "full contents",
+        "but was",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
     assertThatFailure()

--- a/core/src/test/java/com/google/common/truth/PrimitiveDoubleArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveDoubleArraySubjectTest.java
@@ -169,13 +169,12 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(array(1.1, INTOLERABLE_2POINT2, 3.3))
         .usingTolerance(DEFAULT_TOLERANCE)
         .contains(2.2);
-    assertFailureKeys(
-        "value of", "expected to contain", "testing whether", "but did not", "full contents");
+    assertFailureKeys("value of", "expected to contain", "testing whether", "but was");
     assertFailureValue("expected to contain", "2.2");
     assertFailureValue(
         "testing whether",
         "actual element is a finite number within " + DEFAULT_TOLERANCE + " of expected element");
-    assertFailureValue("full contents", "[1.1, " + INTOLERABLE_2POINT2 + ", 3.3]");
+    assertFailureValue("but was", "[1.1, " + INTOLERABLE_2POINT2 + ", 3.3]");
   }
 
   @Test
@@ -183,10 +182,9 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(array(1.1, POSITIVE_INFINITY, 3.3))
         .usingTolerance(DEFAULT_TOLERANCE)
         .contains(POSITIVE_INFINITY);
-    assertFailureKeys(
-        "value of", "expected to contain", "testing whether", "but did not", "full contents");
+    assertFailureKeys("value of", "expected to contain", "testing whether", "but was");
     assertFailureValue("expected to contain", "Infinity");
-    assertFailureValue("full contents", "[1.1, Infinity, 3.3]");
+    assertFailureValue("but was", "[1.1, Infinity, 3.3]");
   }
 
   @Test
@@ -194,10 +192,9 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(array(1.1, NaN, 3.3))
         .usingTolerance(DEFAULT_TOLERANCE)
         .contains(NaN);
-    assertFailureKeys(
-        "value of", "expected to contain", "testing whether", "but did not", "full contents");
+    assertFailureKeys("value of", "expected to contain", "testing whether", "but was");
     assertFailureValue("expected to contain", "NaN");
-    assertFailureValue("full contents", "[1.1, NaN, 3.3]");
+    assertFailureValue("but was", "[1.1, NaN, 3.3]");
   }
 
   @Test
@@ -247,8 +244,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
         "value of",
         "expected to contain",
         "testing whether",
-        "but did not",
-        "full contents",
+        "but was",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
     assertThatFailure()
@@ -430,11 +426,10 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
   @Test
   public void usingExactEquality_contains_failure() {
     expectFailureWhenTestingThat(array(1.1, OVER_2POINT2, 3.3)).usingExactEquality().contains(2.2);
-    assertFailureKeys(
-        "value of", "expected to contain", "testing whether", "but did not", "full contents");
+    assertFailureKeys("value of", "expected to contain", "testing whether", "but was");
     assertFailureValue("expected to contain", "2.2");
     assertFailureValue("testing whether", "actual element is exactly equal to expected element");
-    assertFailureValue("full contents", "[1.1, " + OVER_2POINT2 + ", 3.3]");
+    assertFailureValue("but was", "[1.1, " + OVER_2POINT2 + ", 3.3]");
   }
 
   @Test
@@ -457,8 +452,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
         "value of",
         "expected to contain",
         "testing whether",
-        "but did not",
-        "full contents",
+        "but was",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
     assertFailureValue("expected to contain", Long.toString(expected));
@@ -482,8 +476,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
         "value of",
         "expected to contain",
         "testing whether",
-        "but did not",
-        "full contents",
+        "but was",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
     assertFailureValue("expected to contain", "2");
@@ -506,8 +499,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
         "value of",
         "expected to contain",
         "testing whether",
-        "but did not",
-        "full contents",
+        "but was",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
     assertFailureValue("expected to contain", expected.toString());
@@ -535,8 +527,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
   @Test
   public void usingExactEquality_contains_failureWithNegativeZero() {
     expectFailureWhenTestingThat(array(1.1, -0.0, 3.3)).usingExactEquality().contains(0.0);
-    assertFailureKeys(
-        "value of", "expected to contain", "testing whether", "but did not", "full contents");
+    assertFailureKeys("value of", "expected to contain", "testing whether", "but was");
     /*
      * TODO(cpovirk): Find a way to print "0.0" rather than 0 in the error, even under GWT. One
      * easy(?) hack would be to make UsingCorrespondence use Platform.doubleToString() when
@@ -553,8 +544,7 @@ public class PrimitiveDoubleArraySubjectTest extends BaseSubjectTestCase {
         "value of",
         "expected to contain",
         "testing whether",
-        "but did not",
-        "full contents",
+        "but was",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
     assertFailureValue("expected to contain", "null");

--- a/core/src/test/java/com/google/common/truth/PrimitiveFloatArraySubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/PrimitiveFloatArraySubjectTest.java
@@ -158,15 +158,14 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(array(1.0f, INTOLERABLE_TWO, 3.0f))
         .usingTolerance(DEFAULT_TOLERANCE)
         .contains(2.0f);
-    assertFailureKeys(
-        "value of", "expected to contain", "testing whether", "but did not", "full contents");
+    assertFailureKeys("value of", "expected to contain", "testing whether", "but was");
     assertFailureValue("expected to contain", Float.toString(2.0f));
     assertFailureValue(
         "testing whether",
         "actual element is a finite number within "
             + (double) DEFAULT_TOLERANCE
             + " of expected element");
-    assertFailureValue("full contents", "[" + 1.0f + ", " + INTOLERABLE_TWO + ", " + 3.0f + "]");
+    assertFailureValue("but was", "[" + 1.0f + ", " + INTOLERABLE_TWO + ", " + 3.0f + "]");
   }
 
   @Test
@@ -174,10 +173,9 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(array(1.0f, POSITIVE_INFINITY, 3.0f))
         .usingTolerance(DEFAULT_TOLERANCE)
         .contains(POSITIVE_INFINITY);
-    assertFailureKeys(
-        "value of", "expected to contain", "testing whether", "but did not", "full contents");
+    assertFailureKeys("value of", "expected to contain", "testing whether", "but was");
     assertFailureValue("expected to contain", "Infinity");
-    assertFailureValue("full contents", "[" + 1.0f + ", Infinity, " + 3.0f + "]");
+    assertFailureValue("but was", "[" + 1.0f + ", Infinity, " + 3.0f + "]");
   }
 
   @Test
@@ -185,10 +183,9 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(array(1.0f, NaN, 3.0f))
         .usingTolerance(DEFAULT_TOLERANCE)
         .contains(NaN);
-    assertFailureKeys(
-        "value of", "expected to contain", "testing whether", "but did not", "full contents");
+    assertFailureKeys("value of", "expected to contain", "testing whether", "but was");
     assertFailureValue("expected to contain", "NaN");
-    assertFailureValue("full contents", "[" + 1.0f + ", NaN, " + 3.0f + "]");
+    assertFailureValue("but was", "[" + 1.0f + ", NaN, " + 3.0f + "]");
   }
 
   @Test
@@ -240,8 +237,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         "value of",
         "expected to contain",
         "testing whether",
-        "but did not",
-        "full contents",
+        "but was",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
     assertThatFailure()
@@ -436,11 +432,10 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat(array(1.0f, JUST_OVER_2POINT2, 3.0f))
         .usingExactEquality()
         .contains(2.2f);
-    assertFailureKeys(
-        "value of", "expected to contain", "testing whether", "but did not", "full contents");
+    assertFailureKeys("value of", "expected to contain", "testing whether", "but was");
     assertFailureValue("expected to contain", Float.toString(2.2f));
     assertFailureValue("testing whether", "actual element is exactly equal to expected element");
-    assertFailureValue("full contents", "[" + 1.0f + ", " + JUST_OVER_2POINT2 + ", " + 3.0f + "]");
+    assertFailureValue("but was", "[" + 1.0f + ", " + JUST_OVER_2POINT2 + ", " + 3.0f + "]");
   }
 
   @Test
@@ -462,8 +457,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         "value of",
         "expected to contain",
         "testing whether",
-        "but did not",
-        "full contents",
+        "but was",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
     assertThatFailure()
@@ -492,8 +486,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         "value of",
         "expected to contain",
         "testing whether",
-        "but did not",
-        "full contents",
+        "but was",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
     assertFailureValue("expected to contain", Long.toString(expected));
@@ -523,8 +516,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         "value of",
         "expected to contain",
         "testing whether",
-        "but did not",
-        "full contents",
+        "but was",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
     assertThatFailure()
@@ -551,8 +543,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         "value of",
         "expected to contain",
         "testing whether",
-        "but did not",
-        "full contents",
+        "but was",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
     assertFailureValue("expected to contain", "2");
@@ -581,8 +572,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         "value of",
         "expected to contain",
         "testing whether",
-        "but did not",
-        "full contents",
+        "but was",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
     assertFailureValue("expected to contain", expected.toString());
@@ -617,8 +607,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
   @Test
   public void usingExactEquality_contains_failureWithNegativeZero() {
     expectFailureWhenTestingThat(array(1.0f, -0.0f, 3.0f)).usingExactEquality().contains(0.0f);
-    assertFailureKeys(
-        "value of", "expected to contain", "testing whether", "but did not", "full contents");
+    assertFailureKeys("value of", "expected to contain", "testing whether", "but was");
     assertFailureValue("expected to contain", Float.toString(0.0f));
   }
 
@@ -630,8 +619,7 @@ public class PrimitiveFloatArraySubjectTest extends BaseSubjectTestCase {
         "value of",
         "expected to contain",
         "testing whether",
-        "but did not",
-        "full contents",
+        "but was",
         "additionally, one or more exceptions were thrown while comparing elements",
         "first exception");
     assertFailureValue("expected to contain", "null");


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Slight tweak to make IterableSubject.UsingCorrespondence.contains() failures more like IterableSubject.contains().

The non-fuzzy version only includes a "but did not" fact and replaces the "but was" fact with a "full contents" fact when there is a "though it did contain" fact. This change makes the fuzzy version behave the same way.

Note that it still says "full contents" in the "found match (but failing because of exception)" case, since "but was" seems wrong for this case.

335ebe667461624ab8d216ebeb9ff29255baa784