### PR TITLE
MOE Sync 2020-08-12

### DIFF
--- a/protobufs.md
+++ b/protobufs.md
@@ -50,8 +50,8 @@ steps below, or for Lite proto follow [our Lite Proto instructions](#lite):
 1.  Assert away!
 
     ```java
-    MyProto expected = MyProto.newBuilder().addBar(3).addBar(5).setFoo(“qux”).build();
-    MyProto actual =   MyProto.newBuilder().addBar(5).addBar(3).setFoo(“quizzux”).build();
+    MyProto expected = MyProto.newBuilder().addBar(3).addBar(5).setFoo("qux").build();
+    MyProto actual =   MyProto.newBuilder().addBar(5).addBar(3).setFoo("quizzux").build();
     assertThat(actual).ignoringRepeatedFieldOrder().isEqualTo(expected);
     ```
 
@@ -59,7 +59,7 @@ steps below, or for Lite proto follow [our Lite Proto instructions](#lite):
 
     ```shell
     Not true that messages compare equal.  Differences were found:
-    modified: foo: ”qux” -> “quizzux”
+    modified: foo: "qux" -> "quizzux"
     ```
 
 ## Supported Use Cases {#support}

--- a/protobufs.md
+++ b/protobufs.md
@@ -5,7 +5,8 @@ title: Protobuf Extension
 
 
 ProtoTruth is an extension of the Truth library which lets you make assertions
-about [Protobufs], a rich data interchange format. To get started:
+about [Protobufs], a rich data interchange format. To get started, follow the
+steps below, or for Lite proto follow [our Lite Proto instructions](#lite):
 
 1.  Add the appropriate dependency to your build:
 

--- a/protobufs.md
+++ b/protobufs.md
@@ -16,7 +16,7 @@ steps below, or for Lite proto follow [our Lite Proto instructions](#lite):
     <dependency>
       <groupId>com.google.truth.extensions</groupId>
       <artifactId>truth-proto-extension</artifactId>
-      <version>0.31</version>
+      <version>{{ site.version }}</version>
     </dependency>
     ```
 
@@ -27,7 +27,7 @@ steps below, or for Lite proto follow [our Lite Proto instructions](#lite):
       repositories.mavenLocal()
     }
     dependencies {
-      testCompile "com.google.truth.extensions:truth-proto-extension:0.31"
+      testCompile "com.google.truth.extensions:truth-proto-extension:{{ site.version }}"
     }
     ```
 

--- a/protobufs.md
+++ b/protobufs.md
@@ -137,6 +137,44 @@ the `displayingDiffsPairedBy` method as providing an equivalent for an assertion
 about an `Iterable`. Note that this won't affect whether the test passes or
 fails.)
 
+## Lite Proto Support {#lite}
+
+Nominal support exists for Lite protos, commonly used in Android code due to the
+size of the full-proto runtime. However, most features available for full protos
+are not available for lite protos because runtime descriptors are essential for
+doing dynamic comparisons. To use lite protos with proto truth:
+
+1.  Add a dependency:
+
+    **Maven:**
+
+    ```xml
+    <dependency>
+      <groupId>com.google.truth.extensions</groupId>
+      <artifactId>truth-liteproto-extension</artifactId>
+      <version>{{ site.version }}</version>
+    </dependency>
+    ```
+
+    **Gradle:**
+
+    ```groovy
+    buildscript {
+      repositories.mavenLocal()
+    }
+    dependencies {
+      testCompile "com.google.truth.extensions:truth-liteproto-extension:{{ site.version }}"
+    }
+    ```
+
+1.  Add a static import:
+
+    ```java
+    import static com.google.common.truth.extensions.proto.LiteProtoTruth.assertThat;
+    ```
+
+1.  And assert away!
+
 <!-- References -->
 
 [Protobufs]:         https://developers.google.com/protocol-buffers/docs/overview


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add a mention about proto-lite support early in the doc

When looking for Truth support for proto-lite it is easy to
see the first part of the doc, try it out, realize it is not
the right instructions, then find the proto-lite support details.
This CL adds a mention early on to help proto-lite users find the
appropriate instructions at the bottom of the doc before trying
the proto instructions.

e1fd4fe8369aa6acf86061b428a866577f5c0ca3

-------

<p> Update version of Proto Truth listed on public site

Version 0.31 was released in 2016, and the most recent version is
1.0.1.

fa646322cc77b629c0742fa8dc2e891667b7ac4e

-------

<p> List Lite Proto support on public site

The public site listed Lite Proto but hid the content.
This commit shows the content and gives Maven/Gradle
details.

86a51af5b9cf8fa5a1395a010c18e45372d3b75e

-------

<p> Replace the unicode quote markers (“) with ascii quote markers (")

When the page is rendered for the external site the quote markers
are displayed in red, as if they were an error. Replacing them with
ascii quotes should highlight the string and remove the red.
Also, if the example were copy/pasted it would work instead of
resulting in a compile failure.

4ad9b8a12f3a0911213f60deee48b31cdb511640