### PR TITLE
MOE Sync 2020-08-05

### DIFF
--- a/comparison.md
+++ b/comparison.md
@@ -23,9 +23,13 @@ assertThat(notificationText, containsString("testuser@google.com"));
 
 ## Why create Truth when AssertJ already exists?
 
-The reason is historical: AssertJ didn’t exist when we started Truth. By the
-time it was created, we’d begun using Truth widely at Google, and we’d made some
-decisions that would be difficult to retrofit onto AssertJ.
+The reason is historical: AssertJ didn’t 
+[exist](https://github.com/joel-costigliola/assertj-core/commit/cc324ba53c55a30717ec3648ee7d563611231a96)
+when we
+[started](https://github.com/google/truth/commit/813afacc95b5f7ae2d38f10a10ca095b8c69b2b3)
+Truth. By the time it was created, we’d begun migrating Google code to Truth,
+and we’d made some design decisions that would be difficult to retrofit onto
+AssertJ.
 
 ## Truth vs. Hamcrest {#vs-hamcrest}
 

--- a/index.md
+++ b/index.md
@@ -82,8 +82,9 @@ create Truth? The reason is historical: AssertJ didn’t
 [exist](https://github.com/joel-costigliola/assertj-core/commit/cc324ba53c55a30717ec3648ee7d563611231a96)
 when we
 [started](https://github.com/google/truth/commit/813afacc95b5f7ae2d38f10a10ca095b8c69b2b3)
-Truth. By the time it was created, we’d begun using Truth widely at Google, and
-we’d made some decisions that would be difficult to retrofit onto AssertJ.
+Truth. By the time it was created, we’d begun migrating Google code to Truth,
+and we’d made some design decisions that would be difficult to retrofit onto
+AssertJ.
 
 Both Truth and AssertJ have their [advantages](comparison#assertj-detail). We
 prefer Truth for its [simpler API](comparison#assertion-count):


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Clarify creation date of AssertJ in comparison.md, too.

Also, rephrase a claim that probably gives the wrong impression: Google's usage of Truth at the time AssertJ was _created_ was in the hundreds of files. While that's arguably "widely" (e.g., it crossed many teams), it's not enough to be a major _barrier to migration_ the way that our usage became in the next year or so.

2943240c7d27160395f24c1a3178c62d5b6b6e79