### PR TITLE
Moe Sync

### DIFF
--- a/core/src/test/java/com/google/common/truth/StringSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/StringSubjectTest.java
@@ -399,6 +399,28 @@ public class StringSubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure()).factKeys().contains("(case is ignored)");
   }
 
+  @Test
+  public void trailingWhitespaceInActual() {
+    expectFailureWhenTestingThat("foo\n").isEqualTo("foo");
+    assertFailureKeys("expected", "but contained extra trailing whitespace");
+    assertFailureValue("but contained extra trailing whitespace", "\\n");
+  }
+
+  @Test
+  public void trailingWhitespaceInExpected() {
+    expectFailureWhenTestingThat("foo").isEqualTo("foo ");
+    assertFailureKeys("expected", "but was missing trailing whitespace");
+    assertFailureValue("but was missing trailing whitespace", "␣");
+  }
+
+  @Test
+  public void trailingWhitespaceInBoth() {
+    expectFailureWhenTestingThat("foo \n").isEqualTo("foo\u00a0");
+    assertFailureKeys("expected", "with trailing whitespace", "but trailing whitespace was");
+    assertFailureValue("with trailing whitespace", "\\u00a0");
+    assertFailureValue("but trailing whitespace was", "␣\\n");
+  }
+
   private StringSubject expectFailureWhenTestingThat(String actual) {
     return expectFailure.whenTesting().that(actual);
   }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Identify trailing whitespace in failed string comparisons.

RELNOTES=Changed failure messages to identify trailing whitespace in failed string comparisons.

cba958b6c793fe58aa1b5f95ad4f2db38388097a