### PR TITLE
MOE Sync 2019-11-21

### DIFF
--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/FluentEqualityConfig.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/FluentEqualityConfig.java
@@ -34,6 +34,7 @@ import com.google.errorprone.annotations.CheckReturnValue;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
+import com.google.protobuf.TypeRegistry;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
@@ -56,6 +57,7 @@ abstract class FluentEqualityConfig implements FieldScopeLogicContainer<FluentEq
           .setCompareExpectedFieldsOnly(false)
           .setCompareFieldsScope(FieldScopeLogic.all())
           .setReportMismatchesOnly(false)
+          .setUseTypeRegistry(TypeRegistry.getEmptyTypeRegistry())
           .setUsingCorrespondenceStringFunction(Functions.constant(""))
           .build();
 
@@ -100,6 +102,8 @@ abstract class FluentEqualityConfig implements FieldScopeLogicContainer<FluentEq
   abstract FieldScopeLogic compareFieldsScope();
 
   abstract boolean reportMismatchesOnly();
+
+  abstract TypeRegistry useTypeRegistry();
 
   // For pretty-printing, does not affect behavior.
   abstract Function<? super Optional<Descriptor>, String> usingCorrespondenceStringFunction();
@@ -317,6 +321,13 @@ abstract class FluentEqualityConfig implements FieldScopeLogicContainer<FluentEq
         .build();
   }
 
+  final FluentEqualityConfig usingTypeRegistry(TypeRegistry typeRegistry) {
+    return toBuilder()
+        .setUseTypeRegistry(typeRegistry)
+        .addUsingCorrespondenceString(".usingTypeRegistry(" + typeRegistry + ")")
+        .build();
+  }
+
   @Override
   public final FluentEqualityConfig subScope(
       Descriptor rootDescriptor, FieldDescriptorOrUnknown fieldDescriptorOrUnknown) {
@@ -429,6 +440,8 @@ abstract class FluentEqualityConfig implements FieldScopeLogicContainer<FluentEq
     abstract Builder setCompareFieldsScope(FieldScopeLogic fieldScopeLogic);
 
     abstract Builder setReportMismatchesOnly(boolean reportMismatchesOnly);
+
+    abstract Builder setUseTypeRegistry(TypeRegistry typeRegistry);
 
     @CheckReturnValue
     abstract Function<? super Optional<Descriptor>, String> usingCorrespondenceStringFunction();

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosFluentAssertion.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosFluentAssertion.java
@@ -17,6 +17,7 @@ package com.google.common.truth.extensions.proto;
 
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
+import com.google.protobuf.TypeRegistry;
 
 /**
  * Fluent API to perform detailed, customizable comparison of iterables of protocol buffers. The
@@ -459,6 +460,23 @@ public interface IterableOfProtosFluentAssertion<M extends Message>
    * <p>This a purely cosmetic setting, and it has no effect on the behavior of the test.
    */
   IterableOfProtosFluentAssertion<M> reportingMismatchesOnly();
+
+  /**
+   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
+   *
+   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
+   * descriptor for the message's type URL.
+   *
+   * <ul>
+   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
+   *       expected value, respecting any configuration methods used for the assertion.
+   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
+   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
+   * </ul>
+   *
+   * @since 1.1
+   */
+  IterableOfProtosFluentAssertion<M> usingTypeRegistry(TypeRegistry typeRegistry);
 
   /**
    * @deprecated Do not call {@code equals()} on a {@code IterableOfProtosFluentAssertion}.

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/IterableOfProtosSubject.java
@@ -28,6 +28,7 @@ import com.google.common.truth.Ordered;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
+import com.google.protobuf.TypeRegistry;
 import java.util.Arrays;
 import java.util.Comparator;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
@@ -629,6 +630,25 @@ public class IterableOfProtosSubject<M extends Message> extends IterableSubject 
     return usingConfig(config.reportingMismatchesOnly());
   }
 
+  /**
+   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
+   *
+   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
+   * descriptor for the message's type URL.
+   *
+   * <ul>
+   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
+   *       expected value, respecting any configuration methods used for the assertion.
+   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
+   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
+   * </ul>
+   *
+   * @since 1.1
+   */
+  public IterableOfProtosFluentAssertion<M> usingTypeRegistry(TypeRegistry typeRegistry) {
+    return usingConfig(config.usingTypeRegistry(typeRegistry));
+  }
+
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Overrides for IterableSubject Methods
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -981,6 +1001,11 @@ public class IterableOfProtosSubject<M extends Message> extends IterableSubject 
     @Override
     public IterableOfProtosFluentAssertion<M> reportingMismatchesOnly() {
       return subject.reportingMismatchesOnly();
+    }
+
+    @Override
+    public IterableOfProtosFluentAssertion<M> usingTypeRegistry(TypeRegistry typeRegistry) {
+      return subject.usingTypeRegistry(typeRegistry);
     }
 
     @Override

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesFluentAssertion.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesFluentAssertion.java
@@ -19,6 +19,7 @@ import com.google.common.truth.Ordered;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
+import com.google.protobuf.TypeRegistry;
 import java.util.Map;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
@@ -475,6 +476,23 @@ public interface MapWithProtoValuesFluentAssertion<M extends Message> {
    * <p>This a purely cosmetic setting, and it has no effect on the behavior of the test.
    */
   MapWithProtoValuesFluentAssertion<M> reportingMismatchesOnlyForValues();
+
+  /**
+   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
+   *
+   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
+   * descriptor for the message's type URL.
+   *
+   * <ul>
+   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
+   *       expected value, respecting any configuration methods used for the assertion.
+   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
+   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
+   * </ul>
+   *
+   * @since 1.1
+   */
+  MapWithProtoValuesFluentAssertion<M> usingTypeRegistryForValues(TypeRegistry typeRegistry);
 
   /**
    * Fails if the map does not contain an entry with the given key and a value that corresponds to

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MapWithProtoValuesSubject.java
@@ -26,6 +26,7 @@ import com.google.common.truth.Ordered;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
+import com.google.protobuf.TypeRegistry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -599,6 +600,26 @@ public class MapWithProtoValuesSubject<M extends Message> extends MapSubject {
     return usingConfig(config.reportingMismatchesOnly());
   }
 
+  /**
+   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
+   *
+   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
+   * descriptor for the message's type URL.
+   *
+   * <ul>
+   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
+   *       expected value, respecting any configuration methods used for the assertion.
+   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
+   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
+   * </ul>
+   *
+   * @since 1.1
+   */
+  public MapWithProtoValuesFluentAssertion<M> usingTypeRegistryForValues(
+      TypeRegistry typeRegistry) {
+    return usingConfig(config.usingTypeRegistry(typeRegistry));
+  }
+
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // UsingCorrespondence Methods
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -819,6 +840,12 @@ public class MapWithProtoValuesSubject<M extends Message> extends MapSubject {
     @Override
     public MapWithProtoValuesFluentAssertion<M> reportingMismatchesOnlyForValues() {
       return subject.reportingMismatchesOnlyForValues();
+    }
+
+    @Override
+    public MapWithProtoValuesFluentAssertion<M> usingTypeRegistryForValues(
+        TypeRegistry typeRegistry) {
+      return subject.usingTypeRegistryForValues(typeRegistry);
     }
 
     @Override

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesFluentAssertion.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesFluentAssertion.java
@@ -20,6 +20,7 @@ import com.google.common.truth.Ordered;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
+import com.google.protobuf.TypeRegistry;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
@@ -476,6 +477,23 @@ public interface MultimapWithProtoValuesFluentAssertion<M extends Message> {
    * <p>This a purely cosmetic setting, and it has no effect on the behavior of the test.
    */
   MultimapWithProtoValuesFluentAssertion<M> reportingMismatchesOnlyForValues();
+
+  /**
+   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
+   *
+   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
+   * descriptor for the message's type URL.
+   *
+   * <ul>
+   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
+   *       expected value, respecting any configuration methods used for the assertion.
+   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
+   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
+   * </ul>
+   *
+   * @since 1.1
+   */
+  MultimapWithProtoValuesFluentAssertion<M> usingTypeRegistryForValues(TypeRegistry typeRegistry);
 
   /**
    * Fails if the multimap does not contain an entry with the given key and a value that corresponds

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/MultimapWithProtoValuesSubject.java
@@ -29,6 +29,7 @@ import com.google.common.truth.Subject;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
+import com.google.protobuf.TypeRegistry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -621,6 +622,26 @@ public class MultimapWithProtoValuesSubject<M extends Message> extends MultimapS
     return usingConfig(config.reportingMismatchesOnly());
   }
 
+  /**
+   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
+   *
+   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
+   * descriptor for the message's type URL.
+   *
+   * <ul>
+   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
+   *       expected value, respecting any configuration methods used for the assertion.
+   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
+   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
+   * </ul>
+   *
+   * @since 1.1
+   */
+  public MultimapWithProtoValuesFluentAssertion<M> usingTypeRegistryForValues(
+      TypeRegistry typeRegistry) {
+    return usingConfig(config.usingTypeRegistry(typeRegistry));
+  }
+
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // UsingCorrespondence Methods
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -850,6 +871,12 @@ public class MultimapWithProtoValuesSubject<M extends Message> extends MultimapS
     @Override
     public MultimapWithProtoValuesFluentAssertion<M> reportingMismatchesOnlyForValues() {
       return subject.reportingMismatchesOnlyForValues();
+    }
+
+    @Override
+    public MultimapWithProtoValuesFluentAssertion<M> usingTypeRegistryForValues(
+        TypeRegistry typeRegistry) {
+      return subject.usingTypeRegistryForValues(typeRegistry);
     }
 
     @Override

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoFluentAssertion.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoFluentAssertion.java
@@ -17,6 +17,7 @@ package com.google.common.truth.extensions.proto;
 
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
+import com.google.protobuf.TypeRegistry;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
@@ -452,6 +453,23 @@ public interface ProtoFluentAssertion {
    * <p>This a purely cosmetic setting, and it has no effect on the behavior of the test.
    */
   ProtoFluentAssertion reportingMismatchesOnly();
+
+  /**
+   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
+   *
+   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
+   * descriptor for the message's type URL.
+   *
+   * <ul>
+   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
+   *       expected value, respecting any configuration methods used for the assertion.
+   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
+   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
+   * </ul>
+   *
+   * @since 1.1
+   */
+  ProtoFluentAssertion usingTypeRegistry(TypeRegistry typeRegistry);
 
   /**
    * Compares the subject of the assertion to {@code expected}, using all of the rules specified by

--- a/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoSubject.java
+++ b/extensions/proto/src/main/java/com/google/common/truth/extensions/proto/ProtoSubject.java
@@ -26,6 +26,7 @@ import com.google.common.base.Objects;
 import com.google.common.truth.FailureMetadata;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
+import com.google.protobuf.TypeRegistry;
 import java.util.Arrays;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
@@ -576,6 +577,25 @@ public class ProtoSubject extends LiteProtoSubject {
     return usingConfig(config.reportingMismatchesOnly());
   }
 
+  /**
+   * Specifies the {@link TypeRegistry} to use for {@link com.google.protobuf.Any Any} messages.
+   *
+   * <p>To compare the value of an {@code Any} message, ProtoTruth looks in the given registry for a
+   * descriptor for the message's type URL.
+   *
+   * <ul>
+   *   <li>If ProtoTruth finds a descriptor, it unpacks the value and compares it against the
+   *       expected value, respecting any configuration methods used for the assertion.
+   *   <li>If ProtoTruth does not find a descriptor (or if the value can't be deserialized with the
+   *       descriptor), it compares the raw, serialized bytes of the expected and actual values.
+   * </ul>
+   *
+   * @since 1.1
+   */
+  public ProtoFluentAssertion usingTypeRegistry(TypeRegistry typeRegistry) {
+    return usingConfig(config.usingTypeRegistry(typeRegistry));
+  }
+
   private static boolean sameClassMessagesWithDifferentDescriptors(
       @NullableDecl Message actual, @NullableDecl Object expected) {
     if (actual == null
@@ -844,6 +864,11 @@ public class ProtoSubject extends LiteProtoSubject {
     @Override
     public ProtoFluentAssertion reportingMismatchesOnly() {
       return protoSubject.reportingMismatchesOnly();
+    }
+
+    @Override
+    public ProtoFluentAssertion usingTypeRegistry(TypeRegistry typeRegistry) {
+      return protoSubject.usingTypeRegistry(typeRegistry);
     }
 
     @Override

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/FieldScopesTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/FieldScopesTest.java
@@ -112,6 +112,28 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
   }
 
   @Test
+  public void testFieldScopes_none_withAnyField() {
+    String typeUrl =
+        isProto3()
+            ? "type.googleapis.com/com.google.common.truth.extensions.proto.SubTestMessage3"
+            : "type.googleapis.com/com.google.common.truth.extensions.proto.SubTestMessage2";
+    Message message = parse("o_int: 3 o_any_message { [" + typeUrl + "]: { r_string: \"foo\" } }");
+    Message diffMessage =
+        parse("o_int: 5 o_any_message { [" + typeUrl + "]: { r_string: \"bar\" } }");
+
+    expectThat(diffMessage).ignoringFieldScope(FieldScopes.none()).isNotEqualTo(message);
+    expectThat(diffMessage).withPartialScope(FieldScopes.none()).isEqualTo(message);
+
+    expectFailureWhenTesting()
+        .that(diffMessage)
+        .withPartialScope(FieldScopes.none())
+        .isNotEqualTo(message);
+    expectIsNotEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("ignored: o_int");
+    expectThatFailure().hasMessageThat().contains("ignored: o_any_message");
+  }
+
+  @Test
   public void testIgnoringTopLevelField_ignoringField() {
     expectThat(ignoringFieldDiffMessage)
         .ignoringFields(goodFieldNumber)
@@ -133,6 +155,32 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
         .isNotEqualTo(ignoringFieldMessage);
     expectIsNotEqualToFailed();
     expectThatFailure().hasMessageThat().contains("ignored: r_string");
+  }
+
+  @Test
+  public void testIgnoringTopLevelAnyField_ignoringField() {
+    String typeUrl =
+        isProto3()
+            ? "type.googleapis.com/com.google.common.truth.extensions.proto.SubTestMessage3"
+            : "type.googleapis.com/com.google.common.truth.extensions.proto.SubTestMessage2";
+    Message message = parse("o_int: 1 o_any_message { [" + typeUrl + "]: { r_string: \"foo\" } }");
+    Message diffMessage = parse("o_int: 1");
+    int goodFieldNumber = getFieldNumber("o_int");
+    int badFieldNumber = getFieldNumber("o_any_message");
+
+    expectThat(diffMessage).ignoringFields(goodFieldNumber).isNotEqualTo(message);
+    expectThat(diffMessage).ignoringFields(badFieldNumber).isEqualTo(diffMessage);
+
+    expectFailureWhenTesting().that(diffMessage).ignoringFields(goodFieldNumber).isEqualTo(message);
+    expectIsEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("deleted: o_any_message");
+
+    expectFailureWhenTesting()
+        .that(diffMessage)
+        .ignoringFields(badFieldNumber)
+        .isNotEqualTo(message);
+    expectIsNotEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("ignored: o_any_message");
   }
 
   @Test
@@ -165,6 +213,22 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
     expectThat(ignoringFieldDiffMessage)
         .ignoringFieldScope(FieldScopes.allowingFields(badFieldNumber))
         .isEqualTo(ignoringFieldMessage);
+  }
+
+  @Test
+  public void testIgnoringTopLevelAnyField_fieldScopes_allowingFields() {
+    String typeUrl =
+        isProto3()
+            ? "type.googleapis.com/com.google.common.truth.extensions.proto.SubTestMessage3"
+            : "type.googleapis.com/com.google.common.truth.extensions.proto.SubTestMessage2";
+    Message message =
+        parse("o_int: 1 o_any_message { [" + typeUrl + "]: { o_int: 2 r_string: \"foo\" } }");
+    Message diffMessage = parse("o_int: 1");
+    int goodFieldNumber = getFieldNumber("o_int");
+
+    expectThat(message)
+        .withPartialScope(FieldScopes.allowingFields(goodFieldNumber))
+        .isEqualTo(diffMessage);
   }
 
   @Test
@@ -268,6 +332,57 @@ public class FieldScopesTest extends ProtoSubjectTestBase {
     expectThatFailure()
         .hasMessageThat()
         .contains("modified: o_sub_test_message.r_string[0]: \"foo\" -> \"bar\"");
+  }
+
+  @Test
+  public void testIgnoringFieldOfAnyMessage() throws Exception {
+    String typeUrl =
+        isProto3()
+            ? "type.googleapis.com/com.google.common.truth.extensions.proto.SubTestMessage3"
+            : "type.googleapis.com/com.google.common.truth.extensions.proto.SubTestMessage2";
+
+    Message message =
+        parse("o_int: 1 o_any_message { [" + typeUrl + "]: { o_int: 2 r_string: \"foo\" } }");
+    Message diffMessage1 =
+        parse("o_int: 2 o_any_message { [" + typeUrl + "]: { o_int: 2 r_string: \"foo\" } }");
+    Message diffMessage2 =
+        parse("o_int: 1 o_any_message { [" + typeUrl + "]: { o_int: 2 r_string: \"bar\" } }");
+    Message eqMessage =
+        parse("o_int: 1 o_any_message { [" + typeUrl + "]: { o_int: 3 r_string: \"foo\" } }");
+
+    FieldDescriptor fieldDescriptor =
+        getTypeRegistry().getDescriptorForTypeUrl(typeUrl).findFieldByName("o_int");
+    FieldScope partialScope = FieldScopes.ignoringFieldDescriptors(fieldDescriptor);
+    expectThat(diffMessage1)
+        .usingTypeRegistry(getTypeRegistry())
+        .withPartialScope(partialScope)
+        .isNotEqualTo(message);
+    expectThat(diffMessage2)
+        .usingTypeRegistry(getTypeRegistry())
+        .withPartialScope(partialScope)
+        .isNotEqualTo(message);
+    expectThat(eqMessage)
+        .usingTypeRegistry(getTypeRegistry())
+        .withPartialScope(partialScope)
+        .isEqualTo(message);
+
+    expectFailureWhenTesting()
+        .that(diffMessage1)
+        .usingTypeRegistry(getTypeRegistry())
+        .withPartialScope(partialScope)
+        .isEqualTo(message);
+    expectIsEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("modified: o_int: 1 -> 2");
+
+    expectFailureWhenTesting()
+        .that(diffMessage2)
+        .usingTypeRegistry(getTypeRegistry())
+        .withPartialScope(partialScope)
+        .isEqualTo(message);
+    expectIsEqualToFailed();
+    expectThatFailure()
+        .hasMessageThat()
+        .contains("modified: o_any_message.value.r_string[0]: \"foo\" -> \"bar\"");
   }
 
   @Test

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.Any;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.DynamicMessage;
@@ -132,6 +133,24 @@ public class ProtoSubjectTest extends ProtoSubjectTestBase {
   }
 
   @Test
+  public void testIgnoringFieldAbsence_anyMessage() {
+    Message message = parse("o_int: 3");
+    Message diffMessage = parse("o_int: 3 o_any_message: {}");
+
+    expectThat(diffMessage).ignoringFieldAbsence().isEqualTo(message);
+    expectThat(message).ignoringFieldAbsence().isEqualTo(diffMessage);
+
+    expectFailureWhenTesting().that(diffMessage).isEqualTo(message);
+    expectIsEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("added: o_any_message:");
+
+    expectFailureWhenTesting().that(diffMessage).ignoringFieldAbsence().isNotEqualTo(message);
+    expectIsNotEqualToFailed();
+    expectThatFailure().hasMessageThat().contains("matched: o_int: 3");
+    expectThatFailure().hasMessageThat().contains("matched: o_any_message");
+  }
+
+  @Test
   public void testIgnoringFieldAbsence_scoped() {
     Message message = parse("o_sub_test_message: { o_test_message: {} }");
     Message emptyMessage = parse("");
@@ -198,7 +217,6 @@ public class ProtoSubjectTest extends ProtoSubjectTestBase {
     }
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void testUnknownFields() throws InvalidProtocolBufferException {
     Message message =
@@ -767,6 +785,82 @@ public class ProtoSubjectTest extends ProtoSubjectTestBase {
     expectThatFailure()
         .factValue("but was missing")
         .contains("r_required_string_message[1].required_string");
+  }
+
+  @Test
+  public void testAnyMessagesWithDifferentTypes() {
+    String typeUrl =
+        isProto3()
+            ? "type.googleapis.com/com.google.common.truth.extensions.proto.SubTestMessage3"
+            : "type.googleapis.com/com.google.common.truth.extensions.proto.SubTestMessage2";
+    String diffTypeUrl =
+        isProto3()
+            ? "type.googleapis.com/com.google.common.truth.extensions.proto.SubSubTestMessage3"
+            : "type.googleapis.com/com.google.common.truth.extensions.proto.SubSubTestMessage2";
+
+    Message message = parse("o_any_message: { [" + typeUrl + "]: {r_string: \"foo\"} }");
+    Message diffMessage = parse("o_any_message: { [" + diffTypeUrl + "]: {r_string: \"bar\"} }");
+
+    expectThat(message).usingTypeRegistry(getTypeRegistry()).isNotEqualTo(diffMessage);
+
+    expectFailureWhenTesting()
+        .that(message)
+        .usingTypeRegistry(getTypeRegistry())
+        .isEqualTo(diffMessage);
+    expectThatFailure().hasMessageThat().contains("modified: o_any_message.type_url");
+    expectThatFailure()
+        .hasMessageThat()
+        .containsMatch("modified: o_any_message.value:.*bar.*->.*foo.*");
+  }
+
+  @Test
+  public void testAnyMessageCompareWithEmptyAnyMessage() {
+    String typeUrl =
+        isProto3()
+            ? "type.googleapis.com/com.google.common.truth.extensions.proto.SubTestMessage3"
+            : "type.googleapis.com/com.google.common.truth.extensions.proto.SubTestMessage2";
+
+    Message messageWithAny = parse("o_any_message: { [" + typeUrl + "]: {o_int: 1} }");
+    Message messageWithEmptyAny = parse("o_any_message: { }");
+
+    expectThat(messageWithAny)
+        .usingTypeRegistry(getTypeRegistry())
+        .isNotEqualTo(messageWithEmptyAny);
+    expectThat(messageWithEmptyAny)
+        .usingTypeRegistry(getTypeRegistry())
+        .isNotEqualTo(messageWithAny);
+
+    expectFailureWhenTesting()
+        .that(messageWithAny)
+        .usingTypeRegistry(getTypeRegistry())
+        .isEqualTo(messageWithEmptyAny);
+    expectThatFailure().hasMessageThat().contains("modified: o_any_message.type_url");
+    expectThatFailure().hasMessageThat().contains("modified: o_any_message.value");
+
+    expectFailureWhenTesting()
+        .that(messageWithEmptyAny)
+        .usingTypeRegistry(getTypeRegistry())
+        .isEqualTo(messageWithAny);
+    expectThatFailure().hasMessageThat().contains("modified: o_any_message.type_url");
+    expectThatFailure().hasMessageThat().contains("modified: o_any_message.value");
+  }
+
+  @Test
+  public void testAnyMessageComparedWithDynamicMessage() throws InvalidProtocolBufferException {
+    String typeUrl =
+        isProto3()
+            ? "type.googleapis.com/com.google.common.truth.extensions.proto.SubTestMessage3"
+            : "type.googleapis.com/com.google.common.truth.extensions.proto.SubTestMessage2";
+
+    Message messageWithAny = parse("o_any_message: { [" + typeUrl + "]: {o_int: 1} }");
+    FieldDescriptor fieldDescriptor = getFieldDescriptor("o_any_message");
+    Any message = (Any) messageWithAny.getField(fieldDescriptor);
+    DynamicMessage dynamicMessage =
+        DynamicMessage.parseFrom(
+            Any.getDescriptor(), message.toByteString(), ExtensionRegistry.getEmptyRegistry());
+
+    expectThat(dynamicMessage).usingTypeRegistry(getTypeRegistry()).isEqualTo(message);
+    expectThat(message).usingTypeRegistry(getTypeRegistry()).isEqualTo(dynamicMessage);
   }
 
   @Test

--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTestBase.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/ProtoSubjectTestBase.java
@@ -36,6 +36,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.TextFormat;
 import com.google.protobuf.TextFormat.ParseException;
+import com.google.protobuf.TypeRegistry;
 import com.google.protobuf.UnknownFieldSet;
 import java.lang.reflect.Method;
 import java.util.Collection;
@@ -66,12 +67,20 @@ public class ProtoSubjectTestBase {
     public boolean isProto3() {
       return this == PROTO3;
     }
+
   }
+
+  private static final TypeRegistry typeRegistry =
+      TypeRegistry.newBuilder()
+          .add(TestMessage3.getDescriptor())
+          .add(TestMessage2.getDescriptor())
+          .build();
 
   private static final TextFormat.Parser PARSER =
       TextFormat.Parser.newBuilder()
           .setSingularOverwritePolicy(
               TextFormat.Parser.SingularOverwritePolicy.FORBID_SINGULAR_OVERWRITES)
+          .setTypeRegistry(typeRegistry)
           .build();
 
   // For Parameterized testing.
@@ -119,6 +128,10 @@ public class ProtoSubjectTestBase {
 
   protected final int getFieldNumber(String fieldName) {
     return getFieldDescriptor(fieldName).getNumber();
+  }
+
+  protected final TypeRegistry getTypeRegistry() {
+    return typeRegistry;
   }
 
   protected Message parse(String textProto) {

--- a/extensions/proto/src/test/proto/test_message2.proto
+++ b/extensions/proto/src/test/proto/test_message2.proto
@@ -2,6 +2,8 @@ syntax = "proto2";
 
 package com.google.common.truth.extensions.proto;
 
+import "google/protobuf/any.proto";
+
 option java_package = "com.google.common.truth.extensions.proto";
 option java_multiple_files = true;
 
@@ -36,6 +38,8 @@ message TestMessage2 {
   optional SubTestMessage2 o_sub_test_message = 15;
   repeated SubTestMessage2 r_sub_test_message = 16;
   map<string, TestMessage2> test_message_map = 17;
+  optional .google.protobuf.Any o_any_message = 18;
+  repeated .google.protobuf.Any r_any_message = 19;
 }
 
 message RequiredStringMessage2 {

--- a/extensions/proto/src/test/proto/test_message3.proto
+++ b/extensions/proto/src/test/proto/test_message3.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package com.google.common.truth.extensions.proto;
 
+import "google/protobuf/any.proto";
+
 option java_package = "com.google.common.truth.extensions.proto";
 option java_multiple_files = true;
 
@@ -36,6 +38,8 @@ message TestMessage3 {
   SubTestMessage3 o_sub_test_message = 15;
   repeated SubTestMessage3 r_sub_test_message = 16;
   map<string, TestMessage3> test_message_map = 17;
+  .google.protobuf.Any o_any_message = 18;
+  repeated .google.protobuf.Any r_any_message = 19;
 }
 
 // message RequiredStringMessage3 {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Implementation tweaks:

1. Rename keyOrder to actualAndExpectedKeys.

The keyOrder name suggests that ordering is significant, when in fact:
- the ProtoTruth logic doesn't take order into consideration
- map fields do not have defined order: https://developers.google.com/protocol-buffers/docs/proto3#maps

2. Extract a method for retrieving the value of a field, substituting the default value. Use it in toProtoMap().

43409863dde3309b5d30cd9c0da91d94f0906853

-------

<p> Roll forward from 2eb500240d0b71d54500afdd7f3eb82e445e31bc after fixing field scope issues:

 - Add checks for FieldScope for
   * google.protobuf.Any.type_url
   * google.protobuf.Any.value
 - Add new tests for field scope and field absence.
 - Added workaround for b/144793871

----

ProtoTruth: Unpack Any before comparing

RELNOTES:
  - `ProtoTruthMessageDifferencer`: Unpacks Any messages before comparing the unpacked message. Using a user supplied TypeRegister in the FluentEqualityConfig. If the message descriptors can not be found in the TypeRegister that it reverts to the original behaviour of comparing the Any messages value ByteString.
  - `ProtoSubject`: added `usingTypeRegistry(TypeRegistry)` method to allow the user to provide a TypeRegistry for processing the Any fields it encounters.

0ae23b4c3401cd28c85a68300a479e9f19713108