### PR TITLE
MOE Sync 2019-11-20

### DIFF
--- a/core/src/main/java/com/google/common/truth/ExpectFailure.java
+++ b/core/src/main/java/com/google/common/truth/ExpectFailure.java
@@ -57,11 +57,13 @@ import org.junit.runners.model.Statement;
  *     assertThat(failure).factKeys().containsExactly("expected to be visible");
  * }</pre>
  *
- * <p>{@code ExpectFailure} is similar to JUnit 5's <a
- * href="http://junit.org/junit5/docs/current/api/org/junit/jupiter/api/Assertions.html#assertThrows-java.lang.Class-org.junit.jupiter.api.function.Executable-">{@code
- * assertThrows}</a>. We recommend it over {@code assertThrows} when you're testing a Truth subject
- * because it also checks that the assertion you're testing uses the supplied {@link
- * FailureStrategy} and calls {@link FailureStrategy#fail} only once.
+ * <p>{@code ExpectFailure} is similar to JUnit's {@code assertThrows} (<a
+ * href="https://junit.org/junit4/javadoc/latest/org/junit/Assert.html#assertThrows%28java.lang.Class,%20org.junit.function.ThrowingRunnable%29">JUnit
+ * 4</a>, <a
+ * href="https://junit.org/junit5/docs/current/api/org/junit/jupiter/api/Assertions.html#assertThrows%28java.lang.Class,org.junit.jupiter.api.function.Executable%29">JUnit
+ * 5</a>). We recommend it over {@code assertThrows} when you're testing a Truth subject because it
+ * also checks that the assertion you're testing uses the supplied {@link FailureStrategy} and calls
+ * {@link FailureStrategy#fail} only once.
  */
 public final class ExpectFailure implements Platform.JUnitTestRule {
   private final FailureStrategy strategy =

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTest.java
@@ -20,8 +20,10 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.UnknownFieldSet;
@@ -765,5 +767,17 @@ public class ProtoSubjectTest extends ProtoSubjectTestBase {
     expectThatFailure()
         .factValue("but was missing")
         .contains("r_required_string_message[1].required_string");
+  }
+
+  @Test
+  public void testMapWithDefaultKeysAndValues() throws InvalidProtocolBufferException {
+    Descriptor descriptor = getFieldDescriptor("o_int").getContainingType();
+    final String defaultString = "";
+    final int defaultInt32 = 0;
+    Message message = makeProtoMap(ImmutableMap.of(defaultString, 1, "foo", defaultInt32));
+    Message dynamicMessage =
+        DynamicMessage.parseFrom(
+            descriptor, message.toByteString(), ExtensionRegistry.getEmptyRegistry());
+    expectThat(message).isEqualTo(dynamicMessage);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
       <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.3</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> errorprone 2.3.3

172825e4f6686ffc2262609546e52348fa1fff13

-------

<p> Add link to assertThrows in JUnit 4.

Also, fix/update JUnit 5 link, as Javadoc has changed URL schemes.

Followup to http://[]

5bfd0223b0d71921aff86854f207fe0d647c13e4

-------

<p> Fix null key bug in ProtoTruthMessageDifferencer#toProtoMap

Maps are implemented in protobufs as repeated messages with a 'key' and 'value' field. In Proto3 fields whose values equal the defaultValue for the field are not serialised to the wire format. That means when the bytes are parsed to de-serialise the message this field is absent, and calls to get(FieldDescriptor) for that field will return null.

This should be interpreted as the defaultValue. Maps in generated message classes already handle this case but DynamicMessage does not, so it must be explicitly handled here.

Also this CL changes the return type of toProtoMap to be an ImmutableMap, where previously it returned either mutable or immutable implementations of Map depending on if the supplied container was null.

RELNOTES=Fix handling of Map with keys equal to the key types default value.

4f2b1c5e83644e998fa55a1dedc5eb1b8da4f21f