### PR TITLE
Add ComparableSubject.isNotEquivalentAccordingToCompareTo().

### DIFF
--- a/core/src/main/java/com/google/common/truth/ComparableSubject.java
+++ b/core/src/main/java/com/google/common/truth/ComparableSubject.java
@@ -51,15 +51,28 @@ public abstract class ComparableSubject<T extends Comparable> extends Subject {
   }
 
   /**
-   * Checks that the subject is equivalent to {@code other} according to {@link
+   * Checks that the subject is equivalent to {@code expected} according to {@link
    * Comparable#compareTo}, (i.e., checks that {@code a.comparesTo(b) == 0}).
    *
    * <p><b>Note:</b> Do not use this method for checking object equality. Instead, use {@link
-   * #isEqualTo(Object)}.
+   * Subject#isEqualTo(Object)}.
    */
   public void isEquivalentAccordingToCompareTo(T expected) {
     if (actual.compareTo(expected) != 0) {
       failWithActual("expected value that sorts equal to", expected);
+    }
+  }
+
+  /**
+   * Checks that the subject is not equivalent to {@code expected} according to {@link
+   * Comparable#compareTo}, (i.e., checks that {@code a.comparesTo(b) != 0}).
+   *
+   * <p><b>Note:</b> Do not use this method for checking object equality. Instead, use {@link
+   * Subject#isNotEqualTo(Object)}.
+   */
+  public void isNotEquivalentAccordingToCompareTo(T expected) {
+    if (actual.compareTo(expected) == 0) {
+      failWithActual("expected value that does not sort equal to", expected);
     }
   }
 

--- a/core/src/test/java/com/google/common/truth/ComparableSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/ComparableSubjectTest.java
@@ -96,6 +96,16 @@ public class ComparableSubjectTest extends BaseSubjectTestCase {
     assertFailureValue("expected value that sorts equal to", "abcd");
   }
 
+  @Test
+  public void isNotEquivalentAccordingToCompareTo() {
+    assertThat(new StringComparedByLength("abc"))
+        .isNotEquivalentAccordingToCompareTo(new StringComparedByLength("abcd"));
+
+    expectFailureWhenTestingThat(new StringComparedByLength("abc"))
+        .isNotEquivalentAccordingToCompareTo(new StringComparedByLength("xyz"));
+    assertFailureValue("expected value that does not sort equal to", "xyz");
+  }
+
   private static final class StringComparedByLength implements Comparable<StringComparedByLength> {
     private final String value;
 


### PR DESCRIPTION
This method is missed by authors attempting to test a new
implementation of Comparable.

Fixes #615