### PR TITLE
Change failure message of StringSubject.matches and add test cases

### DIFF
--- a/core/src/main/java/com/google/common/truth/StringSubject.java
+++ b/core/src/main/java/com/google/common/truth/StringSubject.java
@@ -125,6 +125,11 @@ public class StringSubject extends ComparableSubject<String> {
             fact("expected to match", regex),
             fact("but was", actual),
             simpleFact("Looks like you want to use .isEqualTo() for an exact equality assertion."));
+      } else if (Platform.containsMatch(actual, regex)) {
+        failWithoutActual(
+            fact("expected to match", regex),
+            fact("but was", actual),
+            simpleFact("Did you mean to call containsMatch() instead of match()?"));
       } else {
         failWithActual("expected to match", regex);
       }
@@ -145,6 +150,11 @@ public class StringSubject extends ComparableSubject<String> {
             simpleFact(
                 "If you want an exact equality assertion you can escape your regex with"
                     + " Pattern.quote()."));
+      } else if (regex.matcher(actual).find()) {
+        failWithoutActual(
+                fact("expected to match", regex),
+                fact("but was", actual),
+                simpleFact("Did you mean to call containsMatch() instead of match()?"));
       } else {
         failWithActual("expected to match", regex);
       }

--- a/core/src/test/java/com/google/common/truth/StringSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/StringSubjectTest.java
@@ -216,6 +216,16 @@ public class StringSubjectTest extends BaseSubjectTestCase {
   }
 
   @Test
+  public void stringMatchesStringLiteralFailButContainsMatchSuccess() {
+    expectFailureWhenTestingThat("aba").matches("[b]");
+    assertFailureValue("expected to match", "[b]");
+    assertFailureValue("but was", "aba");
+    assertThat(expectFailure.getFailure())
+            .factKeys()
+            .contains("Did you mean to call containsMatch() instead of match()?");
+  }
+
+  @Test
   @GwtIncompatible("Pattern")
   public void stringMatchesPattern() {
     assertThat("abcaaadev").matches(Pattern.compile(".*aaa.*"));
@@ -246,6 +256,17 @@ public class StringSubjectTest extends BaseSubjectTestCase {
         .contains(
             "If you want an exact equality assertion you can escape your regex with"
                 + " Pattern.quote().");
+  }
+
+  @Test
+  @GwtIncompatible("Pattern")
+  public void stringMatchesPatternLiteralFailButContainsMatchSuccess() {
+    expectFailureWhenTestingThat("aba").matches(Pattern.compile("[b]"));
+    assertFailureValue("expected to match", "[b]");
+    assertFailureValue("but was", "aba");
+    assertThat(expectFailure.getFailure())
+            .factKeys()
+            .contains("Did you mean to call containsMatch() instead of match()?");
   }
 
   @Test


### PR DESCRIPTION
Add an additional message to suggest using containsMatch, if matches(x) fails but containsMatch(x) would have passed. Add corresponding test cases.
issue link: https://github.com/google/truth/issues/791