### PR TITLE
MOE Sync 2020-05-04

### DIFF
--- a/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/OverloadResolutionTest.java
+++ b/extensions/proto/src/test/java/com/google/common/truth/extensions/proto/OverloadResolutionTest.java
@@ -360,4 +360,5 @@ public class OverloadResolutionTest extends ProtoSubjectTestBase {
     assertThat(altActualObjects).doesNotContainEntry("a", message1);
     assertThat(altActualObjects).doesNotContainEntry("b", message2);
   }
+
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add ProtoTruth.assertThat(Multiset<M>) overload to resolve ambiguity

reference to assertThat is ambiguous
  both method <M>assertThat(java.lang.Iterable<M>) in com.google.common.truth.extensions.proto.ProtoTruth and method assertThat(com.google.common.collect.Multiset<?>) in com.google.common.truth.Truth match

927744f5de295dd38492a527ff22649ab81c3880