### PR TITLE
MOE Sync 2020-04-09

### DIFF
--- a/core/src/main/java/com/google/common/truth/PrimitiveDoubleArraySubject.java
+++ b/core/src/main/java/com/google/common/truth/PrimitiveDoubleArraySubject.java
@@ -177,7 +177,7 @@ public final class PrimitiveDoubleArraySubject extends AbstractArraySubject {
    *       {@link Double#NaN} to be equal to themselves (contrast with {@code usingTolerance(0.0)}
    *       which does not).
    *   <li>It does <i>not</i> consider {@code -0.0} to be equal to {@code 0.0} (contrast with {@code
-   *       usingTolerance(0.0)} which does not).
+   *       usingTolerance(0.0)} which does).
    *   <li>The subsequent methods in the chain may throw a {@link NullPointerException} if any
    *       expected {@link Double} instance is null.
    * </ul>

--- a/refactorings/src/main/java/com/google/common/truth/refactorings/CorrespondenceSubclassToFactoryCall.java
+++ b/refactorings/src/main/java/com/google/common/truth/refactorings/CorrespondenceSubclassToFactoryCall.java
@@ -27,7 +27,6 @@ import static com.google.common.collect.Streams.stream;
 import static com.google.common.truth.refactorings.CorrespondenceSubclassToFactoryCall.MemberType.COMPARE_METHOD;
 import static com.google.common.truth.refactorings.CorrespondenceSubclassToFactoryCall.MemberType.CONSTRUCTOR;
 import static com.google.common.truth.refactorings.CorrespondenceSubclassToFactoryCall.MemberType.TO_STRING_METHOD;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.fixes.SuggestedFixes.compilesWithFix;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -92,8 +91,7 @@ import javax.lang.model.element.Modifier;
 @BugPattern(
     name = "CorrespondenceSubclassToFactoryCall",
     summary = "Use the factory methods on Correspondence instead of defining a subclass.",
-    severity = SUGGESTION,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = SUGGESTION)
 public final class CorrespondenceSubclassToFactoryCall extends BugChecker
     implements ClassTreeMatcher {
   @Override

--- a/refactorings/src/main/java/com/google/common/truth/refactorings/FailWithFacts.java
+++ b/refactorings/src/main/java/com/google/common/truth/refactorings/FailWithFacts.java
@@ -18,7 +18,6 @@ package com.google.common.truth.refactorings;
 
 import static com.google.common.base.CharMatcher.inRange;
 import static com.google.common.base.CharMatcher.whitespace;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
@@ -57,8 +56,7 @@ import java.util.List;
 @BugPattern(
     name = "FailWithFacts",
     summary = "Use the new key-value-style failure API instead of the deprecated one.",
-    severity = SUGGESTION,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = SUGGESTION)
 public final class FailWithFacts extends BugChecker implements MethodInvocationTreeMatcher {
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {

--- a/refactorings/src/main/java/com/google/common/truth/refactorings/NamedToWithMessage.java
+++ b/refactorings/src/main/java/com/google/common/truth/refactorings/NamedToWithMessage.java
@@ -18,7 +18,6 @@ package com.google.common.truth.refactorings;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -62,8 +61,7 @@ import javax.annotation.Nullable;
 @BugPattern(
     name = "NamedToWithMessage",
     summary = "Use assertWithMessage(...)/withMessage(...) instead of the deprecated named(...).",
-    severity = SUGGESTION,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = SUGGESTION)
 public final class NamedToWithMessage extends BugChecker implements MethodInvocationTreeMatcher {
   @Override
   public Description matchMethodInvocation(MethodInvocationTree namedCall, VisitorState state) {

--- a/refactorings/src/main/java/com/google/common/truth/refactorings/StoreActualValueInField.java
+++ b/refactorings/src/main/java/com/google/common/truth/refactorings/StoreActualValueInField.java
@@ -18,7 +18,6 @@ package com.google.common.truth.refactorings;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.fixes.SuggestedFix.replace;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -73,8 +72,7 @@ import javax.lang.model.element.Name;
     name = "StoreActualValueInField",
     summary =
         "Store the actual value locally instead of using the deprecated actual() and getSubject().",
-    severity = SUGGESTION,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = SUGGESTION)
 public final class StoreActualValueInField extends BugChecker
     implements MethodInvocationTreeMatcher {
   @Override


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix a small but sense-inverting typo in the PrimitiveDoubleArraySubject docs.

(PrimitiveFloatArraySubject was already correct.)

RELNOTES=N/A

1337257e19813707e8f9281967c6c1e5d705b9ce

-------

<p> Remove use of about-to-be-deprecated @BugPattern.providesFix.

c66b325daa18778c477550f6004639486b99b8c4