### PR TITLE
Special-cases equality testing empty strings against non-empty strings.

### DIFF
--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -836,8 +836,9 @@ public class Subject {
     boolean equal = difference.valuesAreEqual();
     // TODO(cpovirk): Call attention to differing trailing whitespace.
 
-    if (equalityCheck == EqualityCheck.EQUAL && tryFailForTrailingWhitespaceOnly(expected)) {
-      // tryFailForTrailingWhitespaceOnly reported a failure, so we're done.
+    if (equalityCheck == EqualityCheck.EQUAL
+        && (tryFailForTrailingWhitespaceOnly(expected) || tryFailForEmptyString(expected))) {
+      // tryFailForTrailingWhitespaceOnly or tryFailForEmptyString reported a failure, so we're done
       return;
     }
 
@@ -939,6 +940,29 @@ public class Subject {
       default:
         return new String(asUnicodeHexEscape(c));
     }
+  }
+
+  /**
+   * Checks whether the actual and expected values are empty strings. If so, reports a failure and
+   * returns true.
+   */
+  private boolean tryFailForEmptyString(Object expected) {
+    if (!(actual instanceof String) || !(expected instanceof String)) {
+      return false;
+    }
+
+    String actualString = (String) actual;
+    String expectedString = (String) expected;
+    if (actualString.equals("")) {
+      failWithoutActual(fact("expected", expectedString), simpleFact("but was an empty string"));
+      return true;
+    } else if (expectedString.equals("")) {
+      failWithoutActual(simpleFact("expected an empty string"), fact("but was", actualString));
+      return true;
+    }
+
+    // Neither string was empty
+    return false;
   }
 
   // From SourceCodeEscapers:

--- a/core/src/test/java/com/google/common/truth/StringSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/StringSubjectTest.java
@@ -139,6 +139,18 @@ public class StringSubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
+  public void stringEqualityToEmpty() {
+    expectFailureWhenTestingThat("abc").isEqualTo("");
+    assertFailureKeys("expected an empty string", "but was");
+  }
+
+  @Test
+  public void stringEqualityEmptyToNonEmpty() {
+    expectFailureWhenTestingThat("").isEqualTo("abc");
+    assertFailureKeys("expected", "but was an empty string");
+  }
+
+  @Test
   public void stringEqualityFail() {
     expectFailureWhenTestingThat("abc").isEqualTo("ABC");
     assertThat(expectFailure.getFailure()).isInstanceOf(ComparisonFailureWithFacts.class);


### PR DESCRIPTION
Now prints "expected an empty string" or "but was an empty string" instead of "expected: " or "but was: "

Resolves #623 