### PR TITLE
MOE Sync 2020-02-04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   global:
   - secure: Q8O565LFFwytrjS+vRHlzw0sYGjFA4npvaMbyG5w3uoodnHKTh0tMOwiToGzGS0CHRf83LffTlbodVVIWkiyzxcbNwMslkOxLpFtI0Hif2apb/mSQ6vdO/SXTb1MVwQBqBGCF47KBw5XDjvRbXmIh8+4z9yIBO8oWqEbHvBYQl0=
   - secure: EMRsJLQfGoSrArcemMmjmlI4Ut2eGoLgIW/lxHEa/zSzOqSGMUdxo7+Hd23VxQqWWYAa2fV4NPSUqBZrJkS6RFxQOE4CYLpmVenSRdVTNXa0Cw+48k6aw4/kOfOafn7s5EJ/pA0dYjFgj1V2F+vRIywrNs0tpziFanWvMVUBAOY=
-  - secure: XpixMe6WG/U2lUgbkZohDDiDJnrXdra+K+AUvg8ze35Wd6ffPdHh9oLMR6DbMq82VV21G9WcJyRQM7g/mCBHOXDt6/0fj/IPUaev15QsJITF1TAJRISxL4DClsJX6U7i2y+KaZ1pOSnsEFvDHE7QM9+DYqG4cPX++bt7Lr33v+4=
+  - secure: Iru4rmBn4413LXymS4qhoBDHLIgGDAXvt9d4UA9D3MIZkuwESri2ZFe3aWH3LGytcr9p8mxKAkZwUSrOdM3x967ExMtaeIwwi7Y1d0RmdYIbFMqi08W0EJSdYb3/O8FN9jzBP/JieIdqAYrCSnDF4WI29YS9x4HtIdHNdc/ruA0=
 
 after_success:
   - bash util/generate-latest-docs.sh


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Replace a GH_TOKEN probably owned by cgruber with one owned by me.

This will hopefully restore snapshot Javadoc generation.

cgruber's token:
https://github.com/google/truth/commit/55fffba7c6dfd437239bb2df173296c415f49ae7

Process:
  Go to https://github.com/settings/tokens/new, and generate a new token with public_repo permission.
  sudo gem install travis
  travis encrypt -r google/truth GH_TOKEN=`cat` --add env.global
    # and then enter the token

Note that the *encrypted* token appears to be a per-repository value:
  https://badel2.github.io/2018/09/15/github-token-from-travis.html

And I didn't save my token. If we need a new encrypted-token line for another project, we'll have to generate a new token. That seems fine.

Fixes(?) https://github.com/google/truth/issues/662

da1a228001497f7fcbfd6f1e8a81fb02091ae26f