### PR TITLE
MOE Sync 2020-08-19

### DIFF
--- a/core/src/main/java/com/google/common/truth/Truth.gwt.xml
+++ b/core/src/main/java/com/google/common/truth/Truth.gwt.xml
@@ -14,11 +14,17 @@
   <super-source path="super"/>
    
   <inherits name="com.google.gwt.user.User"/>
+    
   <inherits name="com.google.common.annotations.Annotations"/>
+   
   <inherits name="com.google.common.base.Base"/>
+   
   <inherits name="com.google.common.collect.Collect"/>
+   
   <inherits name="com.google.common.primitives.Primitives"/>
+   
   <inherits name="com.google.common.util.concurrent.Concurrent"/>
+      
   <inherits name="com.google.gwt.core.Core"/>
    
 </module>

--- a/extensions/java8/src/main/java/com/google/common/truth/Truth8.gwt.xml
+++ b/extensions/java8/src/main/java/com/google/common/truth/Truth8.gwt.xml
@@ -14,8 +14,11 @@
   <super-source path="super"/>
    
   <inherits name="com.google.gwt.user.User"/>
+    
   <inherits name="com.google.common.annotations.Annotations"/>
+     
   <inherits name="com.google.common.truth.Truth"/>
+   
   <inherits name="com.google.gwt.core.Core"/>
    
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
       <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
-        <version>2.3.3</version>
+        <version>2.4.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Bump error_prone_annotations from 2.3.3 to 2.4.0

Bumps [error_prone_annotations](https://github.com/google/error-prone) from 2.3.3 to 2.4.0.
- [Release notes](https://github.com/google/error-prone/releases)
- [Commits](https://github.com/google/error-prone/compare/v2.3.3...v2.4.0)

Signed-off-by: dependabot[bot] <support@github.com>

Fixes #728

ca47ba99867ccd5bc5e936d73b4174b8c32774ce

-------

<p> Switch GWT rules implementation from native to .bzl.

RELNOTES: GWT rules are now implemented in .bzl.

07db3482dc4819dc51f97d01f1cf8e937536b205