### PR TITLE
Changed failure message of StringSubject.matches and added test cases

### DIFF
--- a/core/src/main/java/com/google/common/truth/StringSubject.java
+++ b/core/src/main/java/com/google/common/truth/StringSubject.java
@@ -142,7 +142,7 @@ public class StringSubject extends ComparableSubject<String> {
         failWithoutActual(
                 fact("expected to match", regex),
                 fact("but was", actual),
-                simpleFact("Looks like you want to use .isEqualTo() for an exact equality assertion."));
+                simpleFact("If you want an exact equality assertion you can escape your regex with Pattern.quote()."));
       } else {
         failWithActual("expected to match", regex);
       }

--- a/core/src/main/java/com/google/common/truth/StringSubject.java
+++ b/core/src/main/java/com/google/common/truth/StringSubject.java
@@ -120,7 +120,14 @@ public class StringSubject extends ComparableSubject<String> {
     if (actual == null) {
       failWithActual("expected a string that matches", regex);
     } else if (!actual.matches(regex)) {
-      failWithActual("expected to match", regex);
+      if (regex.equals(actual)){
+        failWithoutActual(
+                fact("expected to match", regex),
+                fact("but was", actual),
+                simpleFact("Looks like you want to use .isEqualTo() for an exact equality assertion."));
+      } else {
+        failWithActual("expected to match", regex);
+      }
     }
   }
 
@@ -131,7 +138,14 @@ public class StringSubject extends ComparableSubject<String> {
     if (actual == null) {
       failWithActual("expected a string that matches", regex);
     } else if (!regex.matcher(actual).matches()) {
-      failWithActual("expected to match", regex);
+      if (regex.toString().equals(actual)){
+        failWithoutActual(
+                fact("expected to match", regex),
+                fact("but was", actual),
+                simpleFact("Looks like you want to use .isEqualTo() for an exact equality assertion."));
+      } else {
+        failWithActual("expected to match", regex);
+      }
     }
   }
 

--- a/core/src/test/java/com/google/common/truth/StringSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/StringSubjectTest.java
@@ -206,6 +206,14 @@ public class StringSubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
+  public void stringMatchesStringLiteralFail() {
+    expectFailureWhenTestingThat("$abc").matches("$abc");
+    assertFailureValue("expected to match", "$abc");
+    assertFailureValue("but was", "$abc");
+    assertThat(expectFailure.getFailure()).factKeys().contains("Looks like you want to use .isEqualTo() for an exact equality assertion.");
+  }
+
+  @Test
   @GwtIncompatible("Pattern")
   public void stringMatchesPattern() {
     assertThat("abcaaadev").matches(Pattern.compile(".*aaa.*"));
@@ -223,6 +231,15 @@ public class StringSubjectTest extends BaseSubjectTestCase {
   public void stringMatchesPatternFailNull() {
     expectFailureWhenTestingThat(null).matches(Pattern.compile(".*aaa.*"));
     assertFailureValue("expected a string that matches", ".*aaa.*");
+  }
+
+  @Test
+  @GwtIncompatible("Pattern")
+  public void stringMatchesPatternLiteralFail() {
+    expectFailureWhenTestingThat("$abc").matches(Pattern.compile("$abc"));
+    assertFailureValue("expected to match", "$abc");
+    assertFailureValue("but was", "$abc");
+    assertThat(expectFailure.getFailure()).factKeys().contains("Looks like you want to use .isEqualTo() for an exact equality assertion.");
   }
 
   @Test

--- a/core/src/test/java/com/google/common/truth/StringSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/StringSubjectTest.java
@@ -239,7 +239,7 @@ public class StringSubjectTest extends BaseSubjectTestCase {
     expectFailureWhenTestingThat("$abc").matches(Pattern.compile("$abc"));
     assertFailureValue("expected to match", "$abc");
     assertFailureValue("but was", "$abc");
-    assertThat(expectFailure.getFailure()).factKeys().contains("Looks like you want to use .isEqualTo() for an exact equality assertion.");
+    assertThat(expectFailure.getFailure()).factKeys().contains("If you want an exact equality assertion you can escape your regex with Pattern.quote().");
   }
 
   @Test


### PR DESCRIPTION
Added an additional message to hint at the use of isEqualTo in case of a failed test
where most likley a exact equality assertion was needed instead of a regex.

Added two test cases to StringSubjectTest to test for the correct failure messages.
This PR is in reference to https://github.com/google/truth/issues/783#issue-737794162