### PR TITLE
Limit StackTraceCleaner cause traversal to prevent infinite loops

### DIFF
--- a/core/src/main/java/com/google/common/truth/StackTraceCleaner.java
+++ b/core/src/main/java/com/google/common/truth/StackTraceCleaner.java
@@ -37,6 +37,13 @@ final class StackTraceCleaner {
   static final String CLEANER_LINK = "https://goo.gl/aH3UyP";
 
   /**
+   * Upper bound on the number of related {@link Throwable Throwables} whose stack traces will be
+   * cleaned. Prevents infinite loops from broken {@link Throwable#getCause()} implementations that
+   * return a new instance on each call.
+   */
+  private static final int MAX_RELATED_THROWABLES = 1000;
+
+  /**
    * <b>Call {@link Platform#cleanStackTrace} rather than calling this directly.</b>
    *
    * <p>Cleans the stack trace on the given {@link Throwable}, replacing the original stack trace
@@ -147,11 +154,16 @@ final class StackTraceCleaner {
     throwable.setStackTrace(result);
 
     // Recurse on any related Throwables that are attached to this one
-    if (throwable.getCause() != null) {
+    if (throwable.getCause() != null && seenThrowables.size() < MAX_RELATED_THROWABLES) {
       new StackTraceCleaner(throwable.getCause()).clean(seenThrowables);
     }
-    for (Throwable suppressed : throwable.getSuppressed()) {
-      new StackTraceCleaner(suppressed).clean(seenThrowables);
+    if (seenThrowables.size() < MAX_RELATED_THROWABLES) {
+      for (Throwable suppressed : throwable.getSuppressed()) {
+        if (seenThrowables.size() >= MAX_RELATED_THROWABLES) {
+          break;
+        }
+        new StackTraceCleaner(suppressed).clean(seenThrowables);
+      }
     }
   }
 

--- a/core/src/test/java/com/google/common/truth/StackTraceCleanerTest.java
+++ b/core/src/test/java/com/google/common/truth/StackTraceCleanerTest.java
@@ -406,6 +406,17 @@ public class StackTraceCleanerTest {
         .isEqualTo(createStackTrace("com.example.Foo"));
   }
 
+  @Test
+  public void infiniteCauseChainsAreHandled() {
+    InfiniteCauseChainThrowable infiniteCauseChainThrowable =
+        new InfiniteCauseChainThrowable("com.example.Foo", "org.junit.FilterMe");
+
+    cleanStackTrace(infiniteCauseChainThrowable);
+
+    assertThat(infiniteCauseChainThrowable.getStackTrace())
+        .isEqualTo(createStackTrace("com.example.Foo"));
+  }
+
   private static Throwable createThrowableWithStackTrace(String... classNames) {
     return createThrowableWithStackTrace(/* cause= */ null, classNames);
   }
@@ -453,6 +464,19 @@ public class StackTraceCleanerTest {
     @Override
     public synchronized Throwable getCause() {
       return this;
+    }
+  }
+
+  private static class InfiniteCauseChainThrowable extends Exception {
+    InfiniteCauseChainThrowable(String... classNames) {
+      setStackTrace(createStackTrace(classNames));
+    }
+
+    InfiniteCauseChainThrowable() {}
+
+    @Override
+    public synchronized Throwable getCause() {
+      return new InfiniteCauseChainThrowable();
     }
   }
 }


### PR DESCRIPTION
## Summary

- Cap `StackTraceCleaner` related-throwable traversal at 1000 to prevent hangs when `getCause()` returns a new instance on each call (in addition to the existing identity-hash visited set for cyclic references).
- Add `infiniteCauseChainsAreHandled` regression test mirroring the existing `cyclesAreHandled` test style.

Fixes #747

## Test plan

- [x] `mvn -pl core -Dtest=StackTraceCleanerTest test` (22 tests, 0 failures)

Made with [Cursor](https://cursor.com)