### PR TITLE
MOE Sync 2020-04-02

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -14,12 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.foobar2
 {% endcomment %}
 
+{% comment %}
+This logic is trying to find the first portion of the path after the base url to match for
+the top nav. The page url should be in the form /foo/bar/. Sometimes pages also have a trailing
+.html like /foo/bar.html or a trailing /. We strip those off and split on the / separator
+(the split function handles the trailing / and ignores it) to find the base "/foo" to figure out
+what top nav subtree we are in.
+{% endcomment %}
+{% assign page_parts = page.url | remove_first: "/" | split: "/" %}
+{% assign page_url = page_parts[0] | prepend: "/" | remove: ".html" %}
+
 <nav class="c-navigation {% if site.fixedNav == 'true' %}is-fixed{% endif %}">
   <div class="c-navigation__container u-container">
 
     {% for i in site.nav %}
-    {% assign url = i.item.url %}
-    <a class="c-navigation__item {% if page.url == url %}is-active{% endif %}" href="{{ url | prepend: site.baseurl }}">{{i.item.name}}</a>
+      {% assign url = i.item.url %}
+      {% assign url_for_matching = url | remove: ".html" %}
+      <a class="c-navigation__item {% if page_url == url_for_matching %}is-active{% endif %}"
+         href="{{ url | prepend: site.baseurl }}">{{i.item.name}}</a>
     {% endfor %}
 
   </div>

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -1,0 +1,60 @@
+{% comment %}
+Copyright (C) 2020 Google LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.foobar2
+{% endcomment %}
+
+{% comment %}
+This logic is trying to find the last portion of the path after the base url to match for
+the side nav. The page url should be in the form /foo/bar/. Sometimes pages also have a trailing
+.html like /foo/bar.html or a trailing /. We strip those off and split on the / separator
+(the split function handles the trailing / and ignores it) to find the base "/foo" and the "/bar"
+for the side nav to figure out the top and side nav location we are currently in.
+{% endcomment %}
+{% assign page_url = page.url | remove_first: "/" | remove: ".html" %}
+{% assign page_url_top = page_url | split: "/" | first | prepend: "/" %}
+{% assign page_url_rest = page_url | prepend: "/" | remove_first: page_url_top %}
+
+{% for i in site.nav %}
+  {% if page_url_top == i.item.url %}
+    {% assign topitem = i.item %}
+  {% endif %}
+{% endfor %}
+
+{% if topitem.sidenav %}
+<nav class="c-sidenav">
+  <div class="c-sidenav__container u-container">
+
+    <li><a class="c-sidenav__item {% if page_url_rest == '/' or page_url_rest == '' %}is-active{% endif %}"
+           href="{{ topitem.url | prepend: site.baseurl }}">{{topitem.name}}</a></li>
+
+    {% for i in topitem.sidenav %}
+      {% if i.item.url %}
+        {% assign url = i.item.url %}
+        {% assign url_for_matching = url | remove: ".html" %}
+        <li><a class="c-sidenav__item {% if page_url_rest == url_for_matching %}is-active{% endif %}"
+               href="{{ url | prepend: topitem.url | prepend: site.baseurl }}">{{i.item.name}}</a></li>
+      {% else %}
+        <li class="c-sidenav__dir">{{i.item.name}}</li>
+        {% for j in i.item.subgroup %}
+          {% assign url = i.item.dir_url | append: j.item.url %}
+          {% assign url_for_matching = url | remove: ".html" %}
+        <li><a class="c-sidenav__item {% if page_url_rest == url_for_matching %}is-active{% endif %}"
+               href="{{ url | prepend: topitem.url | prepend: site.baseurl }}">&#x2192 {{j.item.name}}</a></li>
+        {% endfor %}
+      {% endif %}
+    {% endfor %}
+
+  </div>
+</nav>
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,6 +22,8 @@ layout: base
     </div>
   </header>
 
+  {% include sidenav.html %}
+
   <div class="c-article__main">
     {{ content }}
   </div>

--- a/_sass/components/_sidenav.scss
+++ b/_sass/components/_sidenav.scss
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ==========================================================================
+   Sidenav
+   ========================================================================== */
+
+.c-sidenav {
+  position: relative;
+  float:left;
+  left: 0;
+  height: 1000px;
+  padding: 0 2.5rem;
+  background: $t-theme;
+  z-index: 10;
+  list-style-type: none;
+
+  &.is-fixed {
+    position: fixed;
+    will-change: transform;
+  }
+}
+
+.c-sidenav__item {
+  position: relative;
+  display: block;
+  padding-top: 2.5rem;
+  padding-bottom: 2.5rem;
+  @include ff--mono(500);
+  @include fs--meta;
+  color: $c__white;
+  text-transform: uppercase;
+
+  &:not(:last-of-type) {
+    margin-right: 2.5rem;
+  }
+
+  &:after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    background: transparent;
+    transition: background ease-in-out 0.2s;
+  }
+
+  &:hover:after,
+  &.is-active:after {
+    background: $c__white;
+  }
+}
+
+.c-sidenav__dir {
+  position: relative;
+  float: bottom;
+  display: block;
+  padding-top: 2.5rem;
+  padding-bottom: 2.5rem;
+  @include ff--mono(500);
+  @include fs--meta;
+  font-weight:bold;
+  color: $c__white;
+  text-transform: uppercase;
+
+  &:not(:last-of-type) {
+    margin-right: 2.5rem;
+  }
+}
+
+
+.c-sidenav__container {
+  overflow: auto;
+  white-space: nowrap;
+}

--- a/_sass/themes/_blue.scss
+++ b/_sass/themes/_blue.scss
@@ -21,6 +21,7 @@
 .t-blue {
 
   .c-navigation,
+  .c-sidenav,
   .c-header {
     background: $c__blue;
   }

--- a/_sass/themes/_green.scss
+++ b/_sass/themes/_green.scss
@@ -21,6 +21,7 @@
 .t-green {
 
   .c-navigation,
+  .c-sidenav,
   .c-header {
     background: $c__green;
   }

--- a/_sass/themes/_grey.scss
+++ b/_sass/themes/_grey.scss
@@ -21,6 +21,7 @@
 .t-grey {
 
   .c-navigation,
+  .c-sidenav,
   .c-header {
     background: $c__blue-grey;
   }

--- a/_sass/themes/_orange.scss
+++ b/_sass/themes/_orange.scss
@@ -21,6 +21,7 @@
 .t-orange {
 
   .c-navigation,
+  .c-sidenav,
   .c-header {
     background: $c__deep-orange;
   }

--- a/_sass/themes/_purple.scss
+++ b/_sass/themes/_purple.scss
@@ -21,6 +21,7 @@
 .t-purple {
 
   .c-navigation,
+  .c-sidenav,
   .c-header {
     background: $c__deep-purple;
   }

--- a/_sass/themes/_teal.scss
+++ b/_sass/themes/_teal.scss
@@ -21,6 +21,7 @@
 .t-teal {
 
   .c-navigation,
+  .c-sidenav,
   .c-header {
     background: $c__teal;
   }

--- a/css/main.scss
+++ b/css/main.scss
@@ -34,6 +34,7 @@
 @import
   'components/header',
   'components/navigation',
+  'components/sidenav',
   'components/article',
   'components/archives',
   'components/social',


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add support for a side navigation bar. Also fixes a bug where the highlighting of the chosen
section in the top navigation was not showing up correctly.

With this support, it is assumed that side navigation is a subtree of the top navigation.
For example, if a url is base.com/foo/bar, then foo is the top nav location and bar
is the left nav location.

The tree can be specified in the config as follows. Note that Home currently cannot support
a side navigation bar.

nav:
  - item:
      name: Home
      url: /
  - item:
      name: Top Item 2
      url: /topitem2
      sidenav:
        - item:
            name: "sidenav1"
            url: "/sidenav2-1"
	- item:
            name: "sidenav2"
            url: "/sidenav2-2"
  - item:
      name: "Top Item 3"
      url: /topitem3
      sidenav:
        - item:
            name: "side nav sub dir"
	    dir_url: "/sidedir"
	    subgroup:
              - item:
                  name: "multibindings"
                  url: "/multibindings"
              - item:
                  name: "multibindings2"
                  url: "/multibindings2"

e60588e8a95539dc025f2d3be1562e3f2dfac7c7