### PR TITLE
Moe Sync

### DIFF
--- a/refactorings/src/main/java/com/google/common/truth/refactorings/FailWithFacts.java
+++ b/refactorings/src/main/java/com/google/common/truth/refactorings/FailWithFacts.java
@@ -88,7 +88,7 @@ public final class FailWithFacts extends BugChecker implements MethodInvocationT
     if (newVerb == null) {
       return NO_MATCH;
     }
-    String newVerbQuoted = state.getTreeMaker().Literal(newVerb).toString();
+    String newVerbQuoted = state.getElements().getConstantExpression(newVerb);
     if (ONE_ARG_FAIL.matches(tree, state)) {
       fix.addStaticImport("com.google.common.truth.Fact.simpleFact");
       fix.replace(oldVerbArg, format("simpleFact(%s)", newVerbQuoted));


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Use Elements.getConstantExpression to create a string literal instead of TreeMaker.Literal.toString() (fixes TreeToString violation)

3770ce0bb226fe1e287854568b06633b9135cfa1