### PR TITLE
MOE Sync 2019-11-18

### DIFF
--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/FluentEqualityConfig.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/FluentEqualityConfig.java
@@ -34,7 +34,6 @@ import com.google.errorprone.annotations.CheckReturnValue;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
-import com.google.protobuf.TypeRegistry;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
@@ -57,7 +56,6 @@ abstract class FluentEqualityConfig implements FieldScopeLogicContainer<FluentEq
           .setCompareExpectedFieldsOnly(false)
           .setCompareFieldsScope(FieldScopeLogic.all())
           .setReportMismatchesOnly(false)
-          .setUseTypeRegistry(TypeRegistry.getEmptyTypeRegistry())
           .setUsingCorrespondenceStringFunction(Functions.constant(""))
           .build();
 
@@ -102,8 +100,6 @@ abstract class FluentEqualityConfig implements FieldScopeLogicContainer<FluentEq
   abstract FieldScopeLogic compareFieldsScope();
 
   abstract boolean reportMismatchesOnly();
-
-  abstract TypeRegistry useTypeRegistry();
 
   // For pretty-printing, does not affect behavior.
   abstract Function<? super Optional<Descriptor>, String> usingCorrespondenceStringFunction();
@@ -321,13 +317,6 @@ abstract class FluentEqualityConfig implements FieldScopeLogicContainer<FluentEq
         .build();
   }
 
-  final FluentEqualityConfig usingTypeRegistry(TypeRegistry typeRegistry) {
-    return toBuilder()
-        .setUseTypeRegistry(typeRegistry)
-        .addUsingCorrespondenceString(".usingTypeRegistry(" + typeRegistry + ")")
-        .build();
-  }
-
   @Override
   public final FluentEqualityConfig subScope(
       Descriptor rootDescriptor, FieldDescriptorOrUnknown fieldDescriptorOrUnknown) {
@@ -440,8 +429,6 @@ abstract class FluentEqualityConfig implements FieldScopeLogicContainer<FluentEq
     abstract Builder setCompareFieldsScope(FieldScopeLogic fieldScopeLogic);
 
     abstract Builder setReportMismatchesOnly(boolean reportMismatchesOnly);
-
-    abstract Builder setUseTypeRegistry(TypeRegistry typeRegistry);
 
     @CheckReturnValue
     abstract Function<? super Optional<Descriptor>, String> usingCorrespondenceStringFunction();

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosFluentAssertion.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosFluentAssertion.java
@@ -17,7 +17,6 @@ package com.google.common.truth.extensions.proto;
 
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
-import com.google.protobuf.TypeRegistry;
 
 /**
  * Fluent API to perform detailed, customizable comparison of iterables of protocol buffers. The
@@ -460,23 +459,6 @@ public interface IterableOfProtosFluentAssertion<M extends Message>
    * <p>This a purely cosmetic setting, and it has no effect on the behavior of the test.
    */
   IterableOfProtosFluentAssertion<M> reportingMismatchesOnly();
-
-  /**
-   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
-   *
-   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
-   * descriptor for the message's type URL.
-   *
-   * <ul>
-   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
-   *       expected value, respecting any configuration methods used for the assertion.
-   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
-   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
-   * </ul>
-   *
-   * @since 1.1
-   */
-  IterableOfProtosFluentAssertion<M> usingTypeRegistry(TypeRegistry typeRegistry);
 
   /**
    * @deprecated Do not call {@code equals()} on a {@code IterableOfProtosFluentAssertion}.

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosSubject.java
@@ -28,7 +28,6 @@ import com.google.common.truth.Ordered;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
-import com.google.protobuf.TypeRegistry;
 import java.util.Arrays;
 import java.util.Comparator;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
@@ -630,25 +629,6 @@ public class IterableOfProtosSubject<M extends Message> extends IterableSubject 
     return usingConfig(config.reportingMismatchesOnly());
   }
 
-  /**
-   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
-   *
-   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
-   * descriptor for the message's type URL.
-   *
-   * <ul>
-   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
-   *       expected value, respecting any configuration methods used for the assertion.
-   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
-   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
-   * </ul>
-   *
-   * @since 1.1
-   */
-  public IterableOfProtosFluentAssertion<M> usingTypeRegistry(TypeRegistry typeRegistry) {
-    return usingConfig(config.usingTypeRegistry(typeRegistry));
-  }
-
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Overrides for IterableSubject Methods
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1001,11 +981,6 @@ public class IterableOfProtosSubject<M extends Message> extends IterableSubject 
     @Override
     public IterableOfProtosFluentAssertion<M> reportingMismatchesOnly() {
       return subject.reportingMismatchesOnly();
-    }
-
-    @Override
-    public IterableOfProtosFluentAssertion<M> usingTypeRegistry(TypeRegistry typeRegistry) {
-      return subject.usingTypeRegistry(typeRegistry);
     }
 
     @Override

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesFluentAssertion.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesFluentAssertion.java
@@ -19,7 +19,6 @@ import com.google.common.truth.Ordered;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
-import com.google.protobuf.TypeRegistry;
 import java.util.Map;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
@@ -476,23 +475,6 @@ public interface MapWithProtoValuesFluentAssertion<M extends Message> {
    * <p>This a purely cosmetic setting, and it has no effect on the behavior of the test.
    */
   MapWithProtoValuesFluentAssertion<M> reportingMismatchesOnlyForValues();
-
-  /**
-   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
-   *
-   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
-   * descriptor for the message's type URL.
-   *
-   * <ul>
-   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
-   *       expected value, respecting any configuration methods used for the assertion.
-   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
-   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
-   * </ul>
-   *
-   * @since 1.1
-   */
-  MapWithProtoValuesFluentAssertion<M> usingTypeRegistryForValues(TypeRegistry typeRegistry);
 
   /**
    * Fails if the map does not contain an entry with the given key and a value that corresponds to

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubject.java
@@ -26,7 +26,6 @@ import com.google.common.truth.Ordered;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
-import com.google.protobuf.TypeRegistry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -600,26 +599,6 @@ public class MapWithProtoValuesSubject<M extends Message> extends MapSubject {
     return usingConfig(config.reportingMismatchesOnly());
   }
 
-  /**
-   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
-   *
-   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
-   * descriptor for the message's type URL.
-   *
-   * <ul>
-   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
-   *       expected value, respecting any configuration methods used for the assertion.
-   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
-   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
-   * </ul>
-   *
-   * @since 1.1
-   */
-  public MapWithProtoValuesFluentAssertion<M> usingTypeRegistryForValues(
-      TypeRegistry typeRegistry) {
-    return usingConfig(config.usingTypeRegistry(typeRegistry));
-  }
-
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // UsingCorrespondence Methods
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -840,12 +819,6 @@ public class MapWithProtoValuesSubject<M extends Message> extends MapSubject {
     @Override
     public MapWithProtoValuesFluentAssertion<M> reportingMismatchesOnlyForValues() {
       return subject.reportingMismatchesOnlyForValues();
-    }
-
-    @Override
-    public MapWithProtoValuesFluentAssertion<M> usingTypeRegistryForValues(
-        TypeRegistry typeRegistry) {
-      return subject.usingTypeRegistryForValues(typeRegistry);
     }
 
     @Override

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesFluentAssertion.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesFluentAssertion.java
@@ -20,7 +20,6 @@ import com.google.common.truth.Ordered;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
-import com.google.protobuf.TypeRegistry;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
@@ -477,23 +476,6 @@ public interface MultimapWithProtoValuesFluentAssertion<M extends Message> {
    * <p>This a purely cosmetic setting, and it has no effect on the behavior of the test.
    */
   MultimapWithProtoValuesFluentAssertion<M> reportingMismatchesOnlyForValues();
-
-  /**
-   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
-   *
-   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
-   * descriptor for the message's type URL.
-   *
-   * <ul>
-   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
-   *       expected value, respecting any configuration methods used for the assertion.
-   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
-   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
-   * </ul>
-   *
-   * @since 1.1
-   */
-  MultimapWithProtoValuesFluentAssertion<M> usingTypeRegistryForValues(TypeRegistry typeRegistry);
 
   /**
    * Fails if the multimap does not contain an entry with the given key and a value that corresponds

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubject.java
@@ -29,7 +29,6 @@ import com.google.common.truth.Subject;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
-import com.google.protobuf.TypeRegistry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -622,26 +621,6 @@ public class MultimapWithProtoValuesSubject<M extends Message> extends MultimapS
     return usingConfig(config.reportingMismatchesOnly());
   }
 
-  /**
-   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
-   *
-   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
-   * descriptor for the message's type URL.
-   *
-   * <ul>
-   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
-   *       expected value, respecting any configuration methods used for the assertion.
-   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
-   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
-   * </ul>
-   *
-   * @since 1.1
-   */
-  public MultimapWithProtoValuesFluentAssertion<M> usingTypeRegistryForValues(
-      TypeRegistry typeRegistry) {
-    return usingConfig(config.usingTypeRegistry(typeRegistry));
-  }
-
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // UsingCorrespondence Methods
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -871,12 +850,6 @@ public class MultimapWithProtoValuesSubject<M extends Message> extends MultimapS
     @Override
     public MultimapWithProtoValuesFluentAssertion<M> reportingMismatchesOnlyForValues() {
       return subject.reportingMismatchesOnlyForValues();
-    }
-
-    @Override
-    public MultimapWithProtoValuesFluentAssertion<M> usingTypeRegistryForValues(
-        TypeRegistry typeRegistry) {
-      return subject.usingTypeRegistryForValues(typeRegistry);
     }
 
     @Override

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoFluentAssertion.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoFluentAssertion.java
@@ -17,7 +17,6 @@ package com.google.common.truth.extensions.proto;
 
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
-import com.google.protobuf.TypeRegistry;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
@@ -453,23 +452,6 @@ public interface ProtoFluentAssertion {
    * <p>This a purely cosmetic setting, and it has no effect on the behavior of the test.
    */
   ProtoFluentAssertion reportingMismatchesOnly();
-
-  /**
-   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
-   *
-   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
-   * descriptor for the message's type URL.
-   *
-   * <ul>
-   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
-   *       expected value, respecting any configuration methods used for the assertion.
-   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
-   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
-   * </ul>
-   *
-   * @since 1.1
-   */
-  ProtoFluentAssertion usingTypeRegistry(TypeRegistry typeRegistry);
 
   /**
    * Compares the subject of the assertion to {@code expected}, using all of the rules specified by

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoSubject.java
@@ -26,7 +26,6 @@ import com.google.common.base.Objects;
 import com.google.common.truth.FailureMetadata;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
-import com.google.protobuf.TypeRegistry;
 import java.util.Arrays;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
@@ -577,25 +576,6 @@ public class ProtoSubject extends LiteProtoSubject {
     return usingConfig(config.reportingMismatchesOnly());
   }
 
-  /**
-   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
-   *
-   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
-   * descriptor for the message's type URL.
-   *
-   * <ul>
-   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
-   *       expected value, respecting any configuration methods used for the assertion.
-   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
-   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
-   * </ul>
-   *
-   * @since 1.1
-   */
-  public ProtoFluentAssertion usingTypeRegistry(TypeRegistry typeRegistry) {
-    return usingConfig(config.usingTypeRegistry(typeRegistry));
-  }
-
   private static boolean sameClassMessagesWithDifferentDescriptors(
       @NullableDecl Message actual, @NullableDecl Object expected) {
     if (actual == null
@@ -864,11 +844,6 @@ public class ProtoSubject extends LiteProtoSubject {
     @Override
     public ProtoFluentAssertion reportingMismatchesOnly() {
       return protoSubject.reportingMismatchesOnly();
-    }
-
-    @Override
-    public ProtoFluentAssertion usingTypeRegistry(TypeRegistry typeRegistry) {
-      return protoSubject.usingTypeRegistry(typeRegistry);
     }
 
     @Override

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoTruthMessageDifferencer.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoTruthMessageDifferencer.java
@@ -32,18 +32,12 @@ import com.google.common.truth.extensions.proto.DiffResult.RepeatedField;
 import com.google.common.truth.extensions.proto.DiffResult.SingularField;
 import com.google.common.truth.extensions.proto.DiffResult.UnknownFieldSetDiff;
 import com.google.common.truth.extensions.proto.RecursableDiffEntity.WithResultCode.Result;
-import com.google.protobuf.Any;
-import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType;
 import com.google.protobuf.Descriptors.FileDescriptor.Syntax;
-import com.google.protobuf.DynamicMessage;
-import com.google.protobuf.ExtensionRegistry;
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.TextFormat;
-import com.google.protobuf.TypeRegistry;
 import com.google.protobuf.UnknownFieldSet;
 import java.io.IOException;
 import java.util.ArrayDeque;
@@ -95,9 +89,6 @@ final class ProtoTruthMessageDifferencer {
   }
 
   private DiffResult diffMessages(Message actual, Message expected, FluentEqualityConfig config) {
-    if (actual.getDescriptorForType().equals(Any.getDescriptor())) {
-      return diffAnyMessages(actual, expected, config);
-    }
     DiffResult.Builder builder = DiffResult.newBuilder().setActual(actual).setExpected(expected);
 
     // Compare known fields.
@@ -198,94 +189,6 @@ final class ProtoTruthMessageDifferencer {
     }
 
     return builder.build();
-  }
-
-  private DiffResult diffAnyMessages(
-      Message actual, Message expected, FluentEqualityConfig config) {
-    DiffResult.Builder builder = DiffResult.newBuilder().setActual(actual).setExpected(expected);
-
-    // Compare the TypeUrl fields.
-    FieldDescriptor typeUrlField =
-        actual.getDescriptorForType().findFieldByNumber(Any.TYPE_URL_FIELD_NUMBER);
-    FieldDescriptorOrUnknown typeUrlFieldDescriptorOrUnknown =
-        FieldDescriptorOrUnknown.fromFieldDescriptor(typeUrlField);
-    SingularField typeUrlDiffResult =
-        compareSingularPrimitive(
-            actual.getField(typeUrlField),
-            expected.getField(typeUrlField),
-            /* defaultValue= */ "",
-            typeUrlField,
-            name(typeUrlField),
-            config.subScope(rootDescriptor, typeUrlFieldDescriptorOrUnknown));
-    builder.addSingularField(Any.TYPE_URL_FIELD_NUMBER, typeUrlDiffResult);
-
-    // Try to unpack the Any fields using the TypeRegister. If that does not work then we revert to
-    // the original behaviour compare the bytes strings.
-    FieldDescriptor valueFieldDescriptor =
-        actual.getDescriptorForType().findFieldByNumber(Any.VALUE_FIELD_NUMBER);
-    FieldDescriptorOrUnknown valueFieldDescriptorOrUnknown =
-        FieldDescriptorOrUnknown.fromFieldDescriptor(valueFieldDescriptor);
-    TypeRegistry typeRegistry = config.useTypeRegistry();
-    Optional<Message> unpackedActual = unpackAny(actual, typeRegistry);
-    Optional<Message> unpackedExpected = unpackAny(expected, typeRegistry);
-    FieldScopeResult shouldCompare =
-        config.compareFieldsScope().policyFor(rootDescriptor, valueFieldDescriptorOrUnknown);
-    if (unpackedActual.isPresent()
-        && unpackedExpected.isPresent()
-        && descriptorsMatch(unpackedActual.get(), unpackedExpected.get())) {
-      Message defaultMessage = unpackedActual.get().getDefaultInstanceForType();
-      builder.addSingularField(
-          Any.VALUE_FIELD_NUMBER,
-          compareSingularMessage(
-              unpackedActual.get(),
-              unpackedExpected.get(),
-              defaultMessage,
-              shouldCompare == FieldScopeResult.EXCLUDED_NONRECURSIVELY,
-              valueFieldDescriptor,
-              name(valueFieldDescriptor),
-              config.subScope(rootDescriptor, valueFieldDescriptorOrUnknown)));
-    } else {
-      builder.addSingularField(
-          Any.VALUE_FIELD_NUMBER,
-          compareSingularPrimitive(
-              actual.getField(valueFieldDescriptor),
-              expected.getField(valueFieldDescriptor),
-              valueFieldDescriptor.getDefaultValue(),
-              valueFieldDescriptor,
-              name(valueFieldDescriptor),
-              config.subScope(rootDescriptor, valueFieldDescriptorOrUnknown)));
-    }
-
-    // Compare unknown fields.
-    if (!config.ignoreFieldAbsenceScope().isAll()) {
-      UnknownFieldSetDiff diff =
-          diffUnknowns(actual.getUnknownFields(), expected.getUnknownFields(), config);
-      builder.setUnknownFields(diff);
-    }
-
-    return builder.build();
-  }
-
-  private static boolean descriptorsMatch(Message actual, Message expected) {
-    return actual.getDescriptorForType().equals(expected.getDescriptorForType());
-  }
-
-  private static Optional<Message> unpackAny(Message any, TypeRegistry typeRegistry) {
-    String typeUrl =
-        (String) any.getField(Any.getDescriptor().findFieldByNumber(Any.TYPE_URL_FIELD_NUMBER));
-    ByteString value =
-        (ByteString) any.getField(Any.getDescriptor().findFieldByNumber(Any.VALUE_FIELD_NUMBER));
-    try {
-      Descriptor descriptor = typeRegistry.getDescriptorForTypeUrl(typeUrl);
-      if (descriptor == null) {
-        return Optional.absent();
-      }
-      Message defaultMessage =
-          DynamicMessage.parseFrom(descriptor, value, ExtensionRegistry.getEmptyRegistry());
-      return Optional.of(defaultMessage);
-    } catch (InvalidProtocolBufferException e) {
-      return Optional.absent();
-    }
   }
 
   // Helper which takes a proto map in List<Message> form, and converts it to a Map<Object, Object>

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/FieldScopesTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/FieldScopesTest.java
@@ -271,58 +271,6 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
   }
 
   @Test
-  public void testIgnoringFieldOfAnyMessage() throws Exception {
-
-    String typeUrl =
-        isProto3()
-            ? "type.googleapis.com/com.google.common.truth.extensions.proto.SubTestMessage3"
-            : "type.googleapis.com/com.google.common.truth.extensions.proto.SubTestMessage2";
-
-    Message message =
-        parse("o_int: 1 o_any_message { [" + typeUrl + "]: { o_int: 2 r_string: \"foo\" } }");
-    Message diffMessage1 =
-        parse("o_int: 2 o_any_message { [" + typeUrl + "]: { o_int: 2 r_string: \"foo\" } }");
-    Message diffMessage2 =
-        parse("o_int: 1 o_any_message { [" + typeUrl + "]: { o_int: 2 r_string: \"bar\" } }");
-    Message eqMessage =
-        parse("o_int: 1 o_any_message { [" + typeUrl + "]: { o_int: 3 r_string: \"foo\" } }");
-
-    FieldDescriptor fieldDescriptor =
-        getTypeRegistry().getDescriptorForTypeUrl(typeUrl).findFieldByName("o_int");
-    FieldScope partialScope = FieldScopes.ignoringFieldDescriptors(fieldDescriptor);
-    expectThat(diffMessage1)
-        .usingTypeRegistry(getTypeRegistry())
-        .withPartialScope(partialScope)
-        .isNotEqualTo(message);
-    expectThat(diffMessage2)
-        .usingTypeRegistry(getTypeRegistry())
-        .withPartialScope(partialScope)
-        .isNotEqualTo(message);
-    expectThat(eqMessage)
-        .usingTypeRegistry(getTypeRegistry())
-        .withPartialScope(partialScope)
-        .isEqualTo(message);
-
-    expectFailureWhenTesting()
-        .that(diffMessage1)
-        .usingTypeRegistry(getTypeRegistry())
-        .withPartialScope(partialScope)
-        .isEqualTo(message);
-    expectIsEqualToFailed();
-    expectThatFailure().hasMessageThat().contains("modified: o_int: 1 -> 2");
-
-    expectFailureWhenTesting()
-        .that(diffMessage2)
-        .usingTypeRegistry(getTypeRegistry())
-        .withPartialScope(partialScope)
-        .isEqualTo(message);
-    expectIsEqualToFailed();
-    expectThatFailure()
-        .hasMessageThat()
-        .contains("modified: o_any_message.value.r_string[0]: \"foo\" -> \"bar\"");
-  }
-
-  @Test
   public void testIgnoringAllButOneFieldOfSubMessage() {
     // Consider all of TestMessage, but none of o_sub_test_message, except
     // o_sub_test_message.o_int.

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTestBase.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTestBase.java
@@ -36,7 +36,6 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.TextFormat;
 import com.google.protobuf.TextFormat.ParseException;
-import com.google.protobuf.TypeRegistry;
 import com.google.protobuf.UnknownFieldSet;
 import java.lang.reflect.Method;
 import java.util.Collection;
@@ -67,20 +66,12 @@ public class ProtoSubjectTestBase {
     public boolean isProto3() {
       return this == PROTO3;
     }
-
   }
-
-  private static final TypeRegistry typeRegistry =
-      TypeRegistry.newBuilder()
-          .add(TestMessage3.getDescriptor())
-          .add(TestMessage2.getDescriptor())
-          .build();
 
   private static final TextFormat.Parser PARSER =
       TextFormat.Parser.newBuilder()
           .setSingularOverwritePolicy(
               TextFormat.Parser.SingularOverwritePolicy.FORBID_SINGULAR_OVERWRITES)
-          .setTypeRegistry(typeRegistry)
           .build();
 
   // For Parameterized testing.
@@ -128,10 +119,6 @@ public class ProtoSubjectTestBase {
 
   protected final int getFieldNumber(String fieldName) {
     return getFieldDescriptor(fieldName).getNumber();
-  }
-
-  protected final TypeRegistry getTypeRegistry() {
-    return typeRegistry;
   }
 
   protected Message parse(String textProto) {

--- a/extensions/proto/src/test/proto/test_message2.proto
+++ b/extensions/proto/src/test/proto/test_message2.proto
@@ -2,8 +2,6 @@ syntax = "proto2";
 
 package com.google.common.truth.extensions.proto;
 
-import "google/protobuf/any.proto";
-
 option java_package = "com.google.common.truth.extensions.proto";
 option java_multiple_files = true;
 
@@ -38,8 +36,6 @@ message TestMessage2 {
   optional SubTestMessage2 o_sub_test_message = 15;
   repeated SubTestMessage2 r_sub_test_message = 16;
   map<string, TestMessage2> test_message_map = 17;
-  optional .google.protobuf.Any o_any_message = 18;
-  repeated .google.protobuf.Any r_any_message = 19;
 }
 
 message RequiredStringMessage2 {

--- a/extensions/proto/src/test/proto/test_message3.proto
+++ b/extensions/proto/src/test/proto/test_message3.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package com.google.common.truth.extensions.proto;
 
-import "google/protobuf/any.proto";
-
 option java_package = "com.google.common.truth.extensions.proto";
 option java_multiple_files = true;
 
@@ -38,8 +36,6 @@ message TestMessage3 {
   SubTestMessage3 o_sub_test_message = 15;
   repeated SubTestMessage3 r_sub_test_message = 16;
   map<string, TestMessage3> test_message_map = 17;
-  .google.protobuf.Any o_any_message = 18;
-  repeated .google.protobuf.Any r_any_message = 19;
 }
 
 // message RequiredStringMessage3 {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Rollback 2eb500240d0b71d54500afdd7f3eb82e445e31bc

*** Reason for rollback ***

Caused continuous build failure, due to change of semantics of handling of typeUrl and value fields of any messages.

NO_SQ=PURE_ROLLBACK

*** Original change description ***

ProtoTruth: Unpack Any before comparing

Relnotes:
  - `ProtoTruthMessageDifferencer`: Unpacks Any messages before comparing the unpacked message. Using a user supplied TypeRegister in the FluentEqualityConfig. If the message descriptors can not be found in the TypeRegister that it reverts to the original behaviour of comparing the Any messages value ByteString.
  - `ProtoSubject`: added `usingTypeRegistry(TypeRegistry)` method to allow the user to provide a TypeRegistry for processing the Any f...

***

99775126b11f89f5e8198b0b3c44804759251a69