### PR TITLE
Fix issue 599

### DIFF
--- a/core/src/main/java/com/google/common/truth/IterableSubject.java
+++ b/core/src/main/java/com/google/common/truth/IterableSubject.java
@@ -271,6 +271,7 @@ public class IterableSubject extends Subject {
   @CanIgnoreReturnValue
   public final Ordered containsAtLeastElementsIn(Iterable<?> expectedIterable) {
     List<?> actual = Lists.newLinkedList(this.actual);
+    List<?> order = Lists.newArrayList(actual);
     final Collection<?> expected = iterableToCollection(expectedIterable);
 
     List<Object> missing = newArrayList();
@@ -306,16 +307,21 @@ public class IterableSubject extends Subject {
      * actual iterable than the default of "but was," which may _sound_ like it should show only the
      * required elements, rather than the full actual iterable.
      */
-    return ordered
-        ? IN_ORDER
-        : new Ordered() {
-          @Override
-          public void inOrder() {
-            failWithActual(
-                simpleFact("required elements were all found, but order was wrong"),
-                fact("expected order for required elements", expected));
-          }
-        };
+    if (ordered) {
+      return IN_ORDER;
+    } else {
+      order.retainAll(expected);
+      return new Ordered() {
+        @Override
+        public void inOrder() {
+          failWithActual(
+                  simpleFact("required elements were all found, but order was wrong"),
+                  fact("expected order for required elements", expected),
+                  fact("actual order for required elements", order));
+
+        }
+      };
+    }
   }
 
   /**

--- a/core/src/main/java/com/google/common/truth/IterableSubject.java
+++ b/core/src/main/java/com/google/common/truth/IterableSubject.java
@@ -271,7 +271,7 @@ public class IterableSubject extends Subject {
   @CanIgnoreReturnValue
   public final Ordered containsAtLeastElementsIn(Iterable<?> expectedIterable) {
     List<?> actual = Lists.newLinkedList(this.actual);
-    List<?> order = Lists.newArrayList(actual);
+    List<?> actualOrder = Lists.newArrayList(actual);
     final Collection<?> expected = iterableToCollection(expectedIterable);
 
     List<Object> missing = newArrayList();
@@ -310,14 +310,14 @@ public class IterableSubject extends Subject {
     if (ordered) {
       return IN_ORDER;
     } else {
-      order.retainAll(expected);
+      actualOrder.retainAll(expected);
       return new Ordered() {
         @Override
         public void inOrder() {
-          failWithActual(
+          failWithoutActual(
                   simpleFact("required elements were all found, but order was wrong"),
                   fact("expected order for required elements", expected),
-                  fact("actual order for required elements", order));
+                  fact("actual order for required elements", actualOrder));
 
         }
       };

--- a/core/src/test/java/com/google/common/truth/IterableSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/IterableSubjectTest.java
@@ -388,8 +388,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
     assertFailureKeys(
         "required elements were all found, but order was wrong",
         "expected order for required elements",
-        "actual order for required elements",
-        "but was");
+        "actual order for required elements");
     assertFailureValue("expected order for required elements", "[null, 1, 3]");
     assertFailureValue("actual order for required elements", "[1, null, 3]");
   }
@@ -434,8 +433,7 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
     assertFailureKeys(
         "required elements were all found, but order was wrong",
         "expected order for required elements",
-        "actual order for required elements",
-        "but was");
+        "actual order for required elements");
     assertFailureValue("expected order for required elements", "[1, 3, null]");
     assertFailureValue("actual order for required elements", "[1, null, 3]");
   }

--- a/core/src/test/java/com/google/common/truth/IterableSubjectTest.java
+++ b/core/src/test/java/com/google/common/truth/IterableSubjectTest.java
@@ -388,8 +388,10 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
     assertFailureKeys(
         "required elements were all found, but order was wrong",
         "expected order for required elements",
+        "actual order for required elements",
         "but was");
     assertFailureValue("expected order for required elements", "[null, 1, 3]");
+    assertFailureValue("actual order for required elements", "[1, null, 3]");
   }
 
   @Test
@@ -432,8 +434,10 @@ public class IterableSubjectTest extends BaseSubjectTestCase {
     assertFailureKeys(
         "required elements were all found, but order was wrong",
         "expected order for required elements",
+        "actual order for required elements",
         "but was");
     assertFailureValue("expected order for required elements", "[1, 3, null]");
+    assertFailureValue("actual order for required elements", "[1, null, 3]");
   }
 
   @Test


### PR DESCRIPTION
Modified containsAtLeastElementsIn(). Now it figures out the actual order of the expected objects when it is not in order. It remembers the actual order, stores the actual objects into a list. If it is not in order, retain the excepted list to get the actual order of the expected objects.