### PR TITLE
MOE Sync 2020-01-16

### DIFF
--- a/core/src/main/java/com/google/common/truth/StackTraceCleaner.java
+++ b/core/src/main/java/com/google/common/truth/StackTraceCleaner.java
@@ -246,7 +246,7 @@ final class StackTraceCleaner {
         return false;
       }
       if (e instanceof IncompatibleClassChangeError) {
-        // Samsung class-loading bug? https://issuetracker.google.com/issues/37045084
+        // OEM class-loading bug? https://issuetracker.google.com/issues/37045084
         return false;
       }
       throw e;

--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,9 @@
               <link>https://junit.org/junit4/javadoc/latest/</link>
             </links>
             <source>8</source>
+            <sourceFileExcludes>
+              <sourceFileExclude>**/super/**/*.java</sourceFileExclude>
+            </sourceFileExcludes>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix Javadoc generation under Java 11.

Java 11 is what we use for building snapshots, so the Truth Javadocs haven't been updating. ("Fortunately," we haven't been adding APIs :))

The problem is errors like the following:

[ERROR] Exit code: 1 - /home/travis/build/google/truth/core/src/main/java/com/google/common/truth/super/com/google/common/truth/Platform.java:20: error: package jsinterop.annotations does not exist
[ERROR] import static jsinterop.annotations.JsPackage.GLOBAL;
[ERROR]                                    ^

Example failure: https://travis-ci.org/google/truth/builds/636435498

It turns out that this error is only a warning under Java 8.

Also, while here, edit the comment from CL 289440196 to reflect that the problem isn't exclusive to Samsung.

c9f2390dbcb93415f8fc9caf1f78c32bce72427f