### PR TITLE
Javadoc: fix invalid `@link`s to `hasValueThat()`

### DIFF
--- a/extensions/java8/src/main/java/com/google/common/truth/OptionalDoubleSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/OptionalDoubleSubject.java
@@ -62,7 +62,7 @@ public final class OptionalDoubleSubject extends Subject {
    * Fails if the {@link OptionalDouble} does not have the given value or the subject is null. This
    * method is <i>not</i> recommended when the code under test is doing any kind of arithmetic,
    * since the exact result of floating point arithmetic is sensitive to apparently trivial changes.
-   * More sophisticated comparisons can be done using {@link #hasValueThat()}. This method is
+   * More sophisticated comparisons can be done using {@code assertThat(optional.getAsDouble())…}. This method is
    * recommended when the code under test is specified as either copying a value without
    * modification from its input or returning a well-defined literal or constant value.
    */

--- a/extensions/java8/src/main/java/com/google/common/truth/OptionalIntSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/OptionalIntSubject.java
@@ -59,7 +59,7 @@ public final class OptionalIntSubject extends Subject {
 
   /**
    * Fails if the {@link OptionalInt} does not have the given value or the subject is null. More
-   * sophisticated comparisons can be done using {@link #hasValueThat()}.
+   * sophisticated comparisons can be done using {@code assertThat(optional.getAsInt())…}.
    */
   public void hasValue(int expected) {
     if (actual == null) {

--- a/extensions/java8/src/main/java/com/google/common/truth/OptionalLongSubject.java
+++ b/extensions/java8/src/main/java/com/google/common/truth/OptionalLongSubject.java
@@ -59,7 +59,7 @@ public final class OptionalLongSubject extends Subject {
 
   /**
    * Fails if the {@link OptionalLong} does not have the given value or the subject is null. More
-   * sophisticated comparisons can be done using {@link #hasValueThat()}.
+   * sophisticated comparisons can be done using {@code assertThat(optional.getAsLong())…}.
    */
   public void hasValue(long expected) {
     if (actual == null) {


### PR DESCRIPTION
`hasValueThat()` has been removed in f6875d6dcb216cecd31555abc90e9537b8130e9c.