### PR TITLE
MOE Sync 2019-11-15

### DIFF
--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/FluentEqualityConfig.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/FluentEqualityConfig.java
@@ -34,6 +34,7 @@ import com.google.errorprone.annotations.CheckReturnValue;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
+import com.google.protobuf.TypeRegistry;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
@@ -56,6 +57,7 @@ abstract class FluentEqualityConfig implements FieldScopeLogicContainer<FluentEq
           .setCompareExpectedFieldsOnly(false)
           .setCompareFieldsScope(FieldScopeLogic.all())
           .setReportMismatchesOnly(false)
+          .setUseTypeRegistry(TypeRegistry.getEmptyTypeRegistry())
           .setUsingCorrespondenceStringFunction(Functions.constant(""))
           .build();
 
@@ -100,6 +102,8 @@ abstract class FluentEqualityConfig implements FieldScopeLogicContainer<FluentEq
   abstract FieldScopeLogic compareFieldsScope();
 
   abstract boolean reportMismatchesOnly();
+
+  abstract TypeRegistry useTypeRegistry();
 
   // For pretty-printing, does not affect behavior.
   abstract Function<? super Optional<Descriptor>, String> usingCorrespondenceStringFunction();
@@ -317,6 +321,13 @@ abstract class FluentEqualityConfig implements FieldScopeLogicContainer<FluentEq
         .build();
   }
 
+  final FluentEqualityConfig usingTypeRegistry(TypeRegistry typeRegistry) {
+    return toBuilder()
+        .setUseTypeRegistry(typeRegistry)
+        .addUsingCorrespondenceString(".usingTypeRegistry(" + typeRegistry + ")")
+        .build();
+  }
+
   @Override
   public final FluentEqualityConfig subScope(
       Descriptor rootDescriptor, FieldDescriptorOrUnknown fieldDescriptorOrUnknown) {
@@ -429,6 +440,8 @@ abstract class FluentEqualityConfig implements FieldScopeLogicContainer<FluentEq
     abstract Builder setCompareFieldsScope(FieldScopeLogic fieldScopeLogic);
 
     abstract Builder setReportMismatchesOnly(boolean reportMismatchesOnly);
+
+    abstract Builder setUseTypeRegistry(TypeRegistry typeRegistry);
 
     @CheckReturnValue
     abstract Function<? super Optional<Descriptor>, String> usingCorrespondenceStringFunction();

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosFluentAssertion.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosFluentAssertion.java
@@ -17,6 +17,7 @@ package com.google.common.truth.extensions.proto;
 
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
+import com.google.protobuf.TypeRegistry;
 
 /**
  * Fluent API to perform detailed, customizable comparison of iterables of protocol buffers. The
@@ -459,6 +460,23 @@ public interface IterableOfProtosFluentAssertion<M extends Message>
    * <p>This a purely cosmetic setting, and it has no effect on the behavior of the test.
    */
   IterableOfProtosFluentAssertion<M> reportingMismatchesOnly();
+
+  /**
+   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
+   *
+   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
+   * descriptor for the message's type URL.
+   *
+   * <ul>
+   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
+   *       expected value, respecting any configuration methods used for the assertion.
+   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
+   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
+   * </ul>
+   *
+   * @since 1.1
+   */
+  IterableOfProtosFluentAssertion<M> usingTypeRegistry(TypeRegistry typeRegistry);
 
   /**
    * @deprecated Do not call {@code equals()} on a {@code IterableOfProtosFluentAssertion}.

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosSubject.java
@@ -28,6 +28,7 @@ import com.google.common.truth.Ordered;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
+import com.google.protobuf.TypeRegistry;
 import java.util.Arrays;
 import java.util.Comparator;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
@@ -629,6 +630,25 @@ public class IterableOfProtosSubject<M extends Message> extends IterableSubject 
     return usingConfig(config.reportingMismatchesOnly());
   }
 
+  /**
+   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
+   *
+   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
+   * descriptor for the message's type URL.
+   *
+   * <ul>
+   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
+   *       expected value, respecting any configuration methods used for the assertion.
+   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
+   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
+   * </ul>
+   *
+   * @since 1.1
+   */
+  public IterableOfProtosFluentAssertion<M> usingTypeRegistry(TypeRegistry typeRegistry) {
+    return usingConfig(config.usingTypeRegistry(typeRegistry));
+  }
+
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Overrides for IterableSubject Methods
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -981,6 +1001,11 @@ public class IterableOfProtosSubject<M extends Message> extends IterableSubject 
     @Override
     public IterableOfProtosFluentAssertion<M> reportingMismatchesOnly() {
       return subject.reportingMismatchesOnly();
+    }
+
+    @Override
+    public IterableOfProtosFluentAssertion<M> usingTypeRegistry(TypeRegistry typeRegistry) {
+      return subject.usingTypeRegistry(typeRegistry);
     }
 
     @Override

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesFluentAssertion.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesFluentAssertion.java
@@ -19,6 +19,7 @@ import com.google.common.truth.Ordered;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
+import com.google.protobuf.TypeRegistry;
 import java.util.Map;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
@@ -475,6 +476,23 @@ public interface MapWithProtoValuesFluentAssertion<M extends Message> {
    * <p>This a purely cosmetic setting, and it has no effect on the behavior of the test.
    */
   MapWithProtoValuesFluentAssertion<M> reportingMismatchesOnlyForValues();
+
+  /**
+   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
+   *
+   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
+   * descriptor for the message's type URL.
+   *
+   * <ul>
+   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
+   *       expected value, respecting any configuration methods used for the assertion.
+   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
+   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
+   * </ul>
+   *
+   * @since 1.1
+   */
+  MapWithProtoValuesFluentAssertion<M> usingTypeRegistryForValues(TypeRegistry typeRegistry);
 
   /**
    * Fails if the map does not contain an entry with the given key and a value that corresponds to

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubject.java
@@ -26,6 +26,7 @@ import com.google.common.truth.Ordered;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
+import com.google.protobuf.TypeRegistry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -599,6 +600,26 @@ public class MapWithProtoValuesSubject<M extends Message> extends MapSubject {
     return usingConfig(config.reportingMismatchesOnly());
   }
 
+  /**
+   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
+   *
+   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
+   * descriptor for the message's type URL.
+   *
+   * <ul>
+   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
+   *       expected value, respecting any configuration methods used for the assertion.
+   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
+   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
+   * </ul>
+   *
+   * @since 1.1
+   */
+  public MapWithProtoValuesFluentAssertion<M> usingTypeRegistryForValues(
+      TypeRegistry typeRegistry) {
+    return usingConfig(config.usingTypeRegistry(typeRegistry));
+  }
+
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // UsingCorrespondence Methods
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -819,6 +840,12 @@ public class MapWithProtoValuesSubject<M extends Message> extends MapSubject {
     @Override
     public MapWithProtoValuesFluentAssertion<M> reportingMismatchesOnlyForValues() {
       return subject.reportingMismatchesOnlyForValues();
+    }
+
+    @Override
+    public MapWithProtoValuesFluentAssertion<M> usingTypeRegistryForValues(
+        TypeRegistry typeRegistry) {
+      return subject.usingTypeRegistryForValues(typeRegistry);
     }
 
     @Override

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesFluentAssertion.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesFluentAssertion.java
@@ -20,6 +20,7 @@ import com.google.common.truth.Ordered;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
+import com.google.protobuf.TypeRegistry;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
@@ -476,6 +477,23 @@ public interface MultimapWithProtoValuesFluentAssertion<M extends Message> {
    * <p>This a purely cosmetic setting, and it has no effect on the behavior of the test.
    */
   MultimapWithProtoValuesFluentAssertion<M> reportingMismatchesOnlyForValues();
+
+  /**
+   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
+   *
+   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
+   * descriptor for the message's type URL.
+   *
+   * <ul>
+   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
+   *       expected value, respecting any configuration methods used for the assertion.
+   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
+   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
+   * </ul>
+   *
+   * @since 1.1
+   */
+  MultimapWithProtoValuesFluentAssertion<M> usingTypeRegistryForValues(TypeRegistry typeRegistry);
 
   /**
    * Fails if the multimap does not contain an entry with the given key and a value that corresponds

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubject.java
@@ -29,6 +29,7 @@ import com.google.common.truth.Subject;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
+import com.google.protobuf.TypeRegistry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -621,6 +622,26 @@ public class MultimapWithProtoValuesSubject<M extends Message> extends MultimapS
     return usingConfig(config.reportingMismatchesOnly());
   }
 
+  /**
+   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
+   *
+   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
+   * descriptor for the message's type URL.
+   *
+   * <ul>
+   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
+   *       expected value, respecting any configuration methods used for the assertion.
+   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
+   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
+   * </ul>
+   *
+   * @since 1.1
+   */
+  public MultimapWithProtoValuesFluentAssertion<M> usingTypeRegistryForValues(
+      TypeRegistry typeRegistry) {
+    return usingConfig(config.usingTypeRegistry(typeRegistry));
+  }
+
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // UsingCorrespondence Methods
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -850,6 +871,12 @@ public class MultimapWithProtoValuesSubject<M extends Message> extends MultimapS
     @Override
     public MultimapWithProtoValuesFluentAssertion<M> reportingMismatchesOnlyForValues() {
       return subject.reportingMismatchesOnlyForValues();
+    }
+
+    @Override
+    public MultimapWithProtoValuesFluentAssertion<M> usingTypeRegistryForValues(
+        TypeRegistry typeRegistry) {
+      return subject.usingTypeRegistryForValues(typeRegistry);
     }
 
     @Override

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoFluentAssertion.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoFluentAssertion.java
@@ -17,6 +17,7 @@ package com.google.common.truth.extensions.proto;
 
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
+import com.google.protobuf.TypeRegistry;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
@@ -452,6 +453,23 @@ public interface ProtoFluentAssertion {
    * <p>This a purely cosmetic setting, and it has no effect on the behavior of the test.
    */
   ProtoFluentAssertion reportingMismatchesOnly();
+
+  /**
+   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
+   *
+   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
+   * descriptor for the message's type URL.
+   *
+   * <ul>
+   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
+   *       expected value, respecting any configuration methods used for the assertion.
+   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
+   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
+   * </ul>
+   *
+   * @since 1.1
+   */
+  ProtoFluentAssertion usingTypeRegistry(TypeRegistry typeRegistry);
 
   /**
    * Compares the subject of the assertion to {@code expected}, using all of the rules specified by

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoSubject.java
@@ -26,6 +26,7 @@ import com.google.common.base.Objects;
 import com.google.common.truth.FailureMetadata;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
+import com.google.protobuf.TypeRegistry;
 import java.util.Arrays;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
@@ -576,6 +577,25 @@ public class ProtoSubject extends LiteProtoSubject {
     return usingConfig(config.reportingMismatchesOnly());
   }
 
+  /**
+   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
+   *
+   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
+   * descriptor for the message's type URL.
+   *
+   * <ul>
+   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
+   *       expected value, respecting any configuration methods used for the assertion.
+   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
+   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
+   * </ul>
+   *
+   * @since 1.1
+   */
+  public ProtoFluentAssertion usingTypeRegistry(TypeRegistry typeRegistry) {
+    return usingConfig(config.usingTypeRegistry(typeRegistry));
+  }
+
   private static boolean sameClassMessagesWithDifferentDescriptors(
       @NullableDecl Message actual, @NullableDecl Object expected) {
     if (actual == null
@@ -844,6 +864,11 @@ public class ProtoSubject extends LiteProtoSubject {
     @Override
     public ProtoFluentAssertion reportingMismatchesOnly() {
       return protoSubject.reportingMismatchesOnly();
+    }
+
+    @Override
+    public ProtoFluentAssertion usingTypeRegistry(TypeRegistry typeRegistry) {
+      return protoSubject.usingTypeRegistry(typeRegistry);
     }
 
     @Override

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubjectTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubjectTest.java
@@ -17,6 +17,7 @@
 package com.google.common.truth.extensions.proto;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.truth.MapSubject;
 import com.google.protobuf.Message;
 import java.util.Collection;
 import org.junit.Test;
@@ -245,5 +246,11 @@ public class MapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
         .containsExactly(
             3, TestMessage3.newBuilder().addRString("qux").addRString("baz").build(),
             2, TestMessage2.newBuilder().addRString("bar").addRString("foo").build());
+  }
+
+  @Test
+  public void testMethodNamesEndWithForValues() {
+    checkMethodNamesEndWithForValues(MapWithProtoValuesSubject.class, MapSubject.class);
+    checkMethodNamesEndWithForValues(MapWithProtoValuesFluentAssertion.class, MapSubject.class);
   }
 }

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubjectTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubjectTest.java
@@ -18,6 +18,7 @@ package com.google.common.truth.extensions.proto;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.truth.MultimapSubject;
 import com.google.protobuf.Message;
 import java.util.Collection;
 import org.junit.Test;
@@ -317,5 +318,12 @@ public class MultimapWithProtoValuesSubjectTest extends ProtoSubjectTestBase {
                 TestMessage3.newBuilder().addRString("qux").addRString("baz").build(),
                 2,
                 TestMessage2.newBuilder().addRString("bar").addRString("foo").build()));
+  }
+
+  @Test
+  public void testMethodNamesEndWithForValues() {
+    checkMethodNamesEndWithForValues(MultimapWithProtoValuesSubject.class, MultimapSubject.class);
+    checkMethodNamesEndWithForValues(
+        MultimapWithProtoValuesFluentAssertion.class, MultimapSubject.class);
   }
 }

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTest.java
@@ -20,8 +20,10 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.Any;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.UnknownFieldSet;
@@ -765,5 +767,81 @@ public class ProtoSubjectTest extends ProtoSubjectTestBase {
     expectThatFailure()
         .factValue("but was missing")
         .contains("r_required_string_message[1].required_string");
+  }
+
+  @Test
+  public void testAnyMessagesWithDifferentTypes() {
+    String typeUrl =
+        isProto3()
+            ? "type.googleapis.com/com.google.common.truth.extensions.proto.SubTestMessage3"
+            : "type.googleapis.com/com.google.common.truth.extensions.proto.SubTestMessage2";
+    String diffTypeUrl =
+        isProto3()
+            ? "type.googleapis.com/com.google.common.truth.extensions.proto.SubSubTestMessage3"
+            : "type.googleapis.com/com.google.common.truth.extensions.proto.SubSubTestMessage2";
+
+    Message message = parse("o_any_message: { [" + typeUrl + "]: {r_string: \"foo\"} }");
+    Message diffMessage = parse("o_any_message: { [" + diffTypeUrl + "]: {r_string: \"bar\"} }");
+
+    expectThat(message).usingTypeRegistry(getTypeRegistry()).isNotEqualTo(diffMessage);
+
+    expectFailureWhenTesting()
+        .that(message)
+        .usingTypeRegistry(getTypeRegistry())
+        .isEqualTo(diffMessage);
+    expectThatFailure().hasMessageThat().contains("modified: o_any_message.type_url");
+    expectThatFailure()
+        .hasMessageThat()
+        .containsMatch("modified: o_any_message.value:.*bar.*->.*foo.*");
+  }
+
+  @Test
+  public void testAnyMessageCompareWithEmptyAnyMessage() {
+    String typeUrl =
+        isProto3()
+            ? "type.googleapis.com/com.google.common.truth.extensions.proto.SubTestMessage3"
+            : "type.googleapis.com/com.google.common.truth.extensions.proto.SubTestMessage2";
+
+    Message messageWithAny = parse("o_any_message: { [" + typeUrl + "]: {o_int: 1} }");
+    Message messageWithEmptyAny = parse("o_any_message: { }");
+
+    expectThat(messageWithAny)
+        .usingTypeRegistry(getTypeRegistry())
+        .isNotEqualTo(messageWithEmptyAny);
+    expectThat(messageWithEmptyAny)
+        .usingTypeRegistry(getTypeRegistry())
+        .isNotEqualTo(messageWithAny);
+
+    expectFailureWhenTesting()
+        .that(messageWithAny)
+        .usingTypeRegistry(getTypeRegistry())
+        .isEqualTo(messageWithEmptyAny);
+    expectThatFailure().hasMessageThat().contains("modified: o_any_message.type_url");
+    expectThatFailure().hasMessageThat().contains("modified: o_any_message.value");
+
+    expectFailureWhenTesting()
+        .that(messageWithEmptyAny)
+        .usingTypeRegistry(getTypeRegistry())
+        .isEqualTo(messageWithAny);
+    expectThatFailure().hasMessageThat().contains("modified: o_any_message.type_url");
+    expectThatFailure().hasMessageThat().contains("modified: o_any_message.value");
+  }
+
+  @Test
+  public void testAnyMessageComparedWithDynamicMessage() throws InvalidProtocolBufferException {
+    String typeUrl =
+        isProto3()
+            ? "type.googleapis.com/com.google.common.truth.extensions.proto.SubTestMessage3"
+            : "type.googleapis.com/com.google.common.truth.extensions.proto.SubTestMessage2";
+
+    Message messageWithAny = parse("o_any_message: { [" + typeUrl + "]: {o_int: 1} }");
+    FieldDescriptor fieldDescriptor = getFieldDescriptor("o_any_message");
+    Any message = (Any) messageWithAny.getField(fieldDescriptor);
+    DynamicMessage dynamicMessage =
+        DynamicMessage.parseFrom(
+            Any.getDescriptor(), message.toByteString(), ExtensionRegistry.getEmptyRegistry());
+
+    expectThat(dynamicMessage).usingTypeRegistry(getTypeRegistry()).isEqualTo(message);
+    expectThat(message).usingTypeRegistry(getTypeRegistry()).isEqualTo(dynamicMessage);
   }
 }

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTestBase.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTestBase.java
@@ -31,6 +31,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.TextFormat;
 import com.google.protobuf.TextFormat.ParseException;
+import com.google.protobuf.TypeRegistry;
 import com.google.protobuf.UnknownFieldSet;
 import java.util.Collection;
 import java.util.Map;
@@ -59,12 +60,20 @@ public class ProtoSubjectTestBase {
     public boolean isProto3() {
       return this == PROTO3;
     }
+
   }
+
+  private static final TypeRegistry typeRegistry =
+      TypeRegistry.newBuilder()
+          .add(TestMessage3.getDescriptor())
+          .add(TestMessage2.getDescriptor())
+          .build();
 
   private static final TextFormat.Parser PARSER =
       TextFormat.Parser.newBuilder()
           .setSingularOverwritePolicy(
               TextFormat.Parser.SingularOverwritePolicy.FORBID_SINGULAR_OVERWRITES)
+          .setTypeRegistry(typeRegistry)
           .build();
 
   // For Parameterized testing.
@@ -112,6 +121,10 @@ public class ProtoSubjectTestBase {
 
   protected final int getFieldNumber(String fieldName) {
     return getFieldDescriptor(fieldName).getNumber();
+  }
+
+  protected final TypeRegistry getTypeRegistry() {
+    return typeRegistry;
   }
 
   protected Message parse(String textProto) {

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTestBase.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTestBase.java
@@ -16,15 +16,20 @@
 package com.google.common.truth.extensions.proto;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.common.truth.TruthFailureSubject.truthFailures;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 import com.google.common.truth.Expect;
 import com.google.common.truth.ExpectFailure;
+import com.google.common.truth.Subject;
 import com.google.common.truth.TruthFailureSubject;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -33,8 +38,10 @@ import com.google.protobuf.TextFormat;
 import com.google.protobuf.TextFormat.ParseException;
 import com.google.protobuf.TypeRegistry;
 import com.google.protobuf.UnknownFieldSet;
+import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import org.junit.Rule;
@@ -249,5 +256,27 @@ public class ProtoSubjectTestBase {
       builder.put((K) rest[i], (V) rest[i + 1]);
     }
     return builder.build();
+  }
+
+  final void checkMethodNamesEndWithForValues(
+      Class<?> clazz, Class<? extends Subject> pseudoSuperclass) {
+    // Don't run this test twice.
+    if (!testIsRunOnce()) {
+      return;
+    }
+
+    Set<String> diff = Sets.difference(getMethodNames(clazz), getMethodNames(pseudoSuperclass));
+    assertWithMessage("Found no methods to test. Bug in test?").that(diff).isNotEmpty();
+    for (String methodName : diff) {
+      assertThat(methodName).endsWith("ForValues");
+    }
+  }
+
+  private static ImmutableSet<String> getMethodNames(Class<?> clazz) {
+    ImmutableSet.Builder<String> names = ImmutableSet.builder();
+    for (Method method : clazz.getMethods()) {
+      names.add(method.getName());
+    }
+    return names.build();
   }
 }

--- a/extensions/proto/src/test/proto/test_message2.proto
+++ b/extensions/proto/src/test/proto/test_message2.proto
@@ -2,6 +2,8 @@ syntax = "proto2";
 
 package com.google.common.truth.extensions.proto;
 
+import "google/protobuf/any.proto";
+
 option java_package = "com.google.common.truth.extensions.proto";
 option java_multiple_files = true;
 
@@ -36,6 +38,8 @@ message TestMessage2 {
   optional SubTestMessage2 o_sub_test_message = 15;
   repeated SubTestMessage2 r_sub_test_message = 16;
   map<string, TestMessage2> test_message_map = 17;
+  optional .google.protobuf.Any o_any_message = 18;
+  repeated .google.protobuf.Any r_any_message = 19;
 }
 
 message RequiredStringMessage2 {

--- a/extensions/proto/src/test/proto/test_message3.proto
+++ b/extensions/proto/src/test/proto/test_message3.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package com.google.common.truth.extensions.proto;
 
+import "google/protobuf/any.proto";
+
 option java_package = "com.google.common.truth.extensions.proto";
 option java_multiple_files = true;
 
@@ -36,6 +38,8 @@ message TestMessage3 {
   SubTestMessage3 o_sub_test_message = 15;
   repeated SubTestMessage3 r_sub_test_message = 16;
   map<string, TestMessage3> test_message_map = 17;
+  .google.protobuf.Any o_any_message = 18;
+  repeated .google.protobuf.Any r_any_message = 19;
 }
 
 // message RequiredStringMessage3 {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> ProtoTruth: Unpack Any before comparing

Relnotes:
  - `ProtoTruthMessageDifferencer`: Unpacks Any messages before comparing the unpacked message. Using a user supplied TypeRegister in the FluentEqualityConfig. If the message descriptors can not be found in the TypeRegister that it reverts to the original behaviour of comparing the Any messages value ByteString.
  - `ProtoSubject`: added `usingTypeRegistry(TypeRegistry)` method to allow the user to provide a TypeRegistry for processing the Any fields it encounters.

2ad8985845d13015021e2e1b67951294bc0d3660

-------

<p> Test that all proto-specific methods on the proto Map and Multimap subjects have names ending in "ForValues."

44bd53c1ef1492d815ec04fd81ad2ac3a4e050c0