### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/common/truth/Subject.java
+++ b/core/src/main/java/com/google/common/truth/Subject.java
@@ -834,10 +834,10 @@ public class Subject {
     // TODO(cpovirk): Handle "same class name, different class loader."
     // `equal` is always false for isEqualTo, but it varies for isSameInstanceAs:
     boolean equal = difference.valuesAreEqual();
-    // TODO(cpovirk): Call attention to differing trailing whitespace.
 
-    if (equalityCheck == EqualityCheck.EQUAL && tryFailForTrailingWhitespaceOnly(expected)) {
-      // tryFailForTrailingWhitespaceOnly reported a failure, so we're done.
+    if (equalityCheck == EqualityCheck.EQUAL
+        && (tryFailForTrailingWhitespaceOnly(expected) || tryFailForEmptyString(expected))) {
+      // tryFailForTrailingWhitespaceOnly or tryFailForEmptyString reported a failure, so we're done
       return;
     }
 
@@ -939,6 +939,29 @@ public class Subject {
       default:
         return new String(asUnicodeHexEscape(c));
     }
+  }
+
+  /**
+   * Checks whether the actual and expected values are empty strings. If so, reports a failure and
+   * returns true.
+   */
+  private boolean tryFailForEmptyString(Object expected) {
+    if (!(actual instanceof String) || !(expected instanceof String)) {
+      return false;
+    }
+
+    String actualString = (String) actual;
+    String expectedString = (String) expected;
+    if (actualString.isEmpty()) {
+      failWithoutActual(fact("expected", expectedString), simpleFact("but was an empty string"));
+      return true;
+    } else if (expectedString.isEmpty()) {
+      failWithoutActual(simpleFact("expected an empty string"), fact("but was", actualString));
+      return true;
+    }
+
+    // Neither string was empty
+    return false;
   }
 
   // From SourceCodeEscapers:

--- a/core/src/test/java/com/google/common/truth/StringSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/StringSubjectTest.java
@@ -139,6 +139,18 @@ public class StringSubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
+  public void stringEqualityToEmpty() {
+    expectFailureWhenTestingThat("abc").isEqualTo("");
+    assertFailureKeys("expected an empty string", "but was");
+  }
+
+  @Test
+  public void stringEqualityEmptyToNonEmpty() {
+    expectFailureWhenTestingThat("").isEqualTo("abc");
+    assertFailureKeys("expected", "but was an empty string");
+  }
+
+  @Test
   public void stringEqualityFail() {
     expectFailureWhenTestingThat("abc").isEqualTo("ABC");
     assertThat(expectFailure.getFailure()).isInstanceOf(ComparisonFailureWithFacts.class);
@@ -419,6 +431,18 @@ public class StringSubjectTest extends BaseSubjectTestCase {
     assertFailureKeys("expected", "with trailing whitespace", "but trailing whitespace was");
     assertFailureValue("with trailing whitespace", "\\u00a0");
     assertFailureValue("but trailing whitespace was", "␣\\n");
+  }
+
+  @Test
+  public void trailingWhitespaceVsEmptyString() {
+    /*
+     * The code has special cases for both trailing whitespace and an empty string. Make sure that
+     * it specifically reports the trailing whitespace. (It might be nice to *also* report the empty
+     * string specially, but that's less important.)
+     */
+    expectFailureWhenTestingThat("\t").isEqualTo("");
+    assertFailureKeys("expected", "but contained extra trailing whitespace");
+    assertFailureValue("but contained extra trailing whitespace", "\\t");
   }
 
   private StringSubject expectFailureWhenTestingThat(String actual) {

--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,7 @@
               <!-- TODO(cpovirk): Link to the version that we depend on? -->
               <link>https://google.github.io/guava/releases/snapshot-jre/api/docs</link>
               <link>https://developers.google.com/protocol-buffers/docs/reference/java</link>
+              <link>https://junit.org/junit4/javadoc/latest/</link>
             </links>
             <source>8</source>
           </configuration>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Link to JUnit Javadoc.

9abbf7353bbac5182cd00d23ef5d2da630173173

-------

<p> Special-cases equality testing empty strings against non-empty strings.

Now prints "expected an empty string" or "but was an empty
string" instead of "expected: " or "but was: ".

Fixes #624

3c59f0c5f31a97c1bd021a2a324a1d0986a9b3a6