### PR TITLE
MOE Sync 2020-08-12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <protobuf.protoc.version>3.7.1</protobuf.protoc.version>
 
     <!-- Property for an extension, since Maven doesn't have extensionManagement. -->
-    <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
+    <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Bump os-maven-plugin from 1.5.0.Final to 1.6.2

Bumps [os-maven-plugin](https://github.com/trustin/os-maven-plugin) from 1.5.0.Final to 1.6.2.
- [Release notes](https://github.com/trustin/os-maven-plugin/releases)
- [Commits](https://github.com/trustin/os-maven-plugin/compare/os-maven-plugin-1.5.0.Final...os-maven-plugin-1.6.2)

Signed-off-by: dependabot[bot] <support@github.com>

Fixes #724

73394cb962302bbf11084f43daa14db2aca4ae14