### PR TITLE
Detect Bazel JUnit 5 test runner stack frames

### DIFF
--- a/core/src/main/java/com/google/common/truth/StackTraceCleaner.java
+++ b/core/src/main/java/com/google/common/truth/StackTraceCleaner.java
@@ -354,6 +354,7 @@ final class StackTraceCleaner {
         "junit",
         "org.junit",
         "androidx.test.internal.runner",
+        "com.github.bazel_contrib.contrib_rules_jvm.junit5",
         "com.google.testing.junit",
         "com.google.testing.testsize",
         "com.google.testing.util"),


### PR DESCRIPTION
Adds the [community-maintained Bazel JUnit 5 test runner](https://github.com/bazel-contrib/rules_jvm#java_junit5_test) to the list of test framework packages to collapse or strip from stack traces.