### PR TITLE
MOE Sync 2019-12-16

### DIFF
--- a/core/src/main/java/com/google/common/truth/StringSubject.java
+++ b/core/src/main/java/com/google/common/truth/StringSubject.java
@@ -32,12 +32,12 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Christian Gruber (cgruber@israfil.net)
  */
 public class StringSubject extends ComparableSubject<String> {
+  private final String actual;
+
   /**
    * Constructor for use by subclasses. If you want to create an instance of this class itself, call
    * {@link Subject#check(String, Object...) check(...)}{@code .that(actual)}.
    */
-  private final String actual;
-
   protected StringSubject(FailureMetadata metadata, @NullableDecl String string) {
     super(metadata, string);
     this.actual = string;


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix Javadoc location

Previously it was talking about a constructor but was applied to a member variable and not the said constructor.

#codehealth

RELNOTES=Correct Javadoc location

4909b0bb11ed297781134235939ae96c92abc5ef