### PR TITLE
MOE Sync 2019-11-11

### DIFF
--- a/extensions/liteproto/src/main/java/com/google/common/truth/extensions/proto/LiteProtoSubject.java
+++ b/extensions/liteproto/src/main/java/com/google/common/truth/extensions/proto/LiteProtoSubject.java
@@ -138,12 +138,6 @@ public class LiteProtoSubject extends Subject {
     }
   }
 
-  private static final class LiteProtoAsStringSubject extends Subject {
-    LiteProtoAsStringSubject(FailureMetadata metadata, @NullableDecl String actual) {
-      super(metadata, actual);
-    }
-  }
-
   /**
    * @deprecated A Builder can never compare equal to a MessageLite instance. Use {@code build()},
    *     or {@code buildPartial()} on the argument to get a MessageLite for comparison instead.
@@ -151,6 +145,12 @@ public class LiteProtoSubject extends Subject {
   @Deprecated
   public void isEqualTo(@NullableDecl MessageLite.Builder builder) {
     isEqualTo((Object) builder);
+  }
+
+  private static final class LiteProtoAsStringSubject extends Subject {
+    LiteProtoAsStringSubject(FailureMetadata metadata, @NullableDecl String actual) {
+      super(metadata, actual);
+    }
   }
 
   @Override


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix 1 ErrorProneStyle finding:
* Constructors and methods with the same name should appear sequentially with no other code in between. Please re-order or re-name methods.

b1d0072e59ba4637f7bd3c469df5de7d3d735c60