### PR TITLE
MOE Sync 2020-08-06

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <!-- Properties for multiple-artifact deps. -->
     <auto-value.version>1.7</auto-value.version>
     <guava.version>28.1</guava.version>
-    <gwt.version>2.8.2</gwt.version>
+    <gwt.version>2.9.0</gwt.version>
     <protobuf.version>3.11.1</protobuf.version>
     <!-- Property for protobuf-lite protocArtifact, which isn't a "normal" Maven dep. -->
     <protobuf-lite.protoc.version>3.1.0</protobuf-lite.protoc.version>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Bump gwt.version from 2.8.2 to 2.9.0

Bumps `gwt.version` from 2.8.2 to 2.9.0.

Updates `gwt-user` from 2.8.2 to 2.9.0

Updates `gwt-maven-plugin` from 2.8.2 to 2.9.0
- [Release notes](https://github.com/gwt-maven-plugin/gwt-maven-plugin/releases)
- [Commits](https://github.com/gwt-maven-plugin/gwt-maven-plugin/compare/gwt-maven-plugin-2.8.2...gwt-maven-plugin-2.9.0)

Signed-off-by: dependabot[bot] <support@github.com>

Fixes #721

46f7d7d276fb74aa0c3b4eeb9733a93868b36a89