### PR TITLE
MOE Sync 2020-07-28

### DIFF
--- a/core/src/main/java/com/google/common/truth/Correspondence.java
+++ b/core/src/main/java/com/google/common/truth/Correspondence.java
@@ -315,8 +315,7 @@ public abstract class Correspondence<A, E> {
   /**
    * Returns a correspondence which compares elements using object equality, i.e. giving the same
    * assertions as you would get without a correspondence. This exists so that we can add a
-   * diff-formatting functionality to it. TODO(b/69154394): Explain why this is here when the
-   * feature is added.
+   * diff-formatting functionality to it. See e.g. {@link IterableSubject#formattingDiffsUsing}.
    */
   @SuppressWarnings("unchecked") // safe covariant cast
   static <T> Correspondence<T, T> equality() {

--- a/core/src/main/java/com/google/common/truth/IterableSubject.java
+++ b/core/src/main/java/com/google/common/truth/IterableSubject.java
@@ -55,6 +55,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
+import com.google.common.truth.Correspondence.DiffFormatter;
 import com.google.common.truth.SubjectUtils.DuplicateGroupedAndTyped;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.ArrayList;
@@ -898,6 +899,40 @@ public class IterableSubject extends Subject {
   public <A, E> UsingCorrespondence<A, E> comparingElementsUsing(
       Correspondence<? super A, ? super E> correspondence) {
     return new UsingCorrespondence<>(this, correspondence);
+  }
+
+  /**
+   * Starts a method chain for a check in which failure messages may use the given {@link
+   * DiffFormatter} to describe the difference between an actual elements (i.e. an element of the
+   * {@link Iterable} under test) and the element it is expected to be equal to, but isn't. The
+   * actual and expected elements must be of type {@code T}. The check is actually executed by
+   * continuing the method chain. You may well want to use {@link
+   * UsingCorrespondence#displayingDiffsPairedBy} to specify how the elements should be paired up
+   * for diffing. For example:
+   *
+   * <pre>{@code
+   * assertThat(actualFoos)
+   *     .formattingDiffsUsing(FooTestHelper::formatDiff)
+   *     .displayingDiffsPairedBy(Foo::getId)
+   *     .containsExactly(foo1, foo2, foo3);
+   * }</pre>
+   *
+   * where {@code actualFoos} is an {@code Iterable<Foo>}, {@code FooTestHelper.formatDiff} is a
+   * static method taking two {@code Foo} arguments and returning a {@link String}, {@code
+   * Foo.getId} is a no-arg instance method returning some kind of ID, and {@code foo1}, {code
+   * foo2}, and {@code foo3} are {@code Foo} instances.
+   *
+   * <p>Unlike when using {@link #comparingElementsUsing}, the elements are still compared using
+   * object equality, so this method does not affect whether a test passes or fails.
+   *
+   * <p>Any of the methods on the returned object may throw {@link ClassCastException} if they
+   * encounter an actual element that is not of type {@code T}.
+   *
+   * @since 1.1
+   */
+  public <T> UsingCorrespondence<T, T> formattingDiffsUsing(
+      DiffFormatter<? super T, ? super T> formatter) {
+    return comparingElementsUsing(Correspondence.<T>equality().formattingDiffsUsing(formatter));
   }
 
   /**

--- a/core/src/main/java/com/google/common/truth/MapSubject.java
+++ b/core/src/main/java/com/google/common/truth/MapSubject.java
@@ -35,6 +35,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Sets;
+import com.google.common.truth.Correspondence.DiffFormatter;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -511,6 +512,37 @@ public class MapSubject extends Subject {
   public final <A, E> UsingCorrespondence<A, E> comparingValuesUsing(
       Correspondence<? super A, ? super E> correspondence) {
     return new UsingCorrespondence<>(correspondence);
+  }
+
+  /**
+   * Starts a method chain for a check in which failure messages may use the given {@link
+   * DiffFormatter} to describe the difference between an actual value (i.e. a value in the {@link
+   * Map} under test) and the value it is expected to be equal to, but isn't. The actual and
+   * expected values must be of type {@code V}. The check is actually executed by continuing the
+   * method chain. For example:
+   *
+   * <pre>{@code
+   * assertThat(actualMap)
+   *   .formattingDiffsUsing(FooTestHelper::formatDiff)
+   *   .containsExactly(key1, foo1, key2, foo2, key3, foo3);
+   * }</pre>
+   *
+   * where {@code actualMap} is a {@code Map<?, Foo>} (or, more generally, a {@code Map<?, ? extends
+   * Foo>}), {@code FooTestHelper.formatDiff} is a static method taking two {@code Foo} arguments
+   * and returning a {@link String}, and {@code foo1}, {@code foo2}, and {@code foo3} are {@code
+   * Foo} instances.
+   *
+   * <p>Unlike when using {@link #comparingValuesUsing}, the values are still compared using object
+   * equality, so this method does not affect whether a test passes or fails.
+   *
+   * <p>Any of the methods on the returned object may throw {@link ClassCastException} if they
+   * encounter a value that is not of type {@code V}.
+   *
+   * @since 1.1
+   */
+  public final <V> UsingCorrespondence<V, V> formattingDiffsUsing(
+      DiffFormatter<? super V, ? super V> formatter) {
+    return comparingValuesUsing(Correspondence.<V>equality().formattingDiffsUsing(formatter));
   }
 
   /**

--- a/core/src/main/java/com/google/common/truth/MultimapSubject.java
+++ b/core/src/main/java/com/google/common/truth/MultimapSubject.java
@@ -531,6 +531,10 @@ public class MultimapSubject extends Subject {
     return new UsingCorrespondence<>(correspondence);
   }
 
+  // TODO(b/69154276): Add formattingDiffsUsing, like we have on MapSubject, once we have
+  // implemented Smart Diffs for multimaps. We could add it now, but there is no way it could have
+  // any effect, and it would not be testable.
+
   /**
    * A partially specified check in which the actual values (i.e. the values of the {@link Multimap}
    * under test) are compared to expected values using a {@link Correspondence}. The expected values

--- a/core/src/test/java/com/google/common/truth/MapSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/MapSubjectTest.java
@@ -16,6 +16,7 @@
 package com.google.common.truth;
 
 import static com.google.common.truth.TestCorrespondences.CASE_INSENSITIVE_EQUALITY;
+import static com.google.common.truth.TestCorrespondences.INT_DIFF_FORMATTER;
 import static com.google.common.truth.TestCorrespondences.STRING_PARSES_TO_INTEGER_CORRESPONDENCE;
 import static com.google.common.truth.TestCorrespondences.WITHIN_10_OF;
 import static com.google.common.truth.Truth.assertThat;
@@ -2128,6 +2129,36 @@ public class MapSubjectTest extends BaseSubjectTestCase {
     assertThat(actual)
         .comparingValuesUsing(STRING_PARSES_TO_INTEGER_CORRESPONDENCE)
         .containsAtLeastEntriesIn(expected);
+  }
+
+  @Test
+  public void formattingDiffsUsing_success() {
+    ImmutableMap<String, Integer> actual = ImmutableMap.of("ghi", 300, "def", 200, "abc", 100);
+    assertThat(actual)
+        .formattingDiffsUsing(INT_DIFF_FORMATTER)
+        .containsExactly("abc", 100, "def", 200, "ghi", 300);
+  }
+
+  @Test
+  public void formattingDiffsUsing_failure() {
+    ImmutableMap<String, Integer> actual = ImmutableMap.of("ghi", 300, "def", 201, "abc", 100);
+    expectFailure
+        .whenTesting()
+        .that(actual)
+        .formattingDiffsUsing(INT_DIFF_FORMATTER)
+        .containsExactly("abc", 100, "def", 200, "ghi", 300);
+    assertFailureKeys(
+        "keys with wrong values",
+        "for key",
+        "expected value",
+        "but got value",
+        "diff",
+        "---",
+        "expected",
+        "but was");
+    assertFailureValue("expected value", "200");
+    assertFailureValue("but got value", "201");
+    assertFailureValue("diff", "1");
   }
 
   private MapSubject expectFailureWhenTestingThat(Map<?, ?> actual) {

--- a/core/src/test/java/com/google/common/truth/TestCorrespondences.java
+++ b/core/src/test/java/com/google/common/truth/TestCorrespondences.java
@@ -236,6 +236,20 @@ final class TestCorrespondences {
           "has the same id as and a score within 10 of");
 
   /**
+   * A formatter for diffs between records. If the records have the same key, it gives a string of
+   * the form {@code "score:<score_diff>"}. If they have different keys, it gives null.
+   */
+  static final Correspondence.DiffFormatter<Record, Record> RECORD_DIFF_FORMATTER =
+      // If we were allowed to use method references, this would be:
+      // TestCorrespondences::formatRecordDiff);
+      new Correspondence.DiffFormatter<Record, Record>() {
+        @Override
+        public String formatDiff(Record actual, Record expected) {
+          return formatRecordDiff(actual, expected);
+        }
+      };
+
+  /**
    * A correspondence between {@link Record} instances which tests whether their {@code id} values
    * are equal and their {@code score} values are within 10 of each other. Smart diffing is enabled
    * for records with equal {@code id} values, with a formatted diff showing the actual {@code
@@ -245,15 +259,7 @@ final class TestCorrespondences {
    * to null only. The {@link Correspondence#formatDiff} implementation does not support nulls.
    */
   static final Correspondence<Record, Record> RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10 =
-      RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10_NO_DIFF.formattingDiffsUsing(
-          // If we were allowed to use method references, this would be:
-          // TestCorrespondences::formatRecordDiff);
-          new Correspondence.DiffFormatter<Record, Record>() {
-            @Override
-            public String formatDiff(Record actual, Record expected) {
-              return formatRecordDiff(actual, expected);
-            }
-          });
+      RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10_NO_DIFF.formattingDiffsUsing(RECORD_DIFF_FORMATTER);
 
   /**
    * A correspondence like {@link #RECORDS_EQUAL_WITH_SCORE_TOLERANCE_10} except that the actual


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Implement "Smart Diffs for non-Fuzzy Truth" for iterables and maps.

(Multimaps is left as a TODO since we don't have Smart Diffs for multimaps at all yet.)

RELNOTES=Add  See formattingDiffsUsing methods to IterableSubject and MapSubject. This allows you to get failure messages which show diffs between the actual and expected elements (like you get with comparingElementsUsing) while still comparing them using object equality.

4533bb7482d8e61e97095cbb3c4c981212326304