### PR TITLE
Add JUnit 5 Expect extension

### DIFF
--- a/extensions/junit5/pom.xml
+++ b/extensions/junit5/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.google.truth.extensions</groupId>
+    <artifactId>truth-extensions-parent</artifactId>
+    <version>HEAD-SNAPSHOT</version>
+  </parent>
+  <artifactId>truth-junit5-extension</artifactId>
+  <name>Truth Extension for JUnit Jupiter</name>
+  <description>
+    An extension for JUnit Jupiter to use soft assertions with Truth test assertion framework
+  </description>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.opentest4j</groupId>
+      <artifactId>opentest4j</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/extensions/junit5/src/main/java/com/google/common/truth/junit5/Expect.java
+++ b/extensions/junit5/src/main/java/com/google/common/truth/junit5/Expect.java
@@ -1,0 +1,82 @@
+package com.google.common.truth.junit5;
+
+import com.google.common.truth.FailureStrategy;
+import com.google.common.truth.StandardSubjectBuilder;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.opentest4j.MultipleFailuresError;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An <tt>Extension</tt> that provides a {@link StandardSubjectBuilder} parameter to test methods.
+ *
+ * <p>Assertion failures on the given <tt>StandardSubjectBuilder</tt> will not immediately fail;
+ * instead, failures will be reported at the <em>end</em> of the test.
+ *
+ * <p>Usage:
+ *
+ * <pre>
+ * @ExtendWith(Expect.class) // or system property junit.jupiter.extensions.autodetection.enabled=true
+ * ...
+ *     @Test
+ *     public void test(StandardSubjectBuilder expect) {
+ *         ...
+ *     }
+ * </pre>
+ */
+public class Expect implements Extension, ParameterResolver, AfterEachCallback {
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        return parameterContext.getParameter().getType() == StandardSubjectBuilder.class;
+    }
+
+    @Override
+    public StandardSubjectBuilder resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        ExtensionContext.Store store = extensionContext.getStore(ExtensionContext.Namespace.create(Expect.class));
+        return store.getOrComputeIfAbsent(extensionContext.getUniqueId(), key -> new Holder(), Holder.class).get();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        ExtensionContext.Store store = context.getStore(ExtensionContext.Namespace.create(Expect.class));
+        Holder holder = store.get(context.getUniqueId(), Holder.class);
+        List<AssertionError> failures = null;
+        if (holder != null) {
+            synchronized (holder) {
+                failures = holder.failures;
+                if (failures == null) {
+                    throw new IllegalStateException();
+                }
+                holder.failures = null;
+            }
+        }
+        if (failures != null && !failures.isEmpty()) {
+            throw failures.size() == 1 ? failures.get(0) : new MultipleFailuresError(null, failures);
+        }
+    }
+
+    private static class Holder implements FailureStrategy, ExtensionContext.Store.CloseableResource {
+        private List<AssertionError> failures = new ArrayList<>();
+
+        private StandardSubjectBuilder get() {
+            return StandardSubjectBuilder.forCustomFailureStrategy(this);
+        }
+
+        @Override
+        public synchronized void fail(AssertionError failure) {
+            failures.add(failure);
+        }
+
+        @Override
+        public synchronized void close() {
+            if (failures != null) {
+                throw new IllegalStateException();
+            }
+        }
+    }
+}

--- a/extensions/junit5/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/extensions/junit5/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+com.google.common.truth.junit5.Expect

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -22,5 +22,6 @@
     <module>re2j</module>
     <module>liteproto</module>
     <module>proto</module>
+    <module>junit5</module>
   </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,16 @@
         <version>4.12</version>
       </dependency>
       <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>5.6.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.opentest4j</groupId>
+        <artifactId>opentest4j</artifactId>
+        <version>1.2.0</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.gwt</groupId>
         <artifactId>gwt-user</artifactId>
         <version>${gwt.version}</version>


### PR DESCRIPTION
Analogous to the `com.google.common.truth.Expect` rule for JUnit4.

I've been using it in a personal (Kotlin) project; for this PR, I translated back to Java as I don't see any usage of Kotlin in this project.