### PR TITLE
MOE Sync 2020-08-17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.1</version>
+          <version>3.8.1</version>
           <configuration>
             <source>1.7</source>
             <target>1.7</target>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Bump maven-compiler-plugin from 3.1 to 3.8.1

Bumps [maven-compiler-plugin](https://github.com/apache/maven-compiler-plugin) from 3.1 to 3.8.1.
- [Release notes](https://github.com/apache/maven-compiler-plugin/releases)
- [Commits](https://github.com/apache/maven-compiler-plugin/compare/maven-compiler-plugin-3.1...maven-compiler-plugin-3.8.1)

Signed-off-by: dependabot[bot] <support@github.com>

Fixes #738

0f30a941d4fa94a82b3f366ab0972afd0ec84a61