### PR TITLE
Bump a bunch of deps at once.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -138,7 +138,7 @@
             <goals><goal>test</goal></goals>
             <configuration>
               <mode>htmlunit</mode>
-              <htmlunit>FF38</htmlunit>
+              <htmlunit>FF</htmlunit>
               <productionMode>true</productionMode>
               <!-- Fix OutOfMemoryError in Travis. -->
               <extraJvmArgs>-Xms3500m -Xmx3500m -Xss1024k</extraJvmArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- Properties for multiple-artifact deps. -->
-    <auto-value.version>1.10.1</auto-value.version>
+    <auto-value.version>1.10.2</auto-value.version>
     <!--
       We have a separate property for each flavor of Guava (instead of a shared
       version without the -android and -jre suffixes) because that lets
@@ -29,8 +29,8 @@
       the other ends up with a merge conflict. That requires reapprovals.
     -->
     <guava.jre.version>32.1.1-jre</guava.jre.version>
-    <gwt.version>2.9.0</gwt.version>
-    <protobuf.version>3.23.2</protobuf.version>
+    <gwt.version>2.10.0</gwt.version>
+    <protobuf.version>3.23.4</protobuf.version>
     <!-- Property for protobuf-lite protocArtifact, which isn't a "normal" Maven dep. -->
     <!-- TODO(cpovirk): Use protobuf.version instead. But that requires finding the new way to request the Lite runtime. -->
     <protobuf-lite.protoc.version>3.1.0</protobuf-lite.protoc.version>
@@ -73,7 +73,7 @@
       <dependency>
         <groupId>org.checkerframework</groupId>
         <artifactId>checker-qual</artifactId>
-        <version>3.35.0</version>
+        <version>3.36.0</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>


### PR DESCRIPTION
Notes:

- The GWT bump requires changing the browser setting from "FF38" to "FF."
- I skipped the `jsinterop-annotations` bump to 2.1.0 because it's built
  with `-target 11`, while we still support 8.
  (Closes https://github.com/google/truth/pull/1147)
  (I've noted this in https://github.com/google/guava/issues/6614)
- The command I used is:
  ```
  mvn org.codehaus.mojo:versions-maven-plugin:2.16.0:{update-properties,use-latest-releases} -DgenerateBackupPoms=false -Dexcludes=com.google.guava:guava
  ```
  That tried to update protobuf to a release candidate. I had thought
  that perhaps this was the result of [a protobuf change from "-rc1" to
  "-rc-1"](https://github.com/protocolbuffers/protobuf/issues/6522), but
  I'm wondering if it's actually just that `versions-maven-plugin` (in
  contrast to Dependabot) counts release candidates [as
  releases](https://www.mojohaus.org/versions/versions-maven-plugin/use-latest-releases-mojo.html)?
  I'd have to investigate further and perhaps [use
  `rulesUri`](https://stackoverflow.com/a/46935363/28465). But since we
  normally rely on Dependabot (and I was using `versions-maven-plugin`
  here only "to make things easier"... :)), I'm not going to worry about
  it now.
  ...
  Also, it looks like protobuf 4 might remove the `hasPresence()` method
  that we'd migrated to back in cl/508716698. If so, there's a good
  chance that the protobuf team will fix things for us :) If not, I'm
  assuming that this will relate to
  ["Editions."](https://protobuf.dev/editions/overview/)

Fixes https://github.com/google/truth/pull/1149
Fixes https://github.com/google/truth/pull/1148
Fixes https://github.com/google/truth/pull/1146
Fixes https://github.com/google/truth/pull/1145