### PR TITLE
MOE Sync 2020-07-27

### DIFF
--- a/core/src/main/java/com/google/common/truth/IterableSubject.java
+++ b/core/src/main/java/com/google/common/truth/IterableSubject.java
@@ -1031,7 +1031,7 @@ public class IterableSubject extends Subject {
                 ImmutableList.<Fact>builder()
                     .addAll(exceptions.describeAsMainCause())
                     .add(fact("expected to contain", expected))
-                    .add(correspondence.describeForIterable())
+                    .addAll(correspondence.describeForIterable())
                     .add(fact("found match (but failing because of exception)", actual))
                     .add(subject.fullContents())
                     .build());
@@ -1046,7 +1046,7 @@ public class IterableSubject extends Subject {
           subject.failWithoutActual(
               ImmutableList.<Fact>builder()
                   .add(fact("expected to contain", expected))
-                  .add(correspondence.describeForIterable())
+                  .addAll(correspondence.describeForIterable())
                   .add(simpleFact("but did not"))
                   .addAll(
                       formatExtras(
@@ -1064,7 +1064,7 @@ public class IterableSubject extends Subject {
       subject.failWithoutActual(
           ImmutableList.<Fact>builder()
               .add(fact("expected to contain", expected))
-              .add(correspondence.describeForIterable())
+              .addAll(correspondence.describeForIterable())
               .add(subject.butWas())
               .addAll(exceptions.describeAsAdditionalInfo())
               .build());
@@ -1084,7 +1084,7 @@ public class IterableSubject extends Subject {
         subject.failWithoutActual(
             ImmutableList.<Fact>builder()
                 .add(fact("expected not to contain", excluded))
-                .add(correspondence.describeForIterable())
+                .addAll(correspondence.describeForIterable())
                 .add(fact("but contained", countDuplicates(matchingElements)))
                 .add(subject.fullContents())
                 .addAll(exceptions.describeAsAdditionalInfo())
@@ -1097,7 +1097,7 @@ public class IterableSubject extends Subject {
             ImmutableList.<Fact>builder()
                 .addAll(exceptions.describeAsMainCause())
                 .add(fact("expected not to contain", excluded))
-                .add(correspondence.describeForIterable())
+                .addAll(correspondence.describeForIterable())
                 .add(simpleFact("found no match (but failing because of exception)"))
                 .add(subject.fullContents())
                 .build());
@@ -1179,7 +1179,7 @@ public class IterableSubject extends Subject {
             ImmutableList.<Fact>builder()
                 .addAll(exceptions.describeAsMainCause())
                 .add(fact("expected", expected))
-                .add(correspondence.describeForIterable())
+                .addAll(correspondence.describeForIterable())
                 .add(simpleFact("found all expected elements (but failing because of exception)"))
                 .add(subject.fullContents())
                 .build());
@@ -1191,9 +1191,11 @@ public class IterableSubject extends Subject {
         @Override
         public void inOrder() {
           subject.failWithActual(
-              simpleFact("contents match, but order was wrong"),
-              fact("expected", expected),
-              correspondence.describeForIterable());
+              ImmutableList.<Fact>builder()
+                  .add(simpleFact("contents match, but order was wrong"))
+                  .add(fact("expected", expected))
+                  .addAll(correspondence.describeForIterable())
+                  .build());
         }
       };
     }
@@ -1274,7 +1276,7 @@ public class IterableSubject extends Subject {
             ImmutableList.<Fact>builder()
                 .addAll(describeMissingOrExtra(missing, extra, exceptions))
                 .add(fact("expected", expected))
-                .add(correspondence.describeForIterable())
+                .addAll(correspondence.describeForIterable())
                 .add(subject.butWas())
                 .addAll(exceptions.describeAsAdditionalInfo())
                 .build());
@@ -1446,7 +1448,7 @@ public class IterableSubject extends Subject {
                             + " tie)"))
                 .addAll(describeMissingOrExtra(missing, extra, exceptions))
                 .add(fact("expected", expected))
-                .add(correspondence.describeForIterable())
+                .addAll(correspondence.describeForIterable())
                 .add(subject.butWas())
                 .addAll(exceptions.describeAsAdditionalInfo())
                 .build());
@@ -1516,7 +1518,7 @@ public class IterableSubject extends Subject {
             ImmutableList.<Fact>builder()
                 .addAll(exceptions.describeAsMainCause())
                 .add(fact("expected to contain at least", expected))
-                .add(correspondence.describeForIterable())
+                .addAll(correspondence.describeForIterable())
                 .add(simpleFact("found all expected elements (but failing because of exception)"))
                 .add(subject.fullContents())
                 .build());
@@ -1528,9 +1530,11 @@ public class IterableSubject extends Subject {
         @Override
         public void inOrder() {
           subject.failWithActual(
-              simpleFact("required elements were all found, but order was wrong"),
-              fact("expected order for required elements", expected),
-              correspondence.describeForIterable());
+              ImmutableList.<Fact>builder()
+                  .add(simpleFact("required elements were all found, but order was wrong"))
+                  .add(fact("expected order for required elements", expected))
+                  .addAll(correspondence.describeForIterable())
+                  .build());
         }
       };
     }
@@ -1609,7 +1613,7 @@ public class IterableSubject extends Subject {
             ImmutableList.<Fact>builder()
                 .addAll(describeMissing(missing, extra, exceptions))
                 .add(fact("expected to contain at least", expected))
-                .add(correspondence.describeForIterable())
+                .addAll(correspondence.describeForIterable())
                 .add(subject.butWas())
                 .addAll(exceptions.describeAsAdditionalInfo())
                 .build());
@@ -1699,7 +1703,7 @@ public class IterableSubject extends Subject {
                             + " tie)"))
                 .addAll(describeMissing(missing, extra, exceptions))
                 .add(fact("expected to contain at least", expected))
-                .add(correspondence.describeForIterable())
+                .addAll(correspondence.describeForIterable())
                 .add(subject.butWas())
                 .addAll(exceptions.describeAsAdditionalInfo())
                 .build());
@@ -1734,7 +1738,7 @@ public class IterableSubject extends Subject {
                   ImmutableList.<Fact>builder()
                       .addAll(exceptions.describeAsMainCause())
                       .add(fact("expected to contain any of", expected))
-                      .add(correspondence.describeForIterable())
+                      .addAll(correspondence.describeForIterable())
                       .add(simpleFact("found match (but failing because of exception)"))
                       .add(subject.fullContents())
                       .build());
@@ -1753,7 +1757,7 @@ public class IterableSubject extends Subject {
             subject.failWithoutActual(
                 ImmutableList.<Fact>builder()
                     .add(fact("expected to contain any of", expected))
-                    .add(correspondence.describeForIterable())
+                    .addAll(correspondence.describeForIterable())
                     .add(subject.butWas())
                     .addAll(describeAnyMatchesByKey(pairing, exceptions))
                     .addAll(exceptions.describeAsAdditionalInfo())
@@ -1762,7 +1766,7 @@ public class IterableSubject extends Subject {
             subject.failWithoutActual(
                 ImmutableList.<Fact>builder()
                     .add(fact("expected to contain any of", expected))
-                    .add(correspondence.describeForIterable())
+                    .addAll(correspondence.describeForIterable())
                     .add(subject.butWas())
                     .add(simpleFact("it does not contain any matches by key, either"))
                     .addAll(exceptions.describeAsAdditionalInfo())
@@ -1772,7 +1776,7 @@ public class IterableSubject extends Subject {
           subject.failWithoutActual(
               ImmutableList.<Fact>builder()
                   .add(fact("expected to contain any of", expected))
-                  .add(correspondence.describeForIterable())
+                  .addAll(correspondence.describeForIterable())
                   .add(subject.butWas())
                   .add(
                       simpleFact(
@@ -1785,7 +1789,7 @@ public class IterableSubject extends Subject {
         subject.failWithoutActual(
             ImmutableList.<Fact>builder()
                 .add(fact("expected to contain any of", expected))
-                .add(correspondence.describeForIterable())
+                .addAll(correspondence.describeForIterable())
                 .add(subject.butWas())
                 .addAll(exceptions.describeAsAdditionalInfo())
                 .build());
@@ -1847,7 +1851,7 @@ public class IterableSubject extends Subject {
       if (!present.isEmpty()) {
         ImmutableList.Builder<Fact> facts = ImmutableList.builder();
         facts.add(fact("expected not to contain any of", annotateEmptyStrings(excluded)));
-        facts.add(correspondence.describeForIterable());
+        facts.addAll(correspondence.describeForIterable());
         for (E excludedItem : present.keySet()) {
           List<A> actualItems = present.get(excludedItem);
           facts.add(fact("but contained", annotateEmptyStrings(actualItems)));
@@ -1866,7 +1870,7 @@ public class IterableSubject extends Subject {
             ImmutableList.<Fact>builder()
                 .addAll(exceptions.describeAsMainCause())
                 .add(fact("expected not to contain any of", annotateEmptyStrings(excluded)))
-                .add(correspondence.describeForIterable())
+                .addAll(correspondence.describeForIterable())
                 .add(simpleFact("found no matches (but failing because of exception)"))
                 .add(subject.fullContents())
                 .build());

--- a/core/src/main/java/com/google/common/truth/MapSubject.java
+++ b/core/src/main/java/com/google/common/truth/MapSubject.java
@@ -463,7 +463,7 @@ public class MapSubject extends Subject {
                         allowUnexpected ? "expected to contain at least" : "expected",
                         expectedMap));
         if (correspondence != null) {
-          facts.add(correspondence.describeForMapValues());
+          facts.addAll(correspondence.describeForMapValues());
         }
         failWithActual(facts.build());
       }
@@ -550,7 +550,7 @@ public class MapSubject extends Subject {
               ImmutableList.<Fact>builder()
                   .add(fact("for key", expectedKey))
                   .add(fact("expected value", expectedValue))
-                  .add(correspondence.describeForMapValues())
+                  .addAll(correspondence.describeForMapValues())
                   .add(fact("but got value", actualValue))
                   .add(fact("diff", diff))
                   .add(fact("full map", actualCustomStringRepresentationForPackageMembersToCall()))
@@ -561,7 +561,7 @@ public class MapSubject extends Subject {
               ImmutableList.<Fact>builder()
                   .add(fact("for key", expectedKey))
                   .add(fact("expected value", expectedValue))
-                  .add(correspondence.describeForMapValues())
+                  .addAll(correspondence.describeForMapValues())
                   .add(fact("but got value", actualValue))
                   .add(fact("full map", actualCustomStringRepresentationForPackageMembersToCall()))
                   .addAll(exceptions.describeAsAdditionalInfo())
@@ -582,7 +582,7 @@ public class MapSubject extends Subject {
               ImmutableList.<Fact>builder()
                   .add(fact("for key", expectedKey))
                   .add(fact("expected value", expectedValue))
-                  .add(correspondence.describeForMapValues())
+                  .addAll(correspondence.describeForMapValues())
                   .add(simpleFact("but was missing"))
                   .add(fact("other keys with matching values", keys))
                   .add(fact("full map", actualCustomStringRepresentationForPackageMembersToCall()))
@@ -594,7 +594,7 @@ public class MapSubject extends Subject {
               ImmutableList.<Fact>builder()
                   .add(fact("for key", expectedKey))
                   .add(fact("expected value", expectedValue))
-                  .add(correspondence.describeForMapValues())
+                  .addAll(correspondence.describeForMapValues())
                   .add(simpleFact("but was missing"))
                   .add(fact("full map", actualCustomStringRepresentationForPackageMembersToCall()))
                   .addAll(exceptions.describeAsAdditionalInfo())
@@ -619,7 +619,7 @@ public class MapSubject extends Subject {
           failWithoutActual(
               ImmutableList.<Fact>builder()
                   .add(fact("expected not to contain", immutableEntry(excludedKey, excludedValue)))
-                  .add(correspondence.describeForMapValues())
+                  .addAll(correspondence.describeForMapValues())
                   .add(fact("but contained", immutableEntry(excludedKey, actualValue)))
                   .add(fact("full map", actualCustomStringRepresentationForPackageMembersToCall()))
                   .addAll(exceptions.describeAsAdditionalInfo())
@@ -631,7 +631,7 @@ public class MapSubject extends Subject {
               ImmutableList.<Fact>builder()
                   .addAll(exceptions.describeAsMainCause())
                   .add(fact("expected not to contain", immutableEntry(excludedKey, excludedValue)))
-                  .add(correspondence.describeForMapValues())
+                  .addAll(correspondence.describeForMapValues())
                   .add(simpleFact("found no match (but failing because of exception)"))
                   .add(fact("full map", actualCustomStringRepresentationForPackageMembersToCall()))
                   .build());
@@ -731,7 +731,7 @@ public class MapSubject extends Subject {
               .addAll(diff.describe(differ(exceptions)))
               .add(simpleFact("---"))
               .add(fact(allowUnexpected ? "expected to contain at least" : "expected", expectedMap))
-              .add(correspondence.describeForMapValues())
+              .addAll(correspondence.describeForMapValues())
               .add(butWas())
               .addAll(exceptions.describeAsAdditionalInfo())
               .build());

--- a/core/src/main/java/com/google/common/truth/MultimapSubject.java
+++ b/core/src/main/java/com/google/common/truth/MultimapSubject.java
@@ -567,7 +567,7 @@ public class MultimapSubject extends Subject {
                           fact(
                               "expected to contain entry",
                               immutableEntry(expectedKey, expectedValue)))
-                      .add(correspondence.describeForMapValues())
+                      .addAll(correspondence.describeForMapValues())
                       .add(
                           fact(
                               "found match (but failing because of exception)",
@@ -585,7 +585,7 @@ public class MultimapSubject extends Subject {
         failWithoutActual(
             ImmutableList.<Fact>builder()
                 .add(fact("expected to contain entry", immutableEntry(expectedKey, expectedValue)))
-                .add(correspondence.describeForMapValues())
+                .addAll(correspondence.describeForMapValues())
                 .add(simpleFact("but did not"))
                 .add(fact("though it did contain values for that key", actualValues))
                 .add(
@@ -608,7 +608,7 @@ public class MultimapSubject extends Subject {
               ImmutableList.<Fact>builder()
                   .add(
                       fact("expected to contain entry", immutableEntry(expectedKey, expectedValue)))
-                  .add(correspondence.describeForMapValues())
+                  .addAll(correspondence.describeForMapValues())
                   .add(simpleFact("but did not"))
                   // The corresponding failure in the non-Correspondence case reports the keys
                   // mapping to the expected value. Here, we show the full entries, because for some
@@ -627,7 +627,7 @@ public class MultimapSubject extends Subject {
               ImmutableList.<Fact>builder()
                   .add(
                       fact("expected to contain entry", immutableEntry(expectedKey, expectedValue)))
-                  .add(correspondence.describeForMapValues())
+                  .addAll(correspondence.describeForMapValues())
                   .add(simpleFact("but did not"))
                   .add(
                       fact(
@@ -662,7 +662,7 @@ public class MultimapSubject extends Subject {
                       fact(
                           "expected not to contain entry",
                           immutableEntry(excludedKey, excludedValue)))
-                  .add(correspondence.describeForMapValues())
+                  .addAll(correspondence.describeForMapValues())
                   .add(fact("but contained that key with matching values", matchingValues))
                   .add(
                       fact(
@@ -680,7 +680,7 @@ public class MultimapSubject extends Subject {
                         fact(
                             "expected not to contain entry",
                             immutableEntry(excludedKey, excludedValue)))
-                    .add(correspondence.describeForMapValues())
+                    .addAll(correspondence.describeForMapValues())
                     .add(simpleFact("found no match (but failing because of exception)"))
                     .add(
                         fact(

--- a/core/src/test/java/com/google/common/truth/IterableSubjectCorrespondenceTest.java
+++ b/core/src/test/java/com/google/common/truth/IterableSubjectCorrespondenceTest.java
@@ -17,10 +17,10 @@ package com.google.common.truth;
 
 import static com.google.common.base.Functions.identity;
 import static com.google.common.collect.Collections2.permutations;
+import static com.google.common.truth.Correspondence.equality;
 import static com.google.common.truth.Correspondence.tolerance;
 import static com.google.common.truth.TestCorrespondences.CASE_INSENSITIVE_EQUALITY;
 import static com.google.common.truth.TestCorrespondences.CASE_INSENSITIVE_EQUALITY_HALF_NULL_SAFE;
-import static com.google.common.truth.TestCorrespondences.EQUALITY;
 import static com.google.common.truth.TestCorrespondences.NULL_SAFE_RECORD_ID;
 import static com.google.common.truth.TestCorrespondences.PARSED_RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10;
 import static com.google.common.truth.TestCorrespondences.PARSED_RECORD_ID;
@@ -365,12 +365,12 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
     CountsToStringCalls o = new CountsToStringCalls();
     List<Object> actual = asList(o, 1);
     List<Object> expected = asList(1, o);
-    assertThat(actual).comparingElementsUsing(EQUALITY).containsExactlyElementsIn(expected);
+    assertThat(actual).comparingElementsUsing(equality()).containsExactlyElementsIn(expected);
     assertThat(o.calls).isEqualTo(0);
     expectFailure
         .whenTesting()
         .that(actual)
-        .comparingElementsUsing(EQUALITY)
+        .comparingElementsUsing(equality())
         .containsExactlyElementsIn(expected)
         .inOrder();
     assertThat(o.calls).isGreaterThan(0);
@@ -1175,12 +1175,12 @@ public class IterableSubjectCorrespondenceTest extends BaseSubjectTestCase {
     CountsToStringCalls o = new CountsToStringCalls();
     List<Object> actual = asList(o, 1);
     List<Object> expected = asList(1, o);
-    assertThat(actual).comparingElementsUsing(EQUALITY).containsAtLeastElementsIn(expected);
+    assertThat(actual).comparingElementsUsing(equality()).containsAtLeastElementsIn(expected);
     assertThat(o.calls).isEqualTo(0);
     expectFailure
         .whenTesting()
         .that(actual)
-        .comparingElementsUsing(EQUALITY)
+        .comparingElementsUsing(equality())
         .containsAtLeastElementsIn(expected)
         .inOrder();
     assertThat(o.calls).isGreaterThan(0);

--- a/core/src/test/java/com/google/common/truth/TestCorrespondences.java
+++ b/core/src/test/java/com/google/common/truth/TestCorrespondences.java
@@ -62,6 +62,17 @@ final class TestCorrespondences {
     }
   }
 
+  /** A formatter for the diffs between integers. */
+  static final Correspondence.DiffFormatter<Integer, Integer> INT_DIFF_FORMATTER =
+      // If we were allowed to use lambdas, this would be:
+      // (a, e) -> Integer.toString(a - e));
+      new Correspondence.DiffFormatter<Integer, Integer>() {
+        @Override
+        public String formatDiff(Integer actual, Integer expected) {
+          return Integer.toString(actual - expected);
+        }
+      };
+
   /**
    * A correspondence between integers which tests whether they are within 10 of each other. Smart
    * diffing is enabled, with a formatted diff showing the actual value less the expected value.
@@ -78,15 +89,7 @@ final class TestCorrespondences {
                 }
               },
               "is within 10 of")
-          .formattingDiffsUsing(
-              // If we were allowed to use lambdas, this would be:
-              // (a, e) -> Integer.toString(a - e));
-              new Correspondence.DiffFormatter<Integer, Integer>() {
-                @Override
-                public String formatDiff(Integer actual, Integer expected) {
-                  return Integer.toString(actual - expected);
-                }
-              });
+          .formattingDiffsUsing(INT_DIFF_FORMATTER);
 
   /**
    * A correspondence between strings which tests for case-insensitive equality. Supports null
@@ -351,17 +354,6 @@ final class TestCorrespondences {
           return record != null ? RECORD_ID.apply(record) : null;
         }
       };
-
-  static final Correspondence<Object, Object> EQUALITY =
-      Correspondence.from(
-          // If we were allowed to use method references, this would be Objects::equal.
-          new Correspondence.BinaryPredicate<Object, Object>() {
-            @Override
-            public boolean apply(@NullableDecl Object actual, @NullableDecl Object expected) {
-              return Objects.equal(actual, expected);
-            }
-          },
-          "is equal to");
 
   private TestCorrespondences() {}
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add the (package-private) concept of an equality correspondence, for use in the forthcoming "smart diffs for non-Fuzzy Truth" feature.

b38b3341c52ea11e599525f6cde23d7277ddaa9c