### PR TITLE
MOE Sync 2020-06-10

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,10 +22,12 @@ layout: base
     </div>
   </header>
 
-  {% include sidenav.html %}
+  <div class="c-article__container">
+    {% include sidenav.html %}
 
-  <div class="c-article__main">
-    {{ content }}
+    <div class="c-article__main">
+      {{ content }}
+    </div>
   </div>
 
   {% include codeselector.html %}

--- a/_sass/components/_article.scss
+++ b/_sass/components/_article.scss
@@ -22,6 +22,16 @@
 
 }
 
+.c-article__container {
+  display: block;
+}
+
+@media (min-width: 42rem) {
+  .c-article__container {
+    display: flex;
+  }
+}
+
 .c-article__main {
   max-width: 76rem; // 760px;
   margin-right: auto;

--- a/_sass/components/_sidenav.scss
+++ b/_sass/components/_sidenav.scss
@@ -19,12 +19,8 @@
    ========================================================================== */
 
 .c-sidenav {
-  position: relative;
-  float:left;
-  left: 0;
   padding: 0 2.5rem 2.5rem;
   background: $t-theme;
-  z-index: 10;
   list-style-type: none;
 
   &.is-fixed {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Wrap the sidenav and article content in a flexbox to avoid issues with content overflowing weirdly on smaller screens.

Fixes https://github.com/google/dagger/issues/1886

f5497d87b4704a981a00a73db35764ad2e4066dc