### PR TITLE
MOE Sync 2020-07-20

### DIFF
--- a/core/src/main/java/com/google/common/truth/MapSubject.java
+++ b/core/src/main/java/com/google/common/truth/MapSubject.java
@@ -112,29 +112,7 @@ public class MapSubject extends Subject {
     if (!actual.entrySet().contains(entry)) {
       List<Object> keyList = Lists.newArrayList(key);
       List<Object> valueList = Lists.newArrayList(value);
-      // TODO(cpovirk): Move the check for the correct key (actual.containsKey) ahead of the check
-      // for a different key with the same toString. And the same for values.
-      if (hasMatchingToStringPair(actual.keySet(), keyList)) {
-        failWithoutActual(
-            fact("expected to contain entry", entry),
-            fact("an instance of", objectToTypeName(entry)),
-            simpleFact("but did not"),
-            fact(
-                "though it did contain keys",
-                countDuplicatesAndAddTypeInfo(
-                    retainMatchingToString(actual.keySet(), /* itemsToCheck= */ keyList))),
-            fact("full contents", actualCustomStringRepresentationForPackageMembersToCall()));
-      } else if (hasMatchingToStringPair(actual.values(), valueList)) {
-        failWithoutActual(
-            fact("expected to contain entry", entry),
-            fact("an instance of", objectToTypeName(entry)),
-            simpleFact("but did not"),
-            fact(
-                "though it did contain values",
-                countDuplicatesAndAddTypeInfo(
-                    retainMatchingToString(actual.values(), /* itemsToCheck= */ valueList))),
-            fact("full contents", actualCustomStringRepresentationForPackageMembersToCall()));
-      } else if (actual.containsKey(key)) {
+      if (actual.containsKey(key)) {
         Object actualValue = actual.get(key);
         /*
          * In the case of a null expected or actual value, clarify that the key *is* present and
@@ -147,6 +125,16 @@ public class MapSubject extends Subject {
         }
         // See the comment on IterableSubject's use of failEqualityCheckForEqualsWithoutDescription.
         check.that(actualValue).failEqualityCheckForEqualsWithoutDescription(value);
+      } else if (hasMatchingToStringPair(actual.keySet(), keyList)) {
+        failWithoutActual(
+            fact("expected to contain entry", entry),
+            fact("an instance of", objectToTypeName(entry)),
+            simpleFact("but did not"),
+            fact(
+                "though it did contain keys",
+                countDuplicatesAndAddTypeInfo(
+                    retainMatchingToString(actual.keySet(), /* itemsToCheck= */ keyList))),
+            fact("full contents", actualCustomStringRepresentationForPackageMembersToCall()));
       } else if (actual.containsValue(value)) {
         Set<Object> keys = new LinkedHashSet<>();
         for (Map.Entry<?, ?> actualEntry : actual.entrySet()) {
@@ -158,6 +146,16 @@ public class MapSubject extends Subject {
             fact("expected to contain entry", entry),
             simpleFact("but did not"),
             fact("though it did contain keys with that value", keys),
+            fact("full contents", actualCustomStringRepresentationForPackageMembersToCall()));
+      } else if (hasMatchingToStringPair(actual.values(), valueList)) {
+        failWithoutActual(
+            fact("expected to contain entry", entry),
+            fact("an instance of", objectToTypeName(entry)),
+            simpleFact("but did not"),
+            fact(
+                "though it did contain values",
+                countDuplicatesAndAddTypeInfo(
+                    retainMatchingToString(actual.values(), /* itemsToCheck= */ valueList))),
             fact("full contents", actualCustomStringRepresentationForPackageMembersToCall()));
       } else {
         failWithActual("expected to contain entry", entry);
@@ -270,10 +268,10 @@ public class MapSubject extends Subject {
     // might be misleading to report a single mismatched value when the assertion was on the whole
     // map - this could be mitigated by adding extra info explaining that. (Would need to ensure
     // that it still fails in cases where e.g. the value is 1 and it should be 1L, where isEqualTo
-    // succeeds. Could do that by having a stricter isEqualTo-like method, or more simply by making
-    // standardIsEqualTo be package-private and return a boolean indicating whether it passed or
-    // failed and falling through to the existing logic if it passed.)
+    // succeeds: perhaps failEqualityCheckForEqualsWithoutDescription will do the right thing.)
     // First, we need to decide whether this kind of cleverness is a line we want to cross.
+    // (See also containsEntry, which does do an isEqualTo-like assertion when the expected key is
+    // present with the wrong value, which may be the closest we currently get to this.)
     failWithoutActual(
         ImmutableList.<Fact>builder()
             .addAll(diff.describe(/* differ = */ null))

--- a/core/src/test/java/com/google/common/truth/MapSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/MapSubjectTest.java
@@ -987,7 +987,8 @@ public class MapSubjectTest extends BaseSubjectTestCase {
 
   @Test
   public void containsEntry_failsWithSameToStringOfValue() {
-    expectFailureWhenTestingThat(ImmutableMap.of(1, "null")).containsEntry(1, null);
+    // Does not contain the correct key, but does contain a value which matches by toString.
+    expectFailureWhenTestingThat(ImmutableMap.of(1, "null")).containsEntry(2, null);
     assertFailureKeys(
         "expected to contain entry",
         "an instance of",
@@ -1043,6 +1044,17 @@ public class MapSubjectTest extends BaseSubjectTestCase {
     assertThat(expectFailure.getFailure())
         .hasMessageThat()
         .contains(KEY_IS_PRESENT_WITH_DIFFERENT_VALUE);
+  }
+
+  @Test
+  public void containsExactly_bothExactAndToStringKeyMatches_showsExactKeyMatch() {
+    ImmutableMap<Number, String> actual = ImmutableMap.of(1, "actual int", 1L, "actual long");
+    expectFailureWhenTestingThat(actual).containsEntry(1L, "expected long");
+    // should show the exact key match, 1="actual int", not the toString key match, 1L="actual long"
+    assertFailureKeys("value of", "expected", "but was", "map was");
+    assertFailureValue("value of", "map.get(1)");
+    assertFailureValue("expected", "expected long");
+    assertFailureValue("but was", "actual long");
   }
 
   @Test


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Change the order of checks in MapSubject.containsEntry.

This addresses a TODO left from the previous CL.

404a6558c687f8ae9d327d8111d3aafe8250b37a

-------

<p> Convert MultimapSubject failures (both vanilla and fuzzy) to facts.

With one minor exception, this only reformats the existing information from free-form text into structured facts, without changing the information shown. In particular, it does not do the group-by-key which would bring multimaps more into parity with maps. However, that change will be easier to do in the new structured format. (The one minor exception is for one of the fuzzy containsExactly cases, and is explained in an implementation comment.)

84061dbc1f7a9ff676617cc61c0756a36f9f5c56