### PR TITLE
MOE Sync 2020-06-09

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,7 @@
             <detectJavaApiLink>false</detectJavaApiLink>
             <links>
               <!-- TODO(cpovirk): Link to the version that we depend on? -->
-              <link>https://google.github.io/guava/releases/snapshot-jre/api/docs</link>
+              <link>https://guava.dev/releases/snapshot-jre/api/docs</link>
               <link>https://developers.google.com/protocol-buffers/docs/reference/java</link>
               <link>https://junit.org/junit4/javadoc/latest/</link>
               <link>https://docs.oracle.com/javase/7/docs/api/</link>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Change links from google.github.io/guava to guava.dev, including making sure they're https.

The links work even now because they automatically redirect.

d4c974d6ab07aa1f9921d51a378aaa7197027a14