### PR TITLE
Moe Sync

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,16 @@ description: "Fluent assertions for Java and Android"
 
 themeColor: purple
 
-exclude: [_site, CHANGELOG.md, LICENSE, README.md, Gemfile, Gemfile.lock]
+exclude:
+  - CHANGELOG.md
+  - Gemfile
+  - Gemfile.lock
+  - LICENSE
+  - README.md
+  - _site
+  - node_modules
+  - vendor
+
 sass:
   style: compressed
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Exclude `vendor` directory.

Without this exclusion, I see an error when running Jekyll locally:

Error: could not read file /tmp/tmp.a3kNObetW4/vendor/bundle/ruby/2.5.0/gems/jekyll-3.6.2/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb: Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/bundle/ruby/2.5.0/gems/jekyll-3.6.2/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.

That led me to https://github.com/jekyll/jekyll/issues/5267#issuecomment-241379902 and the solution.

I followed links from there to https://jekyllrb.com/docs/troubleshooting/#configuration-problems, which suggests also excluding `node_modules`. I don't think we have such a directory currently, but we might as well follow the defaults?

f595f2d2c9a765344b4407452d058607c7a872dc