### PR TITLE
MOE Sync 2020-05-08

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ branches:
 
 cache:
   directories:
-    - $HOME/.m2
+    - $HOME/.m2/repository


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Change travis cache to cache .m2/repository, not all of .m2

This should (?) allow settings.xml changes to propagate down to our build, but still cache copied versions of dependency jars.

02d293f5d2feaeab1fbaeaa7fb9f1d6bdc78697f