### PR TITLE
Use try-with-resources for ExecutorService in ExpectTest

### DIFF
--- a/core/src/test/java/com/google/common/truth/ExpectTest.java
+++ b/core/src/test/java/com/google/common/truth/ExpectTest.java
@@ -182,11 +182,11 @@ public class ExpectTest {
   public void bash() throws Exception {
     Runnable task = () -> expect.that(3).isEqualTo(4);
     List<Future<?>> results = new ArrayList<>();
-    ExecutorService executor = newFixedThreadPool(10);
-    for (int i = 0; i < 1000; i++) {
-      results.add(executor.submit(task));
+    try (ExecutorService executor = newFixedThreadPool(10)) {
+      for (int i = 0; i < 1000; i++) {
+        results.add(executor.submit(task));
+      }
     }
-    executor.shutdown();
     for (Future<?> result : results) {
       result.get();
     }
@@ -195,33 +195,33 @@ public class ExpectTest {
 
   @Test
   public void failWhenCallingThatAfterTest() {
-    ExecutorService executor = newSingleThreadExecutor();
-    taskToAwait =
-        executor.submit(
-            () -> {
-              awaitUninterruptibly(testMethodComplete);
-              assertThrows(IllegalStateException.class, () -> expect.that(3));
-            });
-    executor.shutdown();
+    try (ExecutorService executor = newSingleThreadExecutor()) {
+      taskToAwait =
+          executor.submit(
+              () -> {
+                awaitUninterruptibly(testMethodComplete);
+                assertThrows(IllegalStateException.class, () -> expect.that(3));
+              });
+    }
   }
 
   @Test
   public void failWhenCallingFailingAssertionMethodAfterTest() {
-    ExecutorService executor = newSingleThreadExecutor();
-    /*
-     * We wouldn't expect people to do this exactly. The point is that, if someone were to call
-     * expect.that(3).isEqualTo(4), we would always either fail the test or throw an
-     * IllegalStateException, not record a "failure" that we never read.
-     */
-    IntegerSubject expectThat3 = expect.that(3);
-    taskToAwait =
-        executor.submit(
-            () -> {
-              awaitUninterruptibly(testMethodComplete);
-              IllegalStateException expected =
-                  assertThrows(IllegalStateException.class, () -> expectThat3.isEqualTo(4));
-              assertThat(expected).hasCauseThat().isInstanceOf(AssertionError.class);
-            });
-    executor.shutdown();
+    try (ExecutorService executor = newSingleThreadExecutor()) {
+      /*
+       * We wouldn't expect people to do this exactly. The point is that, if someone were to call
+       * expect.that(3).isEqualTo(4), we would always either fail the test or throw an
+       * IllegalStateException, not record a "failure" that we never read.
+       */
+      IntegerSubject expectThat3 = expect.that(3);
+      taskToAwait =
+          executor.submit(
+              () -> {
+                awaitUninterruptibly(testMethodComplete);
+                IllegalStateException expected =
+                    assertThrows(IllegalStateException.class, () -> expectThat3.isEqualTo(4));
+                assertThat(expected).hasCauseThat().isInstanceOf(AssertionError.class);
+              });
+    }
   }
 }


### PR DESCRIPTION
Relates to #1624

Following a suggestion from @cpovirk, refactor the executors in ExpectTest to use try-with-resources instead of manual shutdown() calls. This improves code cleanliness and ensures executors are always closed even if an exception occurs, without affecting test isolation or readability.